### PR TITLE
Firewall and DB creation support for PostgreSQL

### DIFF
--- a/samples/scripts/postgresql.fsx
+++ b/samples/scripts/postgresql.fsx
@@ -11,6 +11,7 @@ let myPostgres = postgreSQL {
     capacity 4<VCores>
     storage_size 50<Gb>
     tier GeneralPurpose
+    db_name "my_db"
 }
 
 let template = arm {

--- a/samples/scripts/postgresql.fsx
+++ b/samples/scripts/postgresql.fsx
@@ -12,6 +12,7 @@ let myPostgres = postgreSQL {
     storage_size 50<Gb>
     tier GeneralPurpose
     db_name "my_db"
+    enable_azure_firewall
 }
 
 let template = arm {

--- a/src/Farmer/Builders/Builders.Helpers.fs
+++ b/src/Farmer/Builders/Builders.Helpers.fs
@@ -18,3 +18,7 @@ let mergeResource<'T when 'T :> IArmResource> resourceName (merge:'T -> 'T) (exi
     |> List.tryPick(function :? 'T as resource -> Some resource | _ -> None)
     |> Option.map merge
     |> Option.defaultWith (fun () -> failwithf "could not locate %O" resourceName)
+
+let singletonOrEmptyList = function
+    | None -> []
+    | Some v -> [v]


### PR DESCRIPTION
This PR adds two features to the PostgreSQL support in Farmer

1) Database creation
2) Firewall rules

Both features are modelled closely on the corresponding features in the SQL server support

This is related to issue #147 and would probably enable enough use cases to close it for now