### PR TITLE
Support for topics and subscriptions

### DIFF
--- a/samples/scripts/service-bus.fsx
+++ b/samples/scripts/service-bus.fsx
@@ -4,27 +4,30 @@ open Farmer
 open Farmer.Builders
 open Farmer.ServiceBus
 
-let myQueue = serviceBus {
-    namespace_name "allMyQueues"
+let myServiceBus = serviceBus {
+    name "allMyQueues"
     sku Standard
-
-    name "isaacssuperqueue"
+    add_queues [
+        queue { name "queuenumberone" }
+        queue { name "queuenumbertwo" }
+    ]
+    add_topics [
+        topic {
+            name "thetopic"
+            add_subscriptions [
+                subscription {
+                    name "thesub"
+                }
+            ]
+        }
+    ]
 }
-
-let mySecondQueue = serviceBus {
-    name "isaacssecondsuperqueue"
-    link_to_namespace myQueue
-}
-
 
 let deployment = arm {
     location Location.NorthEurope
-    add_resource myQueue
-    add_resource mySecondQueue
-    output "1-NamespaceDefaultConnectionString" myQueue.NamespaceDefaultConnectionString
-    output "1-DefaultSharedAccessPolicyPrimaryKey" myQueue.DefaultSharedAccessPolicyPrimaryKey
-    output "2-NamespaceDefaultConnectionString" mySecondQueue.NamespaceDefaultConnectionString
-    output "2-DefaultSharedAccessPolicyPrimaryKey" mySecondQueue.DefaultSharedAccessPolicyPrimaryKey
+    add_resource myServiceBus
+    output "NamespaceDefaultConnectionString" myServiceBus.NamespaceDefaultConnectionString
+    output "DefaultSharedAccessPolicyPrimaryKey" myServiceBus.DefaultSharedAccessPolicyPrimaryKey
 }
 
 deployment

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -6,22 +6,42 @@ open Farmer.CoreTypes
 open Farmer.ServiceBus
 open System
 
-type ServiceBusQueue =
-    { Name : ResourceName
-      LockDuration : IsoDateTime option
-      DuplicateDetectionHistoryTimeWindow : IsoDateTime option
-      Session : bool option
-      DeadLetteringOnMessageExpiration : bool option
-      DefaultMessageTimeToLive : IsoDateTime
-      MaxDeliveryCount : int option
-      EnablePartitioning : bool option
-      DependsOn : ResourceName list }
+let private tryGetIso (v:IsoDateTime option) = v |> Option.map(fun v -> v.Value) |> Option.toObj
+
+module Namespaces =
+    module Topics =
+        type Subscription =
+            { Name : ResourceName
+              LockDuration : IsoDateTime option
+              DuplicateDetectionHistoryTimeWindow : IsoDateTime option
+              DefaultMessageTimeToLive : IsoDateTime option
+              MaxDeliveryCount : int option
+              Session : bool option
+              DeadLetteringOnMessageExpiration : bool option }
+
+    type Queue =
+        { Name : ResourceName
+          LockDuration : IsoDateTime option
+          DuplicateDetectionHistoryTimeWindow : IsoDateTime option
+          Session : bool option
+          DeadLetteringOnMessageExpiration : bool option
+          DefaultMessageTimeToLive : IsoDateTime
+          MaxDeliveryCount : int option
+          EnablePartitioning : bool option }
+
+    type Topic =
+        { Name : ResourceName
+          DuplicateDetectionHistoryTimeWindow : IsoDateTime option
+          DefaultMessageTimeToLive : IsoDateTime option
+          EnablePartitioning : bool option
+          Subscriptions : Topics.Subscription list }
 
 type Namespace =
     { Name : ResourceName
       Location : Location
       Sku : Sku
-      Queues :ServiceBusQueue list
+      Queues : Namespaces.Queue list
+      Topics : Namespaces.Topic list
       DependsOn : ResourceName list }
     member this.Capacity =
         match this.Sku with
@@ -43,26 +63,57 @@ type Namespace =
                        capacity = this.Capacity |> Option.toNullable |}
                dependsOn = this.DependsOn |> List.map (fun r -> r.Value)
                resources =
