### PR TITLE
Add quickdeploy support for linux and os-x

### DIFF
--- a/src/Farmer/Writer.fs
+++ b/src/Farmer/Writer.fs
@@ -546,6 +546,5 @@ let generateDeployScript resourceGroupName (deployment:Deployment) =
 
 let quickDeploy resourceGroupName deployment =
     generateDeployScript resourceGroupName deployment
-    |> fun s -> printfn "starting process %s" s; s
     |> System.Diagnostics.Process.Start
     |> ignore


### PR DESCRIPTION
This fixes #50 

This is a first draft for making `Writer.quickDeploy` cross-platform. 
I have run the changes in a script on my mac and it works fine. Still left to do is to build a new version of the Farmer package and load that and verify that it works.

And of course we need to verify that I didn't break anything for windows.