### PR TITLE
Support for container groups.

### DIFF
--- a/src/Farmer/Builders.Arm.fs
+++ b/src/Farmer/Builders.Arm.fs
@@ -36,6 +36,8 @@ type ArmBuilder() =
                           ServerFarm outputs.ServerFarm
                           match outputs.Ai with (Some ai) -> AppInsights ai | None -> ()
                           match outputs.Storage with (Some storage) -> StorageAccount storage | None -> ()
+                      | :? ContainerGroupConfig as config ->
+                          ContainerGroup (Converters.containerGroup state.Location config)
                       | :? CosmosDbConfig as config ->
                           let outputs = config |> Converters.cosmosDb state.Location
                           CosmosAccount outputs.Account

--- a/src/Farmer/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders.ContainerGroups.fs
@@ -1,0 +1,105 @@
+[<AutoOpen>]
+module Farmer.Resources.ContainerGroups
+
+open Farmer
+open Farmer.Models
+open Farmer.Models.ContainerGroups
+
+type ContainerInstanceConfig =
+    { // The name of the container
+      Name : ResourceName
+      // THe container image
+      Image : string
+      // List of ports the container listens on
+      Ports : uint16 list
+      // Max number of CPU cores the container may use
+      Cpu : int
+      // Max gigabytes of memory the container may use
+      Memory : float<Gb>
+    }
+    member this.Key = buildKey this.Name
+
+type ContainerInstanceBuilder() =
+    member __.Yield _ = { Name = ResourceName.Empty; Image = ""; Ports = []; Cpu = 1; Memory = 1.5<Gb> }
+    /// Sets the name of the container instance
+    [<CustomOperation "name">]
+    member __.Name(state:ContainerInstanceConfig, name) = { state with Name = ResourceName name }
+    /// Sets the container image.
+    [<CustomOperation "image">]
+    member __.Image (state:ContainerInstanceConfig, image) = { state with Image = image }
+    /// Sets the ports the container exposes
+    [<CustomOperation "ports">]
+    member __.Ports (state:ContainerInstanceConfig, ports) = { state with Ports = ports }
+    /// Sets the maximum CPU cores the container may use
+    [<CustomOperationAttribute "cpu">]
+    member __.CpuCount (state:ContainerInstanceConfig, cpuCount) = { state with Cpu = cpuCount }
+    /// Sets the maximum gigabytes of memory the container may use
+    [<CustomOperationAttribute "memory">]
+    member __.Memory (state:ContainerInstanceConfig, memory) = { state with Memory = memory }
+let containerInstance = ContainerInstanceBuilder()
+
+type ContainerGroupConfig =
+    { /// The name of the container group.
+      Name : ResourceName
+      /// Container group OS.
+      OsType : ContainerGroupOsType
+      /// Container instances for the container group.
+      ContainerInstances : ContainerInstanceConfig list
+      /// Restart policy for the container group.
+      RestartPolicy : ContainerGroupRestartPolicy
+      /// IP address for the container group.
+      IpAddress : ContainerGroupIpAddress
+    }
+    /// Gets the ARM expression path to the key of this container group.
+    member this.Key = buildKey this.Name
+type ContainerGroupBuilder() =
+    member __.Yield _ =
+        { Name = ResourceName.Empty
+          ContainerInstances = []
+          OsType = Linux
+          RestartPolicy = Always
+          IpAddress = { Type = PublicAddress; Ports = [] }
+        }
+    [<CustomOperation "name">]
+    /// Sets the name of the container group.
+    member __.Name(state:ContainerGroupConfig, name) = { state with Name = name }
+    member this.Name(state:ContainerGroupConfig, name) = this.Name(state, ResourceName name)
+    [<CustomOperation "add_containers">]
+    /// Adds container instances.
+    member __.AddContainers(state:ContainerGroupConfig, instances) = { state with ContainerInstances = instances @ state.ContainerInstances }
+    /// Sets the OS type (default Linux)
+    [<CustomOperation "os_type">]
+    member __.OsType(state:ContainerGroupConfig, osType) = { state with OsType = osType }
+    /// Sets the restart policy (default Always)
+    [<CustomOperation "restart_policy">]
+    member __.RestartPolicy(state:ContainerGroupConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
+    /// Sets the IP addresss (default Public)
+    [<CustomOperation "ip_address">]
+    member __.IpAddress(state:ContainerGroupConfig, ipAddress) = { state with IpAddress = ipAddress }
+    /// Adds a TCP port to be externally accessible
+    [<CustomOperation "add_tcp_port">]
+    member __.AddTcpPort(state:ContainerGroupConfig, port) = { state with IpAddress = { state.IpAddress with Ports = { Protocol=System.Net.Sockets.ProtocolType.Tcp; Port = port } :: state.IpAddress.Ports } }
+    /// Adds a UDP port to be externally accessible
+    [<CustomOperation "add_udp_port">]
+    member __.AddUdpPort(state:ContainerGroupConfig, port) = { state with IpAddress = { state.IpAddress with Ports = { Protocol=System.Net.Sockets.ProtocolType.Udp; Port = port } :: state.IpAddress.Ports } }
+
+module Converters =
+    let containerInstance (config:ContainerInstanceConfig) : ContainerInstance =
+        { Name = config.Name
+          Image = config.Image
+          Ports = config.Ports
+          Resources =
+            { Cpu = config.Cpu
+              Memory = config.Memory
+            }
+        }
+    let containerGroup location (config:ContainerGroupConfig) : ContainerGroup =
+        { Location = location
+          Name = config.Name
+          ContainerInstances = config.ContainerInstances |> List.map containerInstance
+          OsType = config.OsType
+          RestartPolicy = config.RestartPolicy
+          IpAddress = config.IpAddress
+        }
+
+let containerGroup = ContainerGroupBuilder()

--- a/src/Farmer/Farmer.fs
+++ b/src/Farmer/Farmer.fs
@@ -77,6 +77,48 @@ type StorageAccount =
       Location : string
       Sku : string
       Containers : (string * StorageContainerAccess) list }