-                 [ for queue in this.Queues do
-                     {| apiVersion = "2017-04-01"
-                        name = queue.Name.Value
-                        ``type`` = "Queues"
-                        dependsOn = queue.DependsOn |> List.map (fun r -> r.Value)
-                        properties =
-                         {| lockDuration = queue.LockDuration |> Option.map (fun iso -> iso.Value) |> Option.toObj
-                            requiresDuplicateDetection =
-                                match queue.DuplicateDetectionHistoryTimeWindow with
-                                | Some _ -> Nullable true
-                                | None -> Nullable()
-                            defaultMessageTimeToLive = queue.DefaultMessageTimeToLive.Value
-                            duplicateDetectionHistoryTimeWindow =
-                                queue.DuplicateDetectionHistoryTimeWindow
-                                |> Option.map (fun iso -> iso.Value)
-                                |> Option.toObj
-                            requiresSession = queue.Session |> Option.toNullable
-                            deadLetteringOnMessageExpiration = queue.DeadLetteringOnMessageExpiration |> Option.toNullable
-                            maxDeliveryCount = queue.MaxDeliveryCount |> Option.toNullable
-                            enablePartitioning = queue.EnablePartitioning |> Option.toNullable |}
-                     |}
+                [ for queue in this.Queues do
+                     box {| apiVersion = "2017-04-01"
+                            name = queue.Name.Value
+                            ``type`` = "Queues"
+                            dependsOn = [ this.Name.Value ]
+                            properties =
+                             {| lockDuration = tryGetIso queue.LockDuration
+                                requiresDuplicateDetection =
+                                    match queue.DuplicateDetectionHistoryTimeWindow with
+                                    | Some _ -> Nullable true
+                                    | None -> Nullable()
+                                duplicateDetectionHistoryTimeWindow = tryGetIso queue.DuplicateDetectionHistoryTimeWindow
+                                defaultMessageTimeToLive = queue.DefaultMessageTimeToLive.Value
+                                requiresSession = queue.Session |> Option.toNullable
+                                deadLetteringOnMessageExpiration = queue.DeadLetteringOnMessageExpiration |> Option.toNullable
+                                maxDeliveryCount = queue.MaxDeliveryCount |> Option.toNullable
+                                enablePartitioning = queue.EnablePartitioning |> Option.toNullable |}
+                         |}
+                  for topic in this.Topics do
+                     box {| apiVersion = "2017-04-01"
+                            name = topic.Name.Value
+                            ``type`` = "Topics"
+                            dependsOn = [ this.Name.Value ]
+                            properties =
+                                {| defaultMessageTimeToLive = tryGetIso topic.DefaultMessageTimeToLive
+                                   requiresDuplicateDetection =
+                                       match topic.DuplicateDetectionHistoryTimeWindow with
+                                       | Some _ -> Nullable true
+                                       | None -> Nullable()
+                                   duplicateDetectionHistoryTimeWindow = tryGetIso topic.DuplicateDetectionHistoryTimeWindow
+                                   enablePartitioning = topic.EnablePartitioning |> Option.toNullable |}
+                            resources = [
+                                for subscription in topic.Subscriptions do
+                                    {| apiVersion = "2017-04-01"
+                                       name = subscription.Name.Value
+                                       ``type`` = "Subscriptions"
+                                       dependsOn = [ topic.Name.Value ]
+                                       properties =
+                                        {| defaultMessageTimeToLive = tryGetIso subscription.DefaultMessageTimeToLive
+                                           requiresDuplicateDetection =
+                                               match subscription.DuplicateDetectionHistoryTimeWindow with
+                                               | Some _ -> Nullable true
+                                               | None -> Nullable()
+                                           duplicateDetectionHistoryTimeWindow = tryGetIso subscription.DuplicateDetectionHistoryTimeWindow
+                                           deadLetteringOnMessageExpiration = subscription.DeadLetteringOnMessageExpiration |> Option.toNullable
+                                           maxDeliveryCount = subscription.MaxDeliveryCount |> Option.toNullable
+                                           requiresSession = subscription.Session |> Option.toNullable
+                                           lockDuration = tryGetIso subscription.LockDuration
+                                        |}
+                                    |}
+                            ]
+                         |}
                  ]
             |} :> _

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -5,111 +5,217 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.ServiceBus
 open Farmer.Arm.ServiceBus
+open Namespaces
+open Topics
 open System
 
 type ServiceBusQueueConfig =
