### PR TITLE
Allow turning AI off, linking to external or implict creation.

### DIFF
--- a/src/Farmer/Farmer.fs
+++ b/src/Farmer/Farmer.fs
@@ -11,6 +11,12 @@ type ResourceName =
         | r when r = ResourceName.Empty -> ResourceName fallbackValue
         | r -> r
 
+[<AutoOpen>]
+module internal ResourceNameHelpers =
+    let (|EmptyResource|_|) = function
+        | r when r = ResourceName.Empty -> Some EmptyResource
+        | _ -> None
+
 type ConsistencyPolicy = Eventual | ConsistentPrefix | Session | BoundedStaleness of maxStaleness:int * maxIntervalSeconds : int | Strong
 type FailoverPolicy = NoFailover | AutoFailover of secondaryLocation:string | MultiMaster of secondaryLocation:string
 type CosmosDbIndexKind = Hash | Range
@@ -32,7 +38,7 @@ type WebAppExtensions = AppInsightsExtension
 type AppInsights =
     { Name : ResourceName 
       Location : string
-      LinkedWebsite : ResourceName }
+      LinkedWebsite : ResourceName option }
 type StorageAccount =
     { Name : ResourceName 
       Location : string

--- a/src/Farmer/Test.fs
+++ b/src/Farmer/Test.fs
@@ -41,7 +41,7 @@ let template (environment:string) storageSku webAppSku =
         name "isaacsuperfun"
         service_plan_name "isaacsuperfunhost"
         storage_account_name "isaacsuperstorage"
-        app_insights_name "isaacsuperai"
+        app_insights_auto_name "isaacsuperai"
         operating_system Windows
         use_runtime DotNet
         setting "myDbName" myCosmosDb.DbName.Value

--- a/src/Farmer/Writer.fs
+++ b/src/Farmer/Writer.fs
@@ -386,7 +386,7 @@ let toFile armTemplateName json =
     templateFilename
 
 let toBatchFile armTemplateName resourceGroupName location templateFilename =
-    let batchFilename = sprintf "deploy-%s.bat" armTemplateName
+    let batchFilename = sprintf "%s.bat" armTemplateName
 
     let azureCliBatch =
         sprintf """az login && az group create -l %s -n %s && az group deployment create -g %s --template-file %s"""

--- a/src/Samples/appinsights.fsx
+++ b/src/Samples/appinsights.fsx
@@ -8,8 +8,7 @@ let myAppInsights = appInsights {
 
 let myFunctions = functions {
     name "mysuperwebapp"
-    service_plan_name "myserverfarm"
-    app_insights_linked myAppInsights.Name
+    app_insights_manual myAppInsights.Name
 }
 
 let template =

--- a/src/Samples/appinsights.fsx
+++ b/src/Samples/appinsights.fsx
@@ -1,0 +1,23 @@
+#r @"..\Farmer\bin\Debug\netstandard2.0\Farmer.dll"
+
+open Farmer
+
+let myAppInsights = appInsights {    
+    name "isaacsAi"
+}
+
+let myFunctions = functions {
+    name "mysuperwebapp"
+    service_plan_name "myserverfarm"
+    app_insights_linked myAppInsights.Name
+}
+
+let template =
+    arm {
+        location NorthEurope
+        add_resource myAppInsights
+        add_resource myFunctions
+    }
+
+template
+|> Writer.quickDeploy "deleteme"


### PR DESCRIPTION
Related to #17. @Dzoukr what do you think of this - one can now do one of four things with AI in functions (and I would add this to webapp as well):

1. Default is to automatically create, configure and link an AI instance (as before).
2. You can also change the name of the "auto" created AI using `app_insights_auto_name`. This lets you link multiple resources together.
3. You can turn off AI completely: `app_insights_off`
4. You can link to an externally created AI instance: `app_insights_link` which takes in the resource name of the "external" AI instance. In this case, you need to still manually add the AI resource that you made into the arm builder.

I have mixed feelings about this PR and whether the flexibility is really needed or not. Do you think all four options are really needed?