### PR TITLE
Small doc fix of container registry keyword

### DIFF
--- a/content/api-overview/resources/container-registry.md
+++ b/content/api-overview/resources/container-registry.md
@@ -13,7 +13,7 @@ The Container Registry builder is used to create Azure Container Registry instan
 |-|-|
 | name | Sets the name of the Container Registry instance. |
 | sku | Sets the SKU of the instance. Defaults to Basic. |
-| api | The value that indicates whether the admin user is enabled. |
+| enable_admin_user | The value that indicates whether the admin user is enabled. |
 
 #### Example
 ```fsharp

--- a/content/api-overview/resources/cosmosdb.md
+++ b/content/api-overview/resources/cosmosdb.md
@@ -1,7 +1,7 @@
 ---
 title: "Cosmos DB"
 date: 2020-02-05T08:53:46+01:00
-weight: 4
+weight: 3
 chapter: false
 ---
 

--- a/content/api-overview/resources/keyvault.md
+++ b/content/api-overview/resources/keyvault.md
@@ -1,7 +1,7 @@
 ---
 title: "Key Vault"
 date: 2020-02-05T08:53:46+01:00
-weight: 7
+weight: 11
 chapter: false
 ---
 

--- a/content/api-overview/resources/redis.md
+++ b/content/api-overview/resources/redis.md
@@ -1,7 +1,7 @@
 ---
 title: "Redis Cache"
 date: 2020-02-23T20:00:00+01:00
-weight: 8
+weight: 18
 chapter: false
 ---
 

--- a/content/api-overview/resources/search.md
+++ b/content/api-overview/resources/search.md
@@ -1,7 +1,7 @@
 ---
 title: "Search"
 date: 2020-02-05T08:53:46+01:00
-weight: 9
+weight: 19
 chapter: false
 ---
 

--- a/content/api-overview/resources/sql.md
+++ b/content/api-overview/resources/sql.md
@@ -1,7 +1,7 @@
 ---
 title: "SQL Azure"
 date: 2020-02-05T08:53:46+01:00
-weight: 10
+weight: 19
 chapter: false
 ---
 

--- a/content/api-overview/resources/storage-account.md
+++ b/content/api-overview/resources/storage-account.md
@@ -1,7 +1,7 @@
 ---
 title: "Storage Account"
 date: 2020-02-05T08:53:46+01:00
-weight: 11
+weight: 19
 chapter: false
 ---
 

--- a/content/api-overview/resources/virtual-machine.md
+++ b/content/api-overview/resources/virtual-machine.md
@@ -1,7 +1,7 @@
 ---
 title: "Virtual Machine"
 date: 2020-02-05T08:53:46+01:00
-weight: 12
+weight: 22
 chapter: false
 ---
 

--- a/content/api-overview/resources/web-app.md
+++ b/content/api-overview/resources/web-app.md
@@ -1,7 +1,7 @@
 ---
 title: "Web App"
 date: 2020-02-05T08:53:46+01:00
-weight: 13
+weight: 23
 chapter: false
 ---
 


### PR DESCRIPTION
Fixes a copy-paste issue in the container registry keywords.
Changes all weights to the alphabet location of the leading letter so adding new resources does not result in a reshuffle to keep alphabetical.

Details found in closed CompositionalIT/farmer#131 issue