### PR TITLE
add settings keyword for webapp builder

### DIFF
--- a/src/Farmer/Builders.Functions.fs
+++ b/src/Farmer/Builders.Functions.fs
@@ -116,6 +116,11 @@ type FunctionsBuilder() =
     [<CustomOperation "setting">]
     member __.AddSetting(state:FunctionsConfig, key, value) = { state with Settings = state.Settings.Add(key, value) }
     member __.AddSetting(state:FunctionsConfig, key, value:ArmExpression) = { state with Settings = state.Settings.Add(key, value.Eval()) }
+    /// Sets a list of app setting of the web app in the form "key" "value".
+    [<CustomOperation "settings">]
+    member __.AddSettings(state:FunctionsConfig, settings: (string*string) list) =
+        settings
+        |> List.fold (fun state (key,value: string) -> __.AddSetting(state, key, value)) state
     /// Sets a dependency for the web app.
     [<CustomOperation "depends_on">]
     member __.DependsOn(state:FunctionsConfig, resourceName) =

--- a/src/Farmer/Builders.Redis.fs
+++ b/src/Farmer/Builders.Redis.fs
@@ -64,6 +64,11 @@ type RedisBuilder() =
     [<CustomOperation "setting">]
     member __.AddSetting(state:RedisConfig, key, value) = { state with RedisConfiguration = state.RedisConfiguration.Add(key, value) }
     member this.AddSetting(state:RedisConfig, key, value:int) = this.AddSetting(state, key, string value)
+    /// Adds a list of custom settings in the form "key" "value" to the Redis configuration.
+    [<CustomOperation "settings">]
+    member __.AddSettings(state:RedisConfig, settings: (string*int) list) =
+        settings
+        |> List.fold (fun state (key,value) -> __.AddSetting(state, key, value)) state
     /// Specifies whether the non-ssl Redis server port (6379) is enabled.
     [<CustomOperation "enable_non_ssl_port">]
     member __.EnableNonSsl(state:RedisConfig) = { state with NonSslEnabled = Some true }

--- a/src/Farmer/Builders.WebApp.fs
+++ b/src/Farmer/Builders.WebApp.fs
@@ -213,6 +213,11 @@ type WebAppBuilder() =
     [<CustomOperation "setting">]
     member __.AddSetting(state:WebAppConfig, key, value) = { state with Settings = state.Settings.Add(key, value) }
     member __.AddSetting(state:WebAppConfig, key, value:ArmExpression) = { state with Settings = state.Settings.Add(key, value.Eval()) }
+    /// Sets a list of app setting of the web app in the form "key" "value".
+    [<CustomOperation "settings">]
+    member __.AddSettings(state:WebAppConfig, settings: (string*string) list) =
+        settings
+        |> List.fold (fun state (key, value: string) -> __.AddSetting(state, key, value)) state
     /// Sets a dependency for the web app.
     [<CustomOperation "depends_on">]
     member __.DependsOn(state:WebAppConfig, resourceName) = { state with Dependencies = resourceName :: state.Dependencies }


### PR DESCRIPTION
This adds, additionally to already existing keyword `setting`, a new CE keyword `settings`, which can take a list of key,value settings. It allows to provide them from extern instead of defining each literally within CE, which by bigger count of settings could be not such comfortable

Example:

```fsharp
let webAppSettings =
    [ "foo", "foo"
      "bar", "bar"
      "baz", "baz"
      "port", "8080" ]

let myFunctions = webApp {
    name "isaacsuperfun"
    settings functionSettings
}
```

Workaround:

```fsharp
type WebAppBuilderExtended() =
    inherit Farmer.Resources.WebApp.WebAppBuilder() with
        /// Sets a list of app setting of the web app in the form "key" "value".
        [<CustomOperation "settings">]
        member __.AddSettings(state:WebAppConfig, settings: (string*string) seq) =
            settings
            |> Seq.fold (fun state (key, value: string) -> __.AddSetting(state, key, value)) state
let webApp = WebAppBuilderExtended()
```