### PR TITLE
Add DependencyName onto IBuilder

### DIFF
--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -21,8 +21,8 @@ type AppInsightsConfig =
     { Name : ResourceName }
     /// Gets the ARM expression path to the instrumentation key of this App Insights instance.
     member this.InstrumentationKey = instrumentationKey this.Name
-
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             { Name = this.Name
               Location = location

--- a/src/Farmer/Builders/Builders.CognitiveServices.fs
+++ b/src/Farmer/Builders/Builders.CognitiveServices.fs
@@ -10,6 +10,7 @@ type CognitiveServicesConfig =
       Sku : Sku
       Api : Kind }
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             { Name = this.Name
               Location = location

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -34,6 +34,7 @@ type ContainerConfig =
     /// Gets the name of the container group.
     member this.GroupName = this.ContainerGroupName.ResourceName
     interface IBuilder with
+        member this.DependencyName = this.ContainerGroupName.ResourceName
         member this.BuildResources location existingResources = [
             let container =
                 {| Name = this.Name

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -14,6 +14,7 @@ type ContainerRegistryConfig =
         (sprintf "reference(resourceId('Microsoft.ContainerRegistry/registries', '%s'),'2019-05-01').loginServer" this.Name.Value)
         |> ArmExpression
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             { Name = this.Name
               Location = location

--- a/src/Farmer/Builders/Builders.EventHub.fs
+++ b/src/Farmer/Builders/Builders.EventHub.fs
@@ -39,6 +39,7 @@ type EventHubConfig =
             this.EventHubNamespace.ResourceName.Value
         |> this.ToKeyExpression
     interface IBuilder with
+        member this.DependencyName = this.EventHubNamespace.ResourceName
         member this.BuildResources location _ = [
             let eventHubNamespaceName = this.EventHubNamespace.ResourceName
             let eventHubNamespace =

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -95,17 +95,18 @@ type ExpressRouteConfig =
     Peerings : ExpressRouteCircuitPeeringConfig list }
 
     interface IBuilder with
-        member exr.BuildResources location _ = [
-            { Name = exr.Name
+        member this.DependencyName = this.Name
+        member this.BuildResources location _ = [
+            { Name = this.Name
               Location = location
-              Tier = exr.Tier
-              Family = exr.Family
-              ServiceProviderName = exr.ServiceProviderName
-              PeeringLocation = exr.PeeringLocation
-              Bandwidth = exr.Bandwidth
-              GlobalReachEnabled = exr.GlobalReachEnabled
+              Tier = this.Tier
+              Family = this.Family
+              ServiceProviderName = this.ServiceProviderName
+              PeeringLocation = this.PeeringLocation
+              Bandwidth = this.Bandwidth
+              GlobalReachEnabled = this.GlobalReachEnabled
               Peerings = [
-                  for peering in exr.Peerings do
+                  for peering in this.Peerings do
                       {| PeeringType = peering.PeeringType
                          AzureASN = peering.AzureASN
                          PeerASN = peering.PeerASN

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -48,7 +48,8 @@ type FunctionsConfig =
     /// Gets the Storage Account name for this functions app.
     member this.StorageAccount = this.StorageAccountName.ResourceName
     interface IBuilder with
-        member this.BuildResources location existingResources = [
+        member this.DependencyName = this.ServicePlanName.ResourceName
+        member this.BuildResources location _ = [
             { Name = this.Name
               ServicePlan = this.ServicePlanName.ResourceName
               Location = location

--- a/src/Farmer/Builders/Builders.IotHub.fs
+++ b/src/Farmer/Builders/Builders.IotHub.fs
@@ -23,6 +23,7 @@ type IotHubConfig =
             (this.BuildKey policy)
         |> ArmExpression
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             { Name = this.Name
               Location = location

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -71,7 +71,8 @@ type KeyVaultConfig =
       NetworkAcl : NetworkAcl
       Uri : Uri option
       Secrets : SecretConfig list }
-    interface IBuilder with
+      interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             let keyVault =
                 { Name = this.Name

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -18,6 +18,7 @@ type PostgreSQLBuilderConfig =
       Capacity : int<VCores>
       Tier : Sku }
     interface IBuilder with
+        member this.DependencyName = this.ServerName.ResourceName
         member this.BuildResources location resources = [
             let inMB (gb: int<Gb>) = 1024 * (int gb) * 1<Mb>
             match this.ServerName with

--- a/src/Farmer/Builders/Builders.Redis.fs
+++ b/src/Farmer/Builders/Builders.Redis.fs
@@ -23,6 +23,7 @@ type RedisConfig =
       MinimumTlsVersion : TlsVersion option }
     member this.Key = buildRedisKey this.Name
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             { Name = this.Name
               Location = location

--- a/src/Farmer/Builders/Builders.Search.fs
+++ b/src/Farmer/Builders/Builders.Search.fs
@@ -21,6 +21,7 @@ type SearchConfig =
         sprintf "listQueryKeys('Microsoft.Search/searchServices/%s', '2015-08-19').value[0].key" this.Name.Value
         |> ArmExpression
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             { Name = this.Name
               Location = location

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -28,6 +28,7 @@ type ServiceBusQueueConfig =
     member this.NamespaceDefaultConnectionString = this.GetKeyPath this.NamespaceName.ResourceName.Value "primaryConnectionString"
     member this.DefaultSharedAccessPolicyPrimaryKey = this.GetKeyPath this.NamespaceName.ResourceName.Value "primaryKey"
     interface IBuilder with
+        member this.DependencyName = this.NamespaceName.ResourceName
         member this.BuildResources location existingResources = [
             let queue =
                   { Name = this.Name

--- a/src/Farmer/Builders/Builders.ServicePlan.fs
+++ b/src/Farmer/Builders/Builders.ServicePlan.fs
@@ -13,6 +13,7 @@ type ServicePlanConfig =
       WorkerCount : int
       OperatingSystem : OS }
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
           { Name = this.Name
             Location = location

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -32,6 +32,7 @@ type SqlAzureConfig =
     member this.Server =
         this.ServerName.ResourceName
     interface IBuilder with
+        member this.DependencyName = this.Server
         member this.BuildResources location resources = [
             let database =
                 {| Name = this.Name

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -23,6 +23,7 @@ type StorageAccountConfig =
     /// Gets the ARM expression path to the key of this storage account.
     member this.Key = buildKey this.Name
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             { Name = this.Name
               Location = location

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -31,7 +31,9 @@ type VmConfig =
     member this.SubnetName = makeResourceName this.Name "subnet"
     member this.IpName = makeResourceName this.Name "ip"
     member this.Hostname = sprintf "reference('%s').dnsSettings.fqdn" this.IpName.Value |> ArmExpression
+
     interface IBuilder with
+        member this.DependencyName = this.Name
         member this.BuildResources location _ = [
             // VM itself
             { Name = this.Name

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -90,7 +90,8 @@ type WebAppConfig =
     /// Gets the App Insights name for this web app, if it exists.
     member this.AppInsights = this.AppInsightsName |> Option.map (fun ai -> ai.ResourceName)
     interface IBuilder with
-        member this.BuildResources location existingResources = [
+        member this.DependencyName = this.ServicePlanName.ResourceName
+        member this.BuildResources location _ = [
             let webApp =
                 { Name = this.Name
                   Location = location
@@ -342,6 +343,7 @@ type WebAppBuilder() =
     /// Sets a dependency for the web app.
     [<CustomOperation "depends_on">]
     member __.DependsOn(state:WebAppConfig, resourceName) = { state with Dependencies = resourceName :: state.Dependencies }
+    member __.DependsOn(state:WebAppConfig, builder:IBuilder) = { state with Dependencies = builder.DependencyName :: state.Dependencies }
     /// Sets "Always On" flag
     [<CustomOperation "always_on">]
     member __.AlwaysOn(state:WebAppConfig) = { state with AlwaysOn = true }

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -57,6 +57,8 @@ type IPostDeploy =
 type IBuilder =
     /// Given a location and the currently-built resources, returns a set of resource actions.
     abstract member BuildResources : Location -> IArmResource list -> IArmResource list
+    /// Provides the resource name that other resources should use when depending upon this builder.
+    abstract member DependencyName : ResourceName
 
 /// A functional equivalent of the IBuilder's BuildResources method.
 type Builder = Location -> IArmResource list -> IArmResource list

--- a/src/Tests/Template.fs
+++ b/src/Tests/Template.fs
@@ -117,4 +117,22 @@ let tests = testList "Template" [
         }
         Expect.sequenceEqual template.Template.Outputs [ "bar", "bop"; "foo", "baz" ] "Outputs should work like a key/value store"
     }
+
+    test "Can add a list of resources types together" {
+        let resources : IBuilder list = [
+            storageAccount { name "test" }
+            storageAccount { name "test2" }
+        ]
+        let template = arm {
+            add_resources resources
+        }
+        Expect.hasLength template.Template.Resources 2 "Should be two resources added"
+    }
+
+    test "Can add dependencies through IBuilder" {
+        let a = storageAccount { name "a" }
+        let b = webApp { name "b"; depends_on a }
+
+        Expect.equal b.Dependencies [ ResourceName "a" ] "Dependency should have been set"
+    }
 ]


### PR DESCRIPTION
Fixes #167 by adding a new `DependencyName` property onto `IBuilder`, so you can now simply do the following:

```fsharp
let a = storageAccount {
    name "a"
}

let b = webApp {
    name "b"
    depends_on a // object passed in, not resource name
}
```

This is especially useful for builders that encapsulate multiple resources as now the consumer doesn't have to think about which resource name to use; the builder itself takes care of it for you. So in the case of e.g. SQL, the builder uses the Server Name, and not the Name of the DB itself.