-    { NamespaceName : ResourceRef
-      NamespaceSku : Sku
-      Name : ResourceName
+    { Name : ResourceName
       LockDuration : TimeSpan option
       DuplicateDetection : TimeSpan option
       DefaultMessageTimeToLive : TimeSpan option
       Session : bool option
       DeadLetteringOnMessageExpiration : bool option
       MaxDeliveryCount : int option
-      EnablePartitioning : bool option
-      DependsOn : ResourceName list }
-    member private _.GetKeyPath sbNsName property =
-        sprintf
-            "listkeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '%s', 'RootManageSharedAccessKey'), '2017-04-01').%s"
-            sbNsName
-            property
-        |> ArmExpression
-    member this.NamespaceDefaultConnectionString = this.GetKeyPath this.NamespaceName.ResourceName.Value "primaryConnectionString"
-    member this.DefaultSharedAccessPolicyPrimaryKey = this.GetKeyPath this.NamespaceName.ResourceName.Value "primaryKey"
-    interface IBuilder with
-        member this.DependencyName = this.NamespaceName.ResourceName
-        member this.BuildResources location existingResources = [
-            let queue =
-                  { Name = this.Name
-                    LockDuration = this.LockDuration |> Option.map IsoDateTime.OfTimeSpan
-                    DuplicateDetectionHistoryTimeWindow = this.DuplicateDetection |> Option.map IsoDateTime.OfTimeSpan
-                    Session = this.Session
-                    DeadLetteringOnMessageExpiration = this.DeadLetteringOnMessageExpiration
-                    DefaultMessageTimeToLive =
-                        match this.DefaultMessageTimeToLive, this.NamespaceSku with
-                        | None, Sku.Basic -> TimeSpan.FromDays 14.
-                        | None, (Sku.Standard | Sku.Premium _) -> TimeSpan.MaxValue
-                        | Some ttl, _ -> ttl
-                        |> IsoDateTime.OfTimeSpan
-                    MaxDeliveryCount = this.MaxDeliveryCount
-                    EnablePartitioning = this.EnablePartitioning
-                    DependsOn = [ this.NamespaceName.ResourceName ] }
-
-            match this.NamespaceName with
-            | AutomaticallyCreated namespaceName ->
-                { Name = namespaceName
-                  Location = location
-                  Sku = this.NamespaceSku
-                  DependsOn = this.DependsOn
-                  Queues = [ queue ] }
-            | External namespaceName ->
-                existingResources
-                |> Helpers.mergeResource namespaceName (fun ns -> { ns with Queues = queue :: ns.Queues })
-            | AutomaticPlaceholder ->
-                failwith "Service Bus Namespace Name has not been set."
-        ]
+      EnablePartitioning : bool option }
 
 type ServiceBusQueueBuilder() =
     member _.Yield _ =
-        { NamespaceName = AutomaticPlaceholder
-          NamespaceSku = Basic
-          Name = ResourceName.Empty
+        { Name = ResourceName.Empty
           LockDuration = None
           DuplicateDetection = None
           Session = None
           DeadLetteringOnMessageExpiration = None
           DefaultMessageTimeToLive = None
           MaxDeliveryCount = None
-          EnablePartitioning = None
-          DependsOn = List.empty }
-    member _.Run (state:ServiceBusQueueConfig) =
-        match state.DuplicateDetection, state.NamespaceSku with
-        | Some _, Basic -> failwith "Duplicate Detection cannot be set when creating a queue using the Basic tier."
-        | _ -> ()
+          EnablePartitioning = None }
 
