### PR TITLE
Fix setting httpsOnly for function app

### DIFF
--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -90,7 +90,7 @@ type FunctionsConfig =
                 this.StorageAccountName.ResourceName
               ]
               AlwaysOn = false
-              HTTPSOnly = false
+              HTTPSOnly = this.HTTPSOnly
               LinuxFxVersion = None
               NetFrameworkVersion = None
               JavaVersion = None


### PR DESCRIPTION
httpsOnly value was always false in the template output for function apps.
This appears to be done correctly web apps but not for functions