### PR TITLE
Added support for setting RuntimeStack for WebApp

### DIFF
--- a/src/Farmer/Builders.fs
+++ b/src/Farmer/Builders.fs
@@ -1097,6 +1097,7 @@ module ArmBuilder =
                             | Medium -> "1"
                             | Large -> "2"
                           IsDynamic = false
+                          Kind = if linuxFx.IsSome then "linux" else ""
                           Tier =
                             match wac.Sku with
                             | WebApp.Free -> "Free"
@@ -1180,6 +1181,7 @@ module ArmBuilder =
                           WorkerSize = "Y1"
                           IsDynamic = true
                           Tier = "Dynamic"
+                          Kind = ""
                           WorkerCount = 0 }
 
                     yield ServerFarm serverFarm

--- a/src/Farmer/Farmer.fs
+++ b/src/Farmer/Farmer.fs
@@ -45,7 +45,15 @@ type WebApp =
       Extensions : WebAppExtensions Set
       AlwaysOn : bool
       Dependencies : ResourceName list
-      Kind : string option }
+      Kind : string option 
+      LinuxFxVersion : string option
+      NetFrameworkVersion : string option
+      JavaVersion : string option
+      JavaContainer : string option
+      JavaContainerVersion : string option
+      PhpVersion : string option
+      PythonVersion : string option
+      Metadata : List<string * string> }
 type ServerFarm =
     { Name : ResourceName 
       Location : string

--- a/src/Farmer/Farmer.fs
+++ b/src/Farmer/Farmer.fs
@@ -61,6 +61,7 @@ type ServerFarm =
       WorkerSize : string
       IsDynamic : bool
       Tier : string
+      Kind : string
       WorkerCount : int }
 type CosmosDbContainer =
     { Name : ResourceName

--- a/src/Farmer/Farmer.fs
+++ b/src/Farmer/Farmer.fs
@@ -45,7 +45,7 @@ type WebApp =
       Extensions : WebAppExtensions Set
       AlwaysOn : bool
       Dependencies : ResourceName list
-      Kind : string option 
+      Kind : string
       LinuxFxVersion : string option
       NetFrameworkVersion : string option
       JavaVersion : string option
@@ -60,8 +60,8 @@ type ServerFarm =
       Sku: string
       WorkerSize : string
       IsDynamic : bool
+      Kind : string option
       Tier : string
-      Kind : string
       WorkerCount : int }
 type CosmosDbContainer =
     { Name : ResourceName

--- a/src/Farmer/Test.fs
+++ b/src/Farmer/Test.fs
@@ -55,6 +55,14 @@ let template (environment:string) storageSku webAppSku =
         website_node_default_version "8.1.4"
         setting "public_path" "./public"
         setting "STORAGE_CONNECTIONSTRING" myStorageAccount.Key
+        runtime_stack DotNetCore20
+        runtime_stack (Java8 JavaSE)
+        runtime_stack Python37
+        runtime_stack Php71
+        runtime_stack AspNet47
+        runtime_stack Ruby24
+        runtime_stack Node
+        operating_system Linux
 
         depends_on myStorageAccount
         depends_on myCosmosDb

--- a/src/Farmer/Writer.fs
+++ b/src/Farmer/Writer.fs
@@ -37,70 +37,67 @@ module Outputters =
                   Application_Type = "web" |} |> box
         |}
         