-        { state with
-            DependsOn = List.rev state.DependsOn
-            NamespaceName =
-                match state.NamespaceName with
-                | AutomaticPlaceholder -> state.Name.Map(sprintf "%s-ns") |> AutomaticallyCreated
-                | _ -> state.NamespaceName }
-
-    /// The name of the namespace that holds the queue.
-    [<CustomOperation "namespace_name">] member _.NamespaceName(state:ServiceBusQueueConfig, name) = { state with NamespaceName = AutomaticallyCreated (ResourceName name) }
-    /// Link this queue to an existing namespace instead of creating a new one.
-    [<CustomOperation "link_to_namespace">]
-    member _.LinkToNamespace(state:ServiceBusQueueConfig, name) = { state with NamespaceName = External name }
-    member _.LinkToNamespace(state:ServiceBusQueueConfig, config) = { state with NamespaceName = External config.NamespaceName.ResourceName }
-    /// The SKU of the namespace.
-    [<CustomOperation "sku">] member _.Sku(state:ServiceBusQueueConfig, sku) = { state with NamespaceSku = sku }
     /// The name of the queue.
     [<CustomOperation "name">] member _.Name(state:ServiceBusQueueConfig, name) = { state with Name = ResourceName name }
     /// The length of time that a lock can be held on a message.
     [<CustomOperation "lock_duration_minutes">] member _.LockDurationMinutes(state:ServiceBusQueueConfig, duration) = { state with LockDuration = Some (TimeSpan.FromMinutes (float duration)) }
     /// The maximum number of times a message can be delivered before dead lettering.
