### PR TITLE
Rework using CliWrap

### DIFF
--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -21,7 +21,6 @@ module Az =
 
     [<AutoOpen>]
     module AzHelpers =
-        let outputFile = Path.Combine(deployFolder, "output.txt")
         let (|OperatingSystem|_|) platform () =
             if RuntimeInformation.IsOSPlatform platform then Some() else None
 

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -41,17 +41,15 @@ module Az =
 
     /// Executes a generic AZ CLI command.
     let executeAz (arguments : string) =
-        async {
-            let cmd = Cli.Wrap(findAz)
-                         .WithArguments(arguments)
-                         .WithValidation(CommandResultValidation.None)
+        let cmd = Cli.Wrap(findAz)
+                     .WithArguments(arguments)
+                     .WithValidation(CommandResultValidation.None)
 
-            let! result = cmd.ExecuteBufferedAsync().Task |> Async.AwaitTask
+        let result = cmd.ExecuteBufferedAsync().Task |> Async.AwaitTask |> Async.RunSynchronously
 
-            return match result.ExitCode with
-                   | 0 -> Ok result.StandardOutput
-                   | _ -> Error result.StandardError
-        } |> Async.RunSynchronously
+        match result.ExitCode with
+        | 0 -> Ok result.StandardOutput
+        | _ -> Error result.StandardError
 
     /// Tests if the Az CLI has logged in credentials.
     let isLoggedIn() = executeAz "account show" |> function Ok _ -> true | Error _ -> false

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -30,6 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CliWrap" Version="3.0.0" />
     <PackageReference Include="FSharp.Core" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Not as clean as one would hope but at least it's net negative code lines :)

Main issues:

- Azure CLI on Windows is a "cmd" so `Process.Start` doesn't find it automatically. So for Windows I search for the full path first before running.
- This has the unfortunate downside that the implementation is tied to the assumption that `az` is a cmd file, so if Microsoft ever decides to ship it as an exe, it will not work (or the code will have to be adapted in both cases).
- Process execution is asynchronous in CliWrap (because executing a process is asynchronous by nature) so it breaks compatibility a bit. I put `Async.RunSynchronously` as a temporary solution.

In any case, I tried. Not sure if the end result is better than the original though.