### PR TITLE
Added support for creating containers for StorageAccount #34

### DIFF
--- a/src/Farmer/Builders.Storage.fs
+++ b/src/Farmer/Builders.Storage.fs
@@ -18,15 +18,22 @@ let buildKey (ResourceName name) =
             name
             name
 
+type StorageContainerAccess =
+    | Private
+    | Container
+    | Blob
+
 type StorageAccountConfig =
     { /// The name of the storage account.
         Name : ResourceName
         /// The sku of the storage account.
-        Sku : string }
+        Sku : string
+        /// Containers for the storage account.
+        Containers : (string * StorageContainerAccess) list}
     /// Gets the ARM expression path to the key of this storage account.
     member this.Key = buildKey this.Name
 type StorageAccountBuilder() =
-    member __.Yield _ = { Name = ResourceName.Empty; Sku = Sku.StandardLRS }
+    member __.Yield _ = { Name = ResourceName.Empty; Sku = Sku.StandardLRS; Containers = [] }
     [<CustomOperation "name">]
     /// Sets the name of the storage account.
     member __.Name(state:StorageAccountConfig, name) = { state with Name = name }
@@ -34,10 +41,33 @@ type StorageAccountBuilder() =
     [<CustomOperation "sku">]
     /// Sets the sku of the storage account.
     member __.Sku(state:StorageAccountConfig, sku) = { state with Sku = sku }
+    [<CustomOperation "private_container">]
+    /// Adds private container.
+    member __.PrivateContainer(state:StorageAccountConfig, name) = { state with Containers = (name, StorageContainerAccess.Private) :: state.Containers }
+    [<CustomOperation "public_container">]
+    /// Adds container with anonymous read access for blobs and containers.
+    member __.PublicContainer(state:StorageAccountConfig, name) = { state with Containers = (name, StorageContainerAccess.Container) :: state.Containers }
+    [<CustomOperation "blob_container">]
+    /// Adds container with anonymous read access for blobs only.
+    member __.BlobContainer(state:StorageAccountConfig, name) = { state with Containers = (name, StorageContainerAccess.Blob) :: state.Containers }
 
 module Converters =
     open Farmer.Internal
+    
+    let private containerAccess (a:StorageContainerAccess) =
+        match a with
+        | Private -> "None"
+        | Container -> "Container"
+        | Blob -> "Blob"
+    
     let storage location (sac:StorageAccountConfig) =
-        { Location = location; Name = sac.Name; Sku = sac.Sku }
+        {
+            Location = location
+            Name = sac.Name
+            Sku = sac.Sku
+            Containers =
+                sac.Containers
+                |> List.map (fun (n,a) -> n, containerAccess a)
+        }
 
 let storageAccount = StorageAccountBuilder()

--- a/src/Farmer/Builders.Vm.fs
+++ b/src/Farmer/Builders.Vm.fs
@@ -289,7 +289,8 @@ module Converters =
                 Some
                     { StorageAccount.Name = account
                       Location = location
-                      Sku = Storage.Sku.StandardLRS }                    
+                      Sku = Storage.Sku.StandardLRS
+                      Containers = [] }                    
             | Some AutomaticPlaceholder
             | Some (External _)
             | None ->

--- a/src/Farmer/Builders.WebApp.fs
+++ b/src/Farmer/Builders.WebApp.fs
@@ -366,7 +366,8 @@ module Converters =
             | AutomaticallyCreated resourceName ->
                 { StorageAccount.Name = resourceName 
                   Location = location
-                  Sku = Storage.Sku.StandardLRS }
+                  Sku = Storage.Sku.StandardLRS
+                  Containers = [] }
                 |> Some
             | AutomaticPlaceholder | External _ ->
                 None

--- a/src/Farmer/Farmer.fs
+++ b/src/Farmer/Farmer.fs
@@ -43,11 +43,15 @@ type AppInsights =
     { Name : ResourceName 
       Location : string
       LinkedWebsite : ResourceName option }
+type StorageContainerAccess =
+    | Private
+    | Container
+    | Blob
 type StorageAccount =
     { Name : ResourceName 
       Location : string
       Sku : string
-      Containers : (string * string) list }
+      Containers : (string * StorageContainerAccess) list }
 type WebApp =
     { Name : ResourceName 
       ServerFarm : ResourceName

--- a/src/Farmer/Farmer.fs
+++ b/src/Farmer/Farmer.fs
@@ -46,7 +46,8 @@ type AppInsights =
 type StorageAccount =
     { Name : ResourceName 
       Location : string
-      Sku : string }
+      Sku : string
+      Containers : (string * string) list }
 type WebApp =
     { Name : ResourceName 
       ServerFarm : ResourceName

--- a/src/Farmer/Writer.fs
+++ b/src/Farmer/Writer.fs
@@ -6,12 +6,18 @@ open System
 open System.IO
 
 module Outputters =
+    let private containerAccess (a:StorageContainerAccess) =
+        match a with
+        | Private -> "None"
+        | Container -> "Container"
+        | Blob -> "Blob"
+
     let private storageAccountContainer (parent:StorageAccount) (name, access) = {|
         ``type`` = "blobServices/containers"
         apiVersion = "2018-03-01-preview"
         name = "default/" + name
         dependsOn = [ parent.Name.Value ]
-        properties = {| publicAccess = access |}
+        properties = {| publicAccess = containerAccess access |}
     |}
     
     let storageAccount (resource:StorageAccount) = {|

--- a/src/Farmer/Writer.fs
+++ b/src/Farmer/Writer.fs
@@ -6,6 +6,14 @@ open System
 open System.IO
 
 module Outputters =
+    let private storageAccountContainer (parent:StorageAccount) (name, access) = {|
+        ``type`` = "blobServices/containers"
+        apiVersion = "2018-03-01-preview"
+        name = "default/" + name
+        dependsOn = [ parent.Name.Value ]
+        properties = {| publicAccess = access |}
+    |}
+    
     let storageAccount (resource:StorageAccount) = {|
         ``type`` = "Microsoft.Storage/storageAccounts"
         sku = {| name = resource.Sku |}
@@ -13,7 +21,9 @@ module Outputters =
         name = resource.Name.Value
         apiVersion = "2018-07-01"
         location = resource.Location
+        resources = resource.Containers |> List.map (storageAccountContainer resource)
     |}
+    
     let appInsights (resource:AppInsights) = {|
         ``type`` = "Microsoft.Insights/components"
         kind = "web"


### PR DESCRIPTION
You can specify 3 types of container access:

```fsharp
let stor = storageAccount {
    name "myfarmerstorageaccount"
    sku Sku.StandardGRS
    private_container "my-private-container"
    public_container "my-public-container"
    blob_container "my-blob-container"
}
```

Which creates:

![image](https://user-images.githubusercontent.com/851307/66395273-3cdf0500-e9d7-11e9-9eaa-852b01ab9680.png)

Please, @isaacabraham, review implemenation and feel free to change as you like to fit in current code base. But I tried to follow how the other computation expressions work in Farmer. 