-    let serverFarm (farm:ServerFarm) = {|
-        ``type`` = "Microsoft.Web/serverfarms"
-        sku =
-            let baseProps =
-                {| name = farm.Sku
-                   tier = farm.Tier
-                   size = farm.WorkerSize |}
-            if farm.IsDynamic then box {| baseProps with family = "Y"; capacity = 0 |}
-            else box {| baseProps with
-                            capacity = farm.WorkerCount |}
-        name = farm.Name.Value
-        apiVersion = "2018-02-01"
-        location = farm.Location
-        kind = farm.Kind
-        properties =
-            if farm.IsDynamic then
-                box {| name = farm.Name.Value; computeMode = "Dynamic" |}
-            else
-                box {| name = farm.Name.Value
-                       perSiteScaling = false
-                       reserved = false |}
-    |}
+    let serverFarm (farm:ServerFarm) =
+        let baseProps =
+            {|
+            ``type`` = "Microsoft.Web/serverfarms"
+            sku =
+                let baseProps =
+                    {| name = farm.Sku
+                       tier = farm.Tier
+                       size = farm.WorkerSize |}
+                if farm.IsDynamic then box {| baseProps with family = "Y"; capacity = 0 |}
+                else box {| baseProps with
+                                capacity = farm.WorkerCount |}
+            name = farm.Name.Value
+            apiVersion = "2018-02-01"
+            location = farm.Location
+            properties =
+                if farm.IsDynamic then
+                    box {| name = farm.Name.Value
+                           computeMode = "Dynamic" |}
+                else
+                    box {| name = farm.Name.Value
+                           perSiteScaling = false
+                           reserved = false |}
+            |}
+        match farm.Kind with
+        | Some kind -> box {| baseProps with kind = kind |}
+        | None -> box baseProps
+
     let webApp (webApp:WebApp) =