+module ContainerGroups = 
+    type ContainerGroupOsType =
+        | Windows
+        | Linux
+    type ContainerGroupRestartPolicy =
+        | Never
+        | Always
+        | OnFailure
+    type ContainerGroupIpAddressType =
+        | PublicAddress
+        | PrivateAddress
+    type ContainerPort =
+        { Protocol : System.Net.Sockets.ProtocolType
+          Port : uint16
+        }
+    type ContainerGroupIpAddress =
+        { Type : ContainerGroupIpAddressType
+          Ports : ContainerPort list
+        }
+    /// Gigabytes
+    type [<Measure>] Gb
+    type ContainerResourceRequest =
+        { Cpu : int
+          Memory : float<Gb>
+        }
+    type ContainerInstance =
+        { Name : ResourceName
+          Image : string
+          Ports : uint16 list
+          Resources : ContainerResourceRequest
+        }
+    type ContainerGroup =
+        { Name : ResourceName
+          Location : string
+          ContainerInstances : ContainerInstance list
+          OsType : ContainerGroupOsType
+          RestartPolicy : ContainerGroupRestartPolicy
+          IpAddress : ContainerGroupIpAddress
+        }
+
+open ContainerGroups
+
 type WebApp =
     { Name : ResourceName 
       ServerFarm : ResourceName
@@ -183,6 +225,7 @@ type SupportedResource =
     | ServerFarm of ServerFarm | WebApp of WebApp
     | SqlServer of SqlAzure
     | StorageAccount of StorageAccount
+    | ContainerGroup of ContainerGroup
     | AppInsights of AppInsights
     | Ip of PublicIpAddress | Vnet of VirtualNetwork | Nic of NetworkInterface | Vm of VirtualMachine
     | AzureSearch of Search
@@ -196,6 +239,7 @@ type SupportedResource =
         | WebApp x -> x.Name
         | SqlServer x -> x.DbName
         | StorageAccount x -> x.Name
+        | ContainerGroup x -> x.Name
         | Ip x -> x.Name
         | Vnet x -> x.Name
         | Nic x -> x.Name

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Builders.Sql.fs" />
     <Compile Include="Builders.Search.fs" />
     <Compile Include="Builders.Cosmos.fs" />
+    <Compile Include="Builders.ContainerGroups.fs" />
     <Compile Include="Builders.Arm.fs" />
     <Compile Include="Writer.fs" />
     <Compile Include="Test.fs" />

--- a/src/Farmer/Test.fs
+++ b/src/Farmer/Test.fs
@@ -83,6 +83,30 @@ let template (environment:string) storageSku webAppSku =
         add_ssd_disk 128
         add_slow_disk 1024
     }
+    
+    let myContainerGroup = containerGroup {
+        name "appWithHttpFrontend"
+        os_type Models.ContainerGroups.ContainerGroupOsType.Linux
+        add_tcp_port 80us
+        add_tcp_port 443us
+        restart_policy Models.ContainerGroups.ContainerGroupRestartPolicy.Always
+        add_containers [
+            containerInstance {
+                name "nginx"
+                image "nginx:1.17.6-alpine"
+                ports [ 80us; 443us ]
+                memory 0.5<Models.ContainerGroups.Gb>
+                cpu 1
+            }
+            containerInstance {
+                name "fsharpApp"
+                image "myapp:1.7.2"
+                ports [ 8080us ]
+                memory 1.5<Models.ContainerGroups.Gb>
+                cpu 2
+            }
+        ]
+    }
 
     let mySearch = search {
         name "isaacsSearch"
@@ -99,6 +123,7 @@ let template (environment:string) storageSku webAppSku =
         add_resource myVm
         add_resource mySearch
         add_resource myCustomAi
+        add_resource myContainerGroup
 
         output "webAppName" myWebApp.Name
         output "webAppPassword" myWebApp.PublishingPassword        


### PR DESCRIPTION
This adds support for container groups, which can hold one or more Azure Container Instances. Besides the type safety, this also handles a few implementation details, such as container instance names must be lowercase.