### PR TITLE
Decentralise converters from ARM builder to each builder.

### DIFF
--- a/src/Farmer/Builders.Arm.fs
+++ b/src/Farmer/Builders.Arm.fs
@@ -9,7 +9,7 @@ type ArmConfig =
     { Parameters : string Set
       Outputs : (string * string) list
       Location : Location
-      Resources : obj list }
+      Resources : SupportedResource list }
 
 type Deployment =
     { Location : Location
@@ -24,73 +24,17 @@ type ArmBuilder() =
 
     member __.Run (state:ArmConfig) =
         let resources =
-          [ for resource in state.Resources do
-              match resource with
-              | :? StorageAccountConfig as config ->
-                  StorageAccount (Converters.storage state.Location config)
-              | :? WebAppConfig as config ->
-                  let outputs = Converters.webApp state.Location config
-                  WebApp outputs.WebApp
-                  ServerFarm outputs.ServerFarm
-                  match outputs.Ai with (Some ai) -> AppInsights ai | None -> ()
-              | :? FunctionsConfig as config ->
-                  let outputs = config |> Converters.functions state.Location
-                  WebApp outputs.WebApp
-                  ServerFarm outputs.ServerFarm
-                  match outputs.Ai with (Some ai) -> AppInsights ai | None -> ()
-                  match outputs.Storage with (Some storage) -> StorageAccount storage | None -> ()
-              | :? ContainerGroupConfig as config ->
-                  ContainerGroup (Converters.containerGroup state.Location config)
-              | :? CosmosDbConfig as config ->
-                  let outputs = config |> Converters.cosmosDb state.Location
-                  CosmosAccount outputs.Account
-                  CosmosSqlDb outputs.SqlDb
-                  yield! outputs.Containers |> List.map CosmosContainer
-              | :? SqlAzureConfig as config ->
-                  SqlServer (Converters.sql state.Location config)
-              | :? VmConfig as config ->
-                  let output = Converters.vm state.Location config
-                  Vm output.Vm
-                  Vnet output.Vnet
-                  Ip output.Ip
-                  Nic output.Nic
-                  match output.Storage with Some storage -> StorageAccount storage | None -> ()
-              | :? SearchConfig as search ->
-                  AzureSearch (Converters.search state.Location search)
-              | :? AppInsightsConfig as aiConfig ->
-                  AppInsights (Converters.appInsights state.Location aiConfig)
-              | :? KeyVaultConfig as keyVaultConfig ->
-                  let output = Converters.keyVault state.Location keyVaultConfig
-                  KeyVault output.KeyVault
-                  for secret in output.Secrets do
-                    KeyVaultSecret secret
-              | :? EventHubConfig as eventHub ->
-                  let output = Converters.eventHub state.Location eventHub
-                  EventHub output.EventHub
-                  yield! output.ConsumerGroups |> List.map ConsumerGroup
-
-                  match output.EventHubNamespace with
-                  | Some ns ->
-                    EventHubNamespace ns
-                    // We only emit auth resources if we're creating a namespace
-                    yield! output.Rights |> List.map EventHubAuthRule
-                  | None ->
-                    ()
-              | :? RedisConfig as redisConfig ->
-                  let redis = Converters.redis state.Location redisConfig
-                  RedisCache redis
-              | resource ->
-                  failwithf "Sorry, I don't know how to handle this resource of type '%s'." (resource.GetType().FullName) ]
-          |> List.groupBy(fun r -> r.ResourceName)
-          |> List.choose(fun (resourceName, instances) ->
-                 match instances with
-                 | [] ->
-                    None
-                 | [ resource ] ->
-                    Some resource
-                 | resource :: _ ->
-                    printfn "Warning: %d resources were found with the same name of '%s'. The first one will be used." instances.Length resourceName.Value
-                    Some resource)
+            state.Resources
+            |> List.groupBy(fun r -> r.ResourceName)
+            |> List.choose(fun (resourceName, instances) ->
+                   match instances with
+                   | [] ->
+                      None
+                   | [ resource ] ->
+                      Some resource
+                   | resource :: _ ->
+                      printfn "Warning: %d resources were found with the same name of '%s'. The first one will be used." instances.Length resourceName.Value
+                      Some resource)
         let output =
             { Parameters =
                 [ for resource in resources do
@@ -101,7 +45,9 @@ type ArmBuilder() =
                     | _ -> () ]
               Outputs = state.Outputs
               Resources = resources }
-        { Location = state.Location; Template = output }
+
+        { Location = state.Location
+          Template = output }
 
     /// Creates an output value that will be returned by the ARM template.
     [<CustomOperation "output">]
@@ -120,16 +66,19 @@ type ArmBuilder() =
     /// Sets the default location of all resources.
     [<CustomOperation "location">]
     member __.Location (state, location) : ArmConfig = { state with Location = location }
-
-    /// Adds a resource to the template.
     [<CustomOperation "add_resource">]
-    member __.AddResource(state, resource) : ArmConfig =
-        { state with Resources = box resource :: state.Resources }
 
-    /// Adds a collection of resources to the template.
+    (* These two "fake" methods are needed to ensure that extension members for each builder
+       is always available. *)
+
+    /// Adds a single resource to the ARM template.
+    member __.AddResource (state:ArmConfig, ()) = state
     [<CustomOperation "add_resources">]
-    member this.AddResources(state, resources) =
-        (state, resources)
-        ||> Seq.fold(fun state resource -> this.AddResource(state, resource))
+    /// Adds a sequence of resources to the ARM template.
+    member __.AddResources (state:ArmConfig, ()) = state
+
+let internal addResources addOne (state:ArmConfig) resources =
+    (state, resources)
+    ||> Seq.fold(fun state resource -> addOne (state, resource))
 
 let arm = ArmBuilder()

--- a/src/Farmer/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders.ContainerGroups.fs
@@ -104,5 +104,11 @@ module Converters =
           RestartPolicy = config.RestartPolicy
           IpAddress = config.IpAddress }
 
+type ArmBuilder.ArmBuilder with
+    member this.AddResource(state:ArmConfig, config:ContainerGroupConfig) =
+        { state with Resources = ContainerGroup (Converters.containerGroup state.Location config) :: state.Resources }
+    member this.AddResources (state, configs) = addResources this.AddResource state configs
+
+
 /// Represents a group of Azure Containers.
 let containerGroup = ContainerGroupBuilder()

--- a/src/Farmer/Builders.Cosmos.fs
+++ b/src/Farmer/Builders.Cosmos.fs
@@ -120,5 +120,17 @@ module Converters =
                 })
         {| Account = account; SqlDb = sqlDb; Containers = containers |}
 
+open Farmer.Models
+type ArmBuilder.ArmBuilder with
+    member __.AddResource(state:ArmConfig, config:CosmosDbConfig) =
+        let outputs = config |> Converters.cosmosDb state.Location
+        let resources = [
+            CosmosAccount outputs.Account
+            CosmosSqlDb outputs.SqlDb
+            yield! outputs.Containers |> List.map CosmosContainer
+        ]
+        { state with Resources = state.Resources @ resources }
+    member this.AddResources (state, configs) = addResources this.AddResource state configs
+
 let cosmosDb = CosmosDbBuilder()
 let container = CosmosDbContainerBuilder()

--- a/src/Farmer/Builders.KeyVault.fs
+++ b/src/Farmer/Builders.KeyVault.fs
@@ -312,5 +312,18 @@ module Converters =
 
         {| KeyVault = keyVault; Secrets = secretKeys |}
 
+open Farmer.Models
+type ArmBuilder.ArmBuilder with
+    member this.AddResource(state:ArmConfig, config:KeyVaultConfig) =
+        let output = Converters.keyVault state.Location config
+        let resources = [
+            KeyVault output.KeyVault
+            for secret in output.Secrets do
+                KeyVaultSecret secret
+        ]
+        { state with Resources = resources @ state.Resources }
+    member this.AddResources (state, configs) = addResources this.AddResource state configs
+
+
 let accessPolicy = AccessPolicyBuilder()
 let keyVault = KeyVaultBuilder()

--- a/src/Farmer/Builders.Redis.fs
+++ b/src/Farmer/Builders.Redis.fs
@@ -96,4 +96,10 @@ module Converters =
             | Tls12 -> "1.2")
         }
 
+type ArmBuilder.ArmBuilder with
+    member this.AddResource(state:ArmConfig, config:RedisConfig) =
+        let redis = Converters.redis state.Location config
+        { state with Resources = RedisCache redis :: state.Resources }
+    member this.AddResources (state, configs) = addResources this.AddResource state configs
+
 let redis = RedisBuilder()

--- a/src/Farmer/Builders.Search.fs
+++ b/src/Farmer/Builders.Search.fs
@@ -82,4 +82,10 @@ module Converters =
             | _ -> "default"
           }
 
+open Farmer.Models
+type ArmBuilder.ArmBuilder with
+    member this.AddResource(state:ArmConfig, config:SearchConfig) =
+        { state with Resources = AzureSearch (Converters.search state.Location config) :: state.Resources } 
+    member this.AddResources (state, configs) = addResources this.AddResource state configs
+
 let search = SearchBuilder()

--- a/src/Farmer/Builders.Sql.fs
+++ b/src/Farmer/Builders.Sql.fs
@@ -138,5 +138,11 @@ module Converters =
           FirewallRules = sql.FirewallRules
         }
 
+open Farmer.Models
+type ArmBuilder.ArmBuilder with
+    member this.AddResource(state:ArmConfig, config:SqlAzureConfig) =
+        { state with Resources = SqlServer (Converters.sql state.Location config) :: state.Resources } 
+    member this.AddResources (state, configs) = addResources this.AddResource state configs
+
 let sql = SqlBuilder()
 

--- a/src/Farmer/Builders.Storage.fs
+++ b/src/Farmer/Builders.Storage.fs
@@ -55,4 +55,11 @@ module Converters =
           Sku = sac.Sku
           Containers = sac.Containers }
 
+type Farmer.ArmBuilder.ArmBuilder with
+    member this.AddResource(state:ArmConfig, config:StorageAccountConfig) =
+        { state with
+            Resources = StorageAccount (Converters.storage state.Location config) :: state.Resources
+        }
+    member this.AddResources (state, configs) = addResources this.AddResource state configs
+
 let storageAccount = StorageAccountBuilder()

--- a/src/Farmer/Builders.Vm.fs
+++ b/src/Farmer/Builders.Vm.fs
@@ -334,4 +334,17 @@ module Converters =
               DomainNameLabel = config.DomainNamePrefix }
         {| Storage = storage; Vm = vm; Nic = nic; Vnet = vnet; Ip = ip |}
 
+type ArmBuilder.ArmBuilder with
+    member this.AddResource(state:ArmConfig, config:VmConfig) =
+        let output = Converters.vm state.Location config
+        let resources = [
+            Vm output.Vm
+            Vnet output.Vnet
+            Ip output.Ip
+            Nic output.Nic
+            match output.Storage with Some storage -> StorageAccount storage | None -> ()
+        ]
+        { state with Resources = state.Resources @ resources }
+    member this.AddResources (state, configs) = addResources this.AddResource state configs
+
 let vm = VirtualMachineBuilder()

--- a/src/Farmer/Builders.WebApp.fs
+++ b/src/Farmer/Builders.WebApp.fs
@@ -573,8 +573,29 @@ module Extensions =
             this.DependsOn(state, webAppConfig.Name)
         member this.DependsOn(state:FunctionsConfig, appInsightsConfig:AppInsightsConfig) =
             this.DependsOn(state, appInsightsConfig.Name)
+    type ArmBuilder.ArmBuilder with
+        member __.AddResource(state:ArmConfig, config:WebAppConfig) =
+            let outputs = Converters.webApp state.Location config
+            let resources = [
+                WebApp outputs.WebApp
+                ServerFarm outputs.ServerFarm
+                match outputs.Ai with Some ai -> AppInsights ai | None -> ()
+            ]
+            { state with Resources = state.Resources @ resources }
+        member __.AddResource(state:ArmConfig, config:FunctionsConfig) =
+            let outputs = config |> Converters.functions state.Location
+            let resources = [
+                WebApp outputs.WebApp
+                ServerFarm outputs.ServerFarm
+                match outputs.Ai with (Some ai) -> AppInsights ai | None -> ()
+                match outputs.Storage with (Some storage) -> StorageAccount storage | None -> ()
+            ]
+            { state with Resources = state.Resources @ resources }
+        member this.AddResource(state:ArmConfig, config:AppInsightsConfig) =
+            { state with Resources = AppInsights (Converters.appInsights state.Location config) :: state.Resources } 
+        member this.AddResources (state, configs) = addResources this.AddResource state configs
+
 
 let appInsights = AppInsightsBuilder()
 let webApp = WebAppBuilder()
 let functions = FunctionsBuilder()
-

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="Result.fs" />
     <Compile Include="Farmer.fs" />
     <Compile Include="Builders.Helpers.fs" />
+    <Compile Include="Builders.Arm.fs" />
     <Compile Include="Builders.Storage.fs" />
     <Compile Include="Builders.Redis.fs" />
     <Compile Include="Builders.KeyVault.fs" />
@@ -49,7 +50,6 @@
     <Compile Include="Builders.Cosmos.fs" />
     <Compile Include="Builders.EventHub.fs" />
     <Compile Include="Builders.ContainerGroups.fs" />
-    <Compile Include="Builders.Arm.fs" />
     <Compile Include="Writer.fs" />
     <Compile Include="Deploy.fs" />
   </ItemGroup>


### PR DESCRIPTION
This PR has two effects:

1. We decentralise the mapping from the higher level `Config` values into the lower-level Azure resources e.g. from WebAppConfig -> ServerFarmer and WebApp etc. We achieve this through extension members on each builder. I had to add "dummy" `add_resource` and `add_resources` methods on the top ArmBuilder level so that the custom keywords are always available.

2. This provides us with more type safety. Instead of passing arbitrary objects into `add_resource` and needing type checks, we now get compiler safety if no valid overload for `add_resource` exists.

@Dzoukr Thoughts?