### PR TITLE
Fix value of FUNCTIONS_WORKER_RUNTIME in the generated ARM

### DIFF
--- a/src/Farmer/Builders.WebApp.fs
+++ b/src/Farmer/Builders.WebApp.fs
@@ -334,7 +334,7 @@ module Converters =
               Location = location
               AppSettings = [
                 yield! fns.Settings |> Map.toList
-                "FUNCTIONS_WORKER_RUNTIME", string fns.Runtime
+                "FUNCTIONS_WORKER_RUNTIME", (string fns.Runtime).ToLower()
                 "WEBSITE_NODE_DEFAULT_VERSION", "10.14.1"
                 "FUNCTIONS_EXTENSION_VERSION", match fns.ExtensionVersion with V1 -> "~1" | V2 -> "~2" | V3 -> "~3"
                 "AzureWebJobsStorage", Storage.buildKey fns.StorageAccountName.ResourceName |> ArmExpression.Eval


### PR DESCRIPTION
Right now, Values of the FUNCTIONS_WORKER_RUNTIME setting for Azure Function Apps are generated using the same casing as defined in the associated DU:

```fsharp
type FunctionsRuntime = DotNet | Node | Java | Python
```
However according to the docs, the values should be lowercase.

![image](https://user-images.githubusercontent.com/8404230/78153456-5ec3bc80-743b-11ea-8817-fb1bfb2e2f05.png)

This causes an issue when trying to deploy a function to the Function App, using VS Code for instance (I presume the same issue might happen using a different deployment means).

![image](https://user-images.githubusercontent.com/8404230/78154105-253f8100-743c-11ea-9fa4-2e914b6aebe6.png)

On a side note, changing my local value from `dotnet` to `DotNet` didn't seem to solve the issue either. The suggested change  should fix this issue.