-        let value = function
-            | Some x -> x
-            | None -> null
-        let baseProps = {|
-            ``type`` = "Microsoft.Web/sites"
-            name = webApp.Name.Value
-            apiVersion = "2016-08-01"
-            location = webApp.Location
-            dependsOn = webApp.Dependencies |> List.map(fun p -> p.Value)
-            resources =
-                webApp.Extensions
-                |> Set.toList
-                |> List.map (function
-                | AppInsightsExtension ->
+        {| ``type`` = "Microsoft.Web/sites"
+           name = webApp.Name.Value
+           apiVersion = "2016-08-01"
+           location = webApp.Location
+           dependsOn = webApp.Dependencies |> List.map(fun p -> p.Value)
+           kind = webApp.Kind
+           resources =
+               webApp.Extensions
+               |> Set.toList
+               |> List.map (function
+               | AppInsightsExtension ->
                     {| apiVersion = "2016-08-01"
                        name = "Microsoft.ApplicationInsights.AzureWebSites"
                        ``type`` = "siteextensions"
                        dependsOn = [ webApp.Name.Value ]
                        properties = {||}
                     |})
-            properties =
-                {| serverFarmId = webApp.ServerFarm.Value
-                   siteConfig =
-                        {|
-                           appSettings = webApp.AppSettings |> List.map(fun (k,v) -> {| name = k; value = v |})
-                           alwaysOn = webApp.AlwaysOn
-                           metadata = webApp.Metadata |> List.map(fun (k,v) -> {| name = k; value = v |})
-                           linuxFxVersion = webApp.LinuxFxVersion |> value
-                           netFrameworkVersion = webApp.NetFrameworkVersion |> value
-                           javaVersion = webApp.JavaVersion |> value
-                           javaContainer = webApp.JavaContainer |> value
-                           javaContainerVersion = webApp.JavaContainerVersion |> value
-                           phpVersion = webApp.PhpVersion |> value
-                           pythonVersion = webApp.PhpVersion |> value
-                        |}
-                    
+           properties =
+               {| serverFarmId = webApp.ServerFarm.Value
+                  siteConfig =
+                       {| appSettings = webApp.AppSettings |> List.map(fun (k,v) -> {| name = k; value = v |})
+                          alwaysOn = webApp.AlwaysOn
+                          metadata = webApp.Metadata |> List.map(fun (k,v) -> {| name = k; value = v |})
+                          linuxFxVersion = webApp.LinuxFxVersion |> Option.toObj
+                          netFrameworkVersion = webApp.NetFrameworkVersion |> Option.toObj
+                          javaVersion = webApp.JavaVersion |> Option.toObj
+                          javaContainer = webApp.JavaContainer |> Option.toObj
+                          javaContainerVersion = webApp.JavaContainerVersion |> Option.toObj
+                          phpVersion = webApp.PhpVersion |> Option.toObj
+                          pythonVersion = webApp.PhpVersion |> Option.toObj |}
                 |}
         |}
-        match webApp.Kind with
-        | Some kind -> box {| baseProps with kind = kind |}
-        | None -> box baseProps
         
     let cosmosDbContainer (container:CosmosDbContainer) = {|
         ``type`` = "Microsoft.DocumentDb/databaseAccounts/apis/databases/containers"

--- a/src/Farmer/Writer.fs
+++ b/src/Farmer/Writer.fs
@@ -50,6 +50,7 @@ module Outputters =
         name = farm.Name.Value
         apiVersion = "2018-02-01"
         location = farm.Location
+        kind = farm.Kind
         properties =
             if farm.IsDynamic then
                 box {| name = farm.Name.Value; computeMode = "Dynamic" |}

--- a/src/Farmer/Writer.fs
+++ b/src/Farmer/Writer.fs
@@ -36,6 +36,7 @@ module Outputters =
                {| name = resource.Name.Value
                   Application_Type = "web" |} |> box
         |}
+        
     let serverFarm (farm:ServerFarm) = {|
         ``type`` = "Microsoft.Web/serverfarms"
         sku =
@@ -58,6 +59,9 @@ module Outputters =
                        reserved = false |}
     |}
     let webApp (webApp:WebApp) =
+        let value = function
+            | Some x -> x
+            | None -> null
         let baseProps = {|
             ``type`` = "Microsoft.Web/sites"
             name = webApp.Name.Value
@@ -81,6 +85,14 @@ module Outputters =
                         {|
                            appSettings = webApp.AppSettings |> List.map(fun (k,v) -> {| name = k; value = v |})
                            alwaysOn = webApp.AlwaysOn
+                           metadata = webApp.Metadata |> List.map(fun (k,v) -> {| name = k; value = v |})
+                           linuxFxVersion = webApp.LinuxFxVersion |> value
+                           netFrameworkVersion = webApp.NetFrameworkVersion |> value
+                           javaVersion = webApp.JavaVersion |> value
+                           javaContainer = webApp.JavaContainer |> value
+                           javaContainerVersion = webApp.JavaContainerVersion |> value
+                           phpVersion = webApp.PhpVersion |> value
+                           pythonVersion = webApp.PhpVersion |> value
                         |}
                     
                 |}
@@ -88,6 +100,7 @@ module Outputters =
         match webApp.Kind with
         | Some kind -> box {| baseProps with kind = kind |}
         | None -> box baseProps
+        
     let cosmosDbContainer (container:CosmosDbContainer) = {|
         ``type`` = "Microsoft.DocumentDb/databaseAccounts/apis/databases/containers"
         name = sprintf "%s/sql/%s/%s" container.Account.Value container.Database.Value container.Name.Value

--- a/src/Samples/webapp-appinsights.fsx
+++ b/src/Samples/webapp-appinsights.fsx
@@ -8,7 +8,7 @@ let template =
         name "mysuperwebapp"
         service_plan_name "myserverfarm"
         sku WebApp.Sku.F1
-        app_insights_name "myappinsights"
+        app_insights_auto_name "myappinsights"
     }
 
     arm {


### PR DESCRIPTION
Added initial support for `runtime_stack` for `WebApp`.

.NET Core 2.2
```
webApp {
  // other stuff
  runtime_stack (WebApp.RuntimeStack.DotNetCore(DotNetCoreRuntime.DotNetCore22, OS.Windows))
}
```

![image](https://user-images.githubusercontent.com/851307/65979071-fe949380-e474-11e9-9643-73824488e6cb.png)

.NET FW

```
webApp {
  // other stuff
  runtime_stack (WebApp.RuntimeStack.AspNet AspNetRuntime.AspNet47)
}
```

![image](https://user-images.githubusercontent.com/851307/65979141-14a25400-e475-11e9-8dba-e5a6130b1ac9.png)

The relations between OS and possible runtimes is designed by DUs. Most of Node values skipped for sanity reasons 😄  (could be nice up-for-grabs).