### PR TITLE
Update Functions documentation - wrong setting name in functions.md

### DIFF
--- a/content/api-overview/resources/functions.md
+++ b/content/api-overview/resources/functions.md
@@ -20,7 +20,7 @@ The Functions builder is used to create Azure Functions accounts. It abstracts t
 |-|-|
 | name | Sets the name of the functions instance. |
 | service_plan_name | Sets the name of the service plan hosting the function instance. |
-| storage_account_link | Do not create an automatic storage account; instead, link to a storage account that is created outside of this Functions instance. |
+| link_to_storage_account | Do not create an automatic storage account; instead, link to a storage account that is created outside of this Functions instance. |
 | app_insights_auto_name | Sets the name of the automatically-created app insights instance. |
 | app_insights_off | Removes any automatic app insights creation, configuration and settings for this webapp. |
 | app_insights_manual | Instead of creating a new AI instance, configure this webapp to point to another AI instance that you are managing yourself. |


### PR DESCRIPTION
Looking at the source code, it seems like the proper name is 'link_to_storage_account' and not 'storage_account_link'.