### PR TITLE
Create Server Farm builder.

### DIFF
--- a/src/Farmer/Farmer.fs
+++ b/src/Farmer/Farmer.fs
@@ -166,7 +166,7 @@ open System
 
 type WebApp =
     { Name : ResourceName
-      ServerFarm : ResourceName
+      ServicePlan : ResourceName
       Location : Location
       AppSettings : List<string * string>
       AlwaysOn : bool
@@ -183,7 +183,6 @@ type WebApp =
       PythonVersion : string option
       Metadata : List<string * string>
       ZipDeployPath : string option }
-
 type ServerFarm =
     { Name : ResourceName
       Location : Location


### PR DESCRIPTION
Doing this has actually drawn out some nice refactoring regarding the creation of the server farm between webapp and functions (and possibly actually improved correctness around `kind`). However, this still needs some testing to confirm it all works.

cc: @forki can you give this a bash? Will look something like this.

![image](https://user-images.githubusercontent.com/1781813/79057231-4e8fb680-7c5f-11ea-8815-4ed69816d906.png)

Note that with this approach, because you are taking direct control of the server farm, you will need to explicit add it as a resource in addition to the web app.