-    [<CustomOperation "max_delivery_count">] member _.MaxDeliveryCount(state:ServiceBusQueueConfig, count) = { state with MaxDeliveryCount = Some count }
-    /// Whether to enable duplicate detection, and if so, how long to check for.
     [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
     /// The default time-to-live for messages. If not specified, the maximum TTL will be set for the SKU.
     [<CustomOperation "message_ttl_days">] member _.MessageTtl(state:ServiceBusQueueConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
     /// Enables session support.
+    [<CustomOperation "max_delivery_count">] member _.MaxDeliveryCount(state:ServiceBusQueueConfig, count) = { state with MaxDeliveryCount = Some count }
+    /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "enable_session">] member _.Session(state:ServiceBusQueueConfig) = { state with Session = Some true }
     /// Enables dead lettering of messages that expire.
     [<CustomOperation "enable_dead_letter_on_message_expiration">] member _.DeadLetteringOnMessageExpiration(state:ServiceBusQueueConfig) = { state with DeadLetteringOnMessageExpiration = Some true }
     /// Enables partition support on the queue.
     [<CustomOperation "enable_partition">] member _.EnablePartition(state:ServiceBusQueueConfig) = { state with EnablePartitioning = Some true }
-    /// Adds a resource that the service bus depends on.
-    [<CustomOperation "depends_on">] member _.DependsOn(state:ServiceBusQueueConfig, resourceName) = { state with DependsOn = resourceName :: state.DependsOn }
 
-let serviceBus = ServiceBusQueueBuilder()
+type ServiceBusSubscriptionConfig =
+    { Name : ResourceName
+
+      LockDuration : TimeSpan option
+      DuplicateDetection : TimeSpan option
+      DefaultMessageTimeToLive : TimeSpan option
+      MaxDeliveryCount : int option
+      Session : bool option
+      DeadLetteringOnMessageExpiration : bool option }
+
+type ServiceBusSubscriptionBuilder() =
+    member _.Yield _ =
+        { Name = ResourceName.Empty
+
+          LockDuration = None
+          DuplicateDetection = None
+          DefaultMessageTimeToLive = None
+          MaxDeliveryCount = None
+          Session = None
+          DeadLetteringOnMessageExpiration = None }
+
+    /// The name of the queue.
+    [<CustomOperation "name">] member _.Name(state:ServiceBusSubscriptionConfig, name) = { state with Name = ResourceName name }
+    /// The length of time that a lock can be held on a message.
+    [<CustomOperation "lock_duration_minutes">] member _.LockDurationMinutes(state:ServiceBusSubscriptionConfig, duration) = { state with LockDuration = Some (TimeSpan.FromMinutes (float duration)) }
+    /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
+    [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusSubscriptionConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
+    /// The default time-to-live for messages. If not specified, the maximum TTL will be set for the SKU.
+    [<CustomOperation "message_ttl_days">] member _.MessageTtl(state:ServiceBusSubscriptionConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
+    /// Enables session support.
+    [<CustomOperation "max_delivery_count">] member _.MaxDeliveryCount(state:ServiceBusQueueConfig, count) = { state with MaxDeliveryCount = Some count }
+    /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
+    [<CustomOperation "enable_session">] member _.Session(state:ServiceBusQueueConfig) = { state with Session = Some true }
+    /// Enables dead lettering of messages that expire.
+    [<CustomOperation "enable_dead_letter_on_message_expiration">] member _.DeadLetteringOnMessageExpiration(state:ServiceBusQueueConfig) = { state with DeadLetteringOnMessageExpiration = Some true }
+
+type ServiceBusTopicConfig =
+    { Name : ResourceName
+      DuplicateDetection : TimeSpan option
+      DefaultMessageTimeToLive : TimeSpan option
+      EnablePartitioning : bool option
+      Subscriptions : Map<ResourceName, ServiceBusSubscriptionConfig> }
+
+type ServiceBusTopicBuilder() =
+    member _.Yield _ =
+        { Name = ResourceName.Empty
+          DuplicateDetection = None
+          DefaultMessageTimeToLive = None
+          EnablePartitioning = None
+          Subscriptions = Map.empty }
+
+    /// The name of the queue.
+    [<CustomOperation "name">] member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = ResourceName name }
+    /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
+    [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
+    /// The default time-to-live for messages. If not specified, the maximum TTL will be set for the SKU.
+    [<CustomOperation "message_ttl_days">] member _.MessageTtl(state:ServiceBusTopicConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
+    /// Enables partition support on the queue.
+    [<CustomOperation "enable_partition">] member _.EnablePartition(state:ServiceBusTopicConfig) = { state with EnablePartitioning = Some true }
+    [<CustomOperation "add_subscriptions">]
+    member _.AddSubscriptions(state:ServiceBusTopicConfig, subscriptions) =
+        { state with
+            Subscriptions =
+                (state.Subscriptions, subscriptions)
+                ||> List.fold(fun state (subscription:ServiceBusSubscriptionConfig) -> state.Add(subscription.Name, subscription))
+        }
+
+type ServiceBusConfig =
+    { Name : ResourceName
+      Sku : Sku
+      DependsOn : ResourceName list
+      Queues : Map<ResourceName, ServiceBusQueueConfig>
+      Topics : Map<ResourceName, ServiceBusTopicConfig> }
+    member private _.GetKeyPath sbNsName property =
+        sprintf
+            "listkeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '%s', 'RootManageSharedAccessKey'), '2017-04-01').%s"
+            sbNsName
+            property
+        |> ArmExpression
+    member this.NamespaceDefaultConnectionString = this.GetKeyPath this.Name.Value "primaryConnectionString"
+    member this.DefaultSharedAccessPolicyPrimaryKey = this.GetKeyPath this.Name.Value "primaryKey"
+    interface IBuilder with
+        member this.DependencyName = this.Name
+        member this.BuildResources location _ = [
+            { Name = this.Name
+              Location = location
+              Sku = this.Sku
+              DependsOn = this.DependsOn
+              Queues = [
+                  for queue in this.Queues do
+                    let queue = queue.Value
+                    { Name = queue.Name
+                      LockDuration = queue.LockDuration |> Option.map IsoDateTime.OfTimeSpan
+                      DuplicateDetectionHistoryTimeWindow = queue.DuplicateDetection |> Option.map IsoDateTime.OfTimeSpan
+                      Session = queue.Session
+                      DeadLetteringOnMessageExpiration = queue.DeadLetteringOnMessageExpiration
+                      DefaultMessageTimeToLive =
+                          match queue.DefaultMessageTimeToLive, this.Sku with
+                          | None, Sku.Basic -> TimeSpan.FromDays 14.
+                          | None, (Sku.Standard | Sku.Premium _) -> TimeSpan.MaxValue
+                          | Some ttl, _ -> ttl
+                          |> IsoDateTime.OfTimeSpan
+                      MaxDeliveryCount = queue.MaxDeliveryCount
+                      EnablePartitioning = queue.EnablePartitioning }
+              ]
+              Topics = [
+                  for topic in this.Topics do
+                    let topic = topic.Value
+                    { Namespaces.Topic.Name = topic.Name
+                      DuplicateDetectionHistoryTimeWindow = topic.DuplicateDetection |> Option.map IsoDateTime.OfTimeSpan
+                      DefaultMessageTimeToLive = topic.DefaultMessageTimeToLive |> Option.map IsoDateTime.OfTimeSpan
+                      EnablePartitioning = topic.EnablePartitioning
+                      Subscriptions = [
+                          for subscription in topic.Subscriptions do
+                            let subscription = subscription.Value
+                            { Name = subscription.Name
+                              LockDuration = subscription.LockDuration |> Option.map IsoDateTime.OfTimeSpan
+                              DuplicateDetectionHistoryTimeWindow = subscription.DuplicateDetection |> Option.map IsoDateTime.OfTimeSpan
+                              DefaultMessageTimeToLive = subscription.DefaultMessageTimeToLive |> Option.map IsoDateTime.OfTimeSpan
+                              MaxDeliveryCount = subscription.MaxDeliveryCount
+                              Session = subscription.Session
+                              DeadLetteringOnMessageExpiration = subscription.DeadLetteringOnMessageExpiration }
+                      ]
+                    }
+              ]
+            }
+        ]
+
+type ServiceBusBuilder() =
+    member _.Yield _ =
+        { Name = ResourceName.Empty
+          Sku = Basic
+          Queues = Map.empty
+          Topics = Map.empty
+          DependsOn = List.empty }
+    member _.Run (state:ServiceBusConfig) =
+        let isBetween min max v = v >= min && v <= max
+        for queue in state.Queues do
+            let queue = queue.Value
+
+            match queue.DuplicateDetection, state.Sku with
+            | Some _, Basic -> failwithf "Duplicate Detection cannot be set when creating a queue using the Basic tier (queue '%s' fails this check)." queue.Name.Value
+            | _ -> ()
+            queue.LockDuration |> Option.iter(fun lockDuration -> if lockDuration > TimeSpan(0,5,0) then failwith "Lock duration name must not be more than 5 minutes.")
+
+        if state.Name.Value.Length |> isBetween 6 50 |> not then failwith "Namespace name must be between 6 and 50 characters long"
+        state
+    /// The name of the namespace that holds the queue.
+    [<CustomOperation "name">] member _.NamespaceName(state:ServiceBusConfig, name) = { state with Name = ResourceName name }
+    /// The SKU of the namespace.
+    [<CustomOperation "sku">] member _.Sku(state:ServiceBusConfig, sku) = { state with Sku = sku }
+    /// Adds a resource that the service bus depends on.
+    [<CustomOperation "depends_on">] member _.DependsOn(state:ServiceBusConfig, resourceName) = { state with DependsOn = resourceName :: state.DependsOn }
+    [<CustomOperation "add_queues">]
+    member _.AddQueues(state:ServiceBusConfig, queues) =
+        { state with
+            Queues =
+                (state.Queues, queues)
+                ||> List.fold(fun state (queue:ServiceBusQueueConfig) -> state.Add(queue.Name, queue))
+        }
+    [<CustomOperation "add_topics">]
+    member _.AddTopics(state:ServiceBusConfig, topics) =
+        { state with
+            Topics =
+                (state.Topics, topics)
+                ||> List.fold(fun state (topic:ServiceBusTopicConfig) -> state.Add(topic.Name, topic))
+        }
+
+let serviceBus = ServiceBusBuilder()
+let topic = ServiceBusTopicBuilder()
+let queue = ServiceBusQueueBuilder()
+let subscription = ServiceBusSubscriptionBuilder()

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -27,4 +27,4 @@ let allTests =
 [<EntryPoint>]
 let main _ =
     printfn "Running tests!"
-    runTests { defaultConfig with verbosity = Logging.Verbose } allTests
+    runTests { defaultConfig with verbosity = Logging.Info } allTests

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -14,12 +14,13 @@ open System
 let dummyClient = new ServiceBusManagementClient (Uri "http://management.azure.com", TokenCredentials "NotNullOrWhiteSpace")
 
 let tests = testList "Service Bus Tests" [
+    let getUnsafe data = data |> convertResourceBuilder (fun (ns:{| resources:obj list |}) -> ns.resources.[0]) dummyClient.SerializationSettings
     test "Namespace is correctly created" {
         let sbNs =
             arm {
                 add_resource (
                     serviceBus {
-                        name "my-queue"
+                        name "serviceBus"
                         sku Standard
                     })
             }
@@ -28,71 +29,127 @@ let tests = testList "Service Bus Tests" [
 
         sbNs.Validate()
 
-        Expect.equal sbNs.Name "my-queue-ns" "Invalid namespace name"
+        Expect.equal sbNs.Name "serviceBus" "Invalid namespace name"
         Expect.equal sbNs.Sku.Name SkuName.Standard "Invalid Sku"
     }
 
-    test "Queue is correctly created" {
-        let queue:SBQueue =
-            serviceBus {
-                name "my-queue"
-                duplicate_detection_minutes 5
-                sku ServiceBus.Standard
-                enable_dead_letter_on_message_expiration
-                enable_partition
-                enable_session
-                lock_duration_minutes 10
-                max_delivery_count 3
-                message_ttl_days 10
-            } |> convertResourceBuilder (fun (ns:{| resources:obj list |}) -> ns.resources.[0]) dummyClient.SerializationSettings
-
-        Expect.equal queue.Name "my-queue" "Invalid queue name"
-        Expect.isTrue (queue.RequiresDuplicateDetection.GetValueOrDefault false) "Duplicate detection should be enabled"
-        Expect.equal queue.DuplicateDetectionHistoryTimeWindow (Nullable(TimeSpan(0, 5, 0))) "Duplicate detection window incorrect"
-        Expect.isTrue (queue.DeadLetteringOnMessageExpiration.GetValueOrDefault false) "Dead lettering should be enabled"
-        Expect.isTrue (queue.EnablePartitioning.GetValueOrDefault false) "Partitioning should be enabled"
-        Expect.isTrue (queue.RequiresSession.GetValueOrDefault false) "Sessions should be enabled"
-        Expect.equal queue.LockDuration (Nullable (TimeSpan(0, 10, 0))) "Lock duration incorrect"
-        Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalDays 10. "Default TTL incorrect"
-        Expect.equal queue.MaxDeliveryCount (Nullable 3) "Max delivery count incorrect"
+    test "Namespace name length is respected" {
+        Expect.throws(fun _ -> serviceBus { name "myns" } |> ignore) "Namespace length is too small"
+        Expect.throws(fun _ -> serviceBus { name (String.replicate 51 "x") } |> ignore) "Namespace length is too long"
     }
 
-    test "Cannot set duplicate detection on basic tier" {
-        Expect.throws (fun () ->
-            serviceBus {
-                name "my-queue"
-                duplicate_detection_minutes 1
-            } |> ignore) "Duplicate detection isn't allowed on basic tier"
-    }
+    testList "Queue Tests" [
+        test "Queue is correctly created" {
+            let queue:SBQueue =
+                serviceBus {
+                    name "serviceBus"
+                    sku ServiceBus.Standard
+                    add_queues [
+                        queue {
+                            name "my-queue"
+                            duplicate_detection_minutes 5
+                            enable_dead_letter_on_message_expiration
+                            enable_partition
+                            enable_session
+                            lock_duration_minutes 5
+                            max_delivery_count 3
+                            message_ttl_days 10
+                        }
+                    ]
+                } |> getUnsafe
 
-    test "Default TTL set for Basic queue" {
-        let queue:SBQueue =
-            serviceBus {
-                name "my-queue"
-            } |> convertResourceBuilder (fun (ns:{| resources:obj list |}) -> ns.resources.[0]) dummyClient.SerializationSettings
+            Expect.equal queue.Name "my-queue" "Invalid queue name"
+            Expect.isTrue (queue.RequiresDuplicateDetection.GetValueOrDefault false) "Duplicate detection should be enabled"
+            Expect.equal queue.DuplicateDetectionHistoryTimeWindow (Nullable(TimeSpan(0, 5, 0))) "Duplicate detection window incorrect"
+            Expect.isTrue (queue.DeadLetteringOnMessageExpiration.GetValueOrDefault false) "Dead lettering should be enabled"
+            Expect.isTrue (queue.EnablePartitioning.GetValueOrDefault false) "Partitioning should be enabled"
+            Expect.isTrue (queue.RequiresSession.GetValueOrDefault false) "Sessions should be enabled"
+            Expect.equal queue.LockDuration (Nullable (TimeSpan(0, 5, 0))) "Lock duration incorrect"
+            Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalDays 10. "Default TTL incorrect"
+            Expect.equal queue.MaxDeliveryCount (Nullable 3) "Max delivery count incorrect"
+        }
 
-        Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalDays 14. "Default TTL should be 14 days"
-    }
+        test "Cannot set duplicate detection on basic tier" {
+            Expect.throws (fun () ->
+                serviceBus {
+                    name "serviceBus"
+                    add_queues [
+                        queue {
+                            name "my-queue"
+                            duplicate_detection_minutes 1
+                        }
+                    ]
+                } |> ignore) "Duplicate detection isn't allowed on basic tier"
+        }
 
-    test "Default TTL set for Standard queue" {
-        let queue:SBQueue =
-            serviceBus {
-                name "my-queue"
-                sku ServiceBus.Standard
-            } |> convertResourceBuilder (fun (ns:{| resources:obj list |}) -> ns.resources.[0]) dummyClient.SerializationSettings
+        test "Cannot set lock duration more than 5 minutes" {
+            Expect.throws (fun () ->
+                serviceBus {
+                    name "serviceBus"
+                    add_queues [
+                        queue {
+                            name "my-queue"
+                            lock_duration_minutes 6
+                        }
+                    ]
+                } |> ignore) "Lock duration max should be 5 minutes"
+        }
 
-        Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalDays TimeSpan.MaxValue.TotalDays "Default TTL should be max value"
-    }
+        test "Default TTL set for Basic queue" {
+            let queue:SBQueue =
+                serviceBus {
+                    name "serviceBus"
+                    add_queues [ queue { name "my-queue" } ]
+                } |> getUnsafe
 
-    test "Correctly creates multiple queues" {
-        let queueA = serviceBus { name "queue-a" }
-        let queueB = serviceBus { name "queue-b"; link_to_namespace queueA }
-        let deployment = arm { add_resource queueA; add_resource queueB }
-        match deployment.Template.Resources with
-        | [ :? Namespace as ns ] when ns.Queues.Length = 2 ->
-            ()
-        | _ ->
-            failwith "Should have two queues in a single namespace."
+            Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalDays 14. "Default TTL should be 14 days"
+        }
 
-    }
+        test "Default TTL set for Standard queue" {
+            let queue:SBQueue =
+                serviceBus {
+                    name "serviceBus"
+                    sku ServiceBus.Standard
+                    add_queues [ queue { name "my-queue" } ]
+                } |> getUnsafe
+
+            Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalDays TimeSpan.MaxValue.TotalDays "Default TTL should be max value"
+        }
+
+        test "Correctly creates multiple queues" {
+            let theBus = serviceBus {
+                name "serviceBus"
+                add_queues [
+                    queue { name "queue-a" }
+                    queue { name "queue-b" }
+                ]
+            }
+            let deployment = arm { add_resource theBus }
+            match deployment.Template.Resources with
+            | [ :? Namespace as ns ] when ns.Queues.Length = 2 -> ()
+            | _ -> failwith "Should have two queues in a single namespace."
+        }
+    ]
+
+    testList "Topic Tests" [
+        test "Create create a basic topic" {
+            let topic:SBTopic =
+                serviceBus {
+                    name "servicebus"
+                    add_topics [
+                        topic {
+                            name "topic"
+                            duplicate_detection_minutes 3
+                            message_ttl_days 2
+                            enable_partition
+                        }
+                    ]
+                } |> getUnsafe
+            Expect.equal topic.Name "topic" "Name not set"
+            Expect.equal topic.RequiresDuplicateDetection (Nullable true) "Duplicate detection not set"
+            Expect.equal topic.DuplicateDetectionHistoryTimeWindow (Nullable (TimeSpan.FromMinutes 3.)) "Duplicate detection time not set"
+            Expect.equal topic.DefaultMessageTimeToLive (Nullable (TimeSpan.FromDays 2.)) "Time to live not set"
+            Expect.equal topic.EnablePartitioning (Nullable true) "Paritition not set"
+        }
+    ]
 ]


### PR DESCRIPTION
Closes #165. @evilpilaf can you have a look at this from a consumption point of view if it makes sense?

```fsharp
let myServiceBus = serviceBus {
    name "allMyQueues"
    sku Standard
    add_queues [
        queue { name "queuenumberone" }
        queue { name "queuenumbertwo" }
    ]
    add_topics [
        topic {
            name "thetopic"
            add_subscriptions [
                subscription {
                    name "thesub"
                }
            ]
        }
    ]
}
```

The reference docs are a bit hazy around the exact properties permitted for subs and topics but I've done a few tests and they seem to work ok in that topics and subs are now created as well.