### PR TITLE
SQL Elastic Pools, but better

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger:
   paths:
     exclude:
-    - 'docs/**'
+    - 'docs/'
 strategy:
   matrix:
     Linux:

--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -22,7 +22,7 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 | elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database. |
 | elastic_pool_capacity | Sets the optional disk size in MB for the elastic pool for each database. |
 
-##### Configuration Members
+#### SQL Server Configuration Members
 | Member | Purpose |
 |-|-|
 | ConnectionString | Gets a literal .NET connection string using the administrator username / password, given a database or database name. The password will be evaluated based on the contents of the password parameter supplied to the template at deploy time. |

--- a/samples/scripts/sqlserver.fsx
+++ b/samples/scripts/sqlserver.fsx
@@ -8,6 +8,8 @@ let myDatabases = sqlServer {
     name "isaac_super_server"
     admin_username "admin_username"
     enable_azure_firewall
+    elastic_pool_database_min_max 0<Sql.DTU> 5<Sql.DTU>
+    elastic_pool_capacity 5000<Mb>
     add_databases [
         sqlDb { name "poolDb1" }
         sqlDb { name "poolDb2" }

--- a/samples/scripts/sqlserver.fsx
+++ b/samples/scripts/sqlserver.fsx
@@ -3,17 +3,20 @@
 
 open Farmer
 open Farmer.Builders
+open Sql
 
 let myDatabases = sqlServer {
     name "isaac_super_server"
     admin_username "admin_username"
     enable_azure_firewall
-    elastic_pool_database_min_max 0<Sql.DTU> 5<Sql.DTU>
-    elastic_pool_capacity 5000<Mb>
+
+    elastic_pool_name "mypool"
+    elastic_pool_sku PoolSku.Basic100
+
     add_databases [
         sqlDb { name "poolDb1" }
         sqlDb { name "poolDb2" }
-        sqlDb { name "standaloneDb1"; sku Sql.DbSku.Basic }
+        sqlDb { name "standaloneDb1"; sku DbSku.Basic }
     ]
 }
 

--- a/samples/scripts/sqlserver.fsx
+++ b/samples/scripts/sqlserver.fsx
@@ -4,17 +4,20 @@
 open Farmer
 open Farmer.Builders
 
-let sqlDb = sql {
-    name "my_db"
-    server_name "my_server"
+let myDatabases = sqlServer {
+    name "isaac_super_server"
     admin_username "admin_username"
-    sku Sql.Free
     enable_azure_firewall
+    add_databases [
+        sqlDb { name "poolDb1" }
+        sqlDb { name "poolDb2" }
+        sqlDb { name "standaloneDb1"; sku Sql.DbSku.Basic }
+    ]
 }
 
 let template = arm {
     location Location.NorthEurope
-    add_resource sqlDb
+    add_resource myDatabases
 }
 
 template

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -20,6 +20,8 @@ type Server =
       ElasticPool :
         {| Name : ResourceName
            Sku : PoolSku
+           MinMax : (int<DTU> * int<DTU>) option
+           MaxSizeBytes : int64 option
         |} option
       FirewallRules :
         {| Name : string
@@ -46,7 +48,13 @@ type Server =
                         box
                             {| ``type`` = "elasticPools"
                                name = pool.Name.Value
-                               properties = {| |}
+                               properties =
+                                {| maxSizeBytes = pool.MaxSizeBytes |> Option.toNullable
+                                   perDatabaseSettings =
+                                    match pool.MinMax with
+                                    | Some (min, max) -> box {| minCapacity = min; maxCapacity = max |}
+                                    | None -> null
+                                |}
                                apiVersion = "2017-10-01-preview"
                                location = this.Location.ArmValue
                                sku = {| name = pool.Sku.Name; tier = pool.Sku.Edition; size = string pool.Sku.Capacity |}

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -46,6 +46,7 @@ type Server =
                         box
                             {| ``type`` = "elasticPools"
                                name = pool.Name.Value
+                               properties = {| |}
                                apiVersion = "2017-10-01-preview"
                                location = this.Location.ArmValue
                                sku = {| name = pool.Sku.Name; tier = pool.Sku.Edition; size = string pool.Sku.Capacity |}
@@ -72,9 +73,9 @@ type Server =
                                      | Pool pool -> sprintf "[resourceId('Microsoft.Sql/servers/elasticPools', '%s', '%s')]" this.ServerName.Value pool.Value |}
                                dependsOn =
                                  [ this.ServerName.Value
-                                   match this.ElasticPool with
-                                   | Some pool -> pool.Name.Value
-                                   | None -> ()
+                                   match database.Sku with
+                                   | Standalone _ -> ()
+                                   | Pool poolName -> poolName.Value
                                  ]
                                resources = [
                                    match database.TransparentDataEncryption with

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -7,124 +7,108 @@ open Farmer.Sql
 open Farmer.Arm.Sql
 open System.Net
 
-type SkuKind =
-    | DbSku of DbSku
-    | PoolSku of PoolSku
-    | ExternalPool
+type SqlAzureDbConfig =
+    { Name : ResourceName
+      Sku : DbSku option
+      Collation : string
+      Encryption : FeatureFlag }
 
 type SqlAzureConfig =
-    { ServerName : ResourceRef
+    { Name : ResourceName
       AdministratorCredentials : {| UserName : string; Password : SecureParameter |}
-      Name : ResourceName
-      Sku : SkuKind
-      DbCollation : string
-      Encryption : FeatureFlag
-      FirewallRules : {| Name : string; Start : IPAddress; End : IPAddress |} list }
-    /// Gets the ARM expression path to the FQDN of this VM.
-    member this.FullyQualifiedDomainName =
-        sprintf "reference(concat('Microsoft.Sql/servers/', variables('%s'))).fullyQualifiedDomainName" this.ServerName.ResourceName.Value
-        |> ArmExpression
+      FirewallRules : {| Name : string; Start : IPAddress; End : IPAddress |} list
+      ElasticPoolSku : PoolSku
+      Databases : SqlAzureDbConfig list }
     /// Gets a basic .NET connection string using the administrator username / password.
-    member this.ConnectionString =
+    member this.ConnectionString (database:SqlAzureDbConfig) =
         concat
             [ literal
                 (sprintf "Server=tcp:%s.database.windows.net,1433;Initial Catalog=%s;Persist Security Info=False;User ID=%s;Password="
-                    this.ServerName.ResourceName.Value
                     this.Name.Value
+                    database.Name.Value
                     this.AdministratorCredentials.UserName)
               this.AdministratorCredentials.Password.AsArmRef
               literal ";MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;" ]
-    member this.Server =
-        this.ServerName.ResourceName
-    interface IBuilder with
-        member this.DependencyName = this.Server
-        member this.BuildResources location resources = [
-            let elasticPoolName = this.Server.Map (sprintf "%s-pool")
-            let database =
-                {| Name = this.Name
-                   Sku =
-                    match this.Sku with
-                    | PoolSku _
-                    | ExternalPool _ ->
-                        Pool elasticPoolName
-                    | DbSku sku ->
-                        Standalone sku
-                   Collation = this.DbCollation
-                   TransparentDataEncryption = this.Encryption |}
+    member this.ConnectionString databaseName =
+        this.Databases
+        |> List.tryFind(fun db -> db.Name = databaseName)
+        |> Option.map this.ConnectionString
+        |> Option.defaultWith(fun _ -> failwithf "Unknown database name %s" databaseName.Value)
 
-            match this.ServerName with
-            | AutomaticallyCreated serverName ->
-                { ServerName = serverName
-                  Location = location
-                  Credentials =
-                    {| Username = this.AdministratorCredentials.UserName
-                       Password = this.AdministratorCredentials.Password |}
-                  FirewallRules = this.FirewallRules
-                  ElasticPool =
-                    match this.Sku with
-                    | PoolSku sku ->
-                        Some {| Name = elasticPoolName; Sku = sku |}
-                    | DbSku _
-                    | ExternalPool ->
-                        None
-                  Databases = [ database ]
-                }
-            | External serverName ->
-                resources
-                |> Helpers.mergeResource serverName (fun server -> { server with Databases = database :: server.Databases })
-            | AutomaticPlaceholder ->
-                failwith "SQL Server Name has not been set."
+    interface IBuilder with
+        member this.DependencyName = this.Name
+        member this.BuildResources location resources = [
+            let elasticPoolName = this.Name.Map (sprintf "%s-pool")
+            { ServerName = this.Name
+              Location = location
+              Credentials =
+                {| Username = this.AdministratorCredentials.UserName
+                   Password = this.AdministratorCredentials.Password |}
+              FirewallRules = this.FirewallRules
+              ElasticPool =
+                if this.Databases |> List.forall(fun db -> db.Sku.IsSome) then None
+                else Some {| Name = elasticPoolName; Sku = this.ElasticPoolSku |}
+              Databases = [
+                  for database in this.Databases do
+                    {| Name = database.Name
+                       Sku =
+                        match database.Sku with
+                        | Some dbSku -> Standalone dbSku
+                        | None -> Pool elasticPoolName
+                       Collation = database.Collation
+                       TransparentDataEncryption = database.Encryption |}
+              ]
+            }
         ]
+
+type SqlDbBuilder() =
+    member _.Yield _ =
+        { Name = ResourceName ""
+          Collation = "SQL_Latin1_General_CP1_CI_AS"
+          Sku = None
+          Encryption = Disabled }
+    /// Sets the name of the database.
+    [<CustomOperation "name">]
+    member _.DbName(state:SqlAzureDbConfig, name) = { state with Name = name }
+    member this.DbName(state:SqlAzureDbConfig, name:string) = this.DbName(state, ResourceName name)
+    // Sets the sku of the database
+    [<CustomOperation "sku">]
+    member _.DbSku(state:SqlAzureDbConfig, sku:DbSku) = { state with Sku = Some sku }
+    // Sets the collation of the database.
+    [<CustomOperation "collation">]
+    member _.DbCollation(state:SqlAzureDbConfig, collation:string) = { state with Collation = collation }
+    // Enables encryption of the database.
+    [<CustomOperation "use_encryption">]
+    member _.UseEncryption(state:SqlAzureDbConfig) = { state with Encryption = Enabled }
+    // Adds a custom firewall rule given a name, start and end IP address range.
+    member _.Run (state:SqlAzureDbConfig) =
+        if state.Name = ResourceName.Empty then failwith "You must set a database name."
+        state
 
 type SqlBuilder() =
     let makeIp = IPAddress.Parse
     member __.Yield _ =
-        { ServerName = AutomaticPlaceholder
+        { Name = ResourceName ""
           AdministratorCredentials = {| UserName = ""; Password = SecureParameter "" |}
-          Name = ResourceName ""
-          Sku = DbSku Free
-          DbCollation = "SQL_Latin1_General_CP1_CI_AS"
-          Encryption = Disabled
+          ElasticPoolSku = PoolSku.Basic50
+          Databases = []
           FirewallRules = [] }
     member __.Run(state) =
         { state with
-            ServerName =
-                match state.ServerName with
-                | External name -> External(name |> Helpers.sanitiseDb |> ResourceName)
-                | AutomaticallyCreated name -> AutomaticallyCreated(name |> Helpers.sanitiseDb |> ResourceName)
-                | AutomaticPlaceholder -> failwith "You must specify a server name, or link to an existing server."
             Name = state.Name |> Helpers.sanitiseDb |> ResourceName
             AdministratorCredentials =
-                match state.ServerName with
-                | External _ -> state.AdministratorCredentials
-                | AutomaticallyCreated _
-                | AutomaticPlaceholder ->
-                    if System.String.IsNullOrWhiteSpace state.AdministratorCredentials.UserName then failwith "You must specify an admin_username."
-                    {| state.AdministratorCredentials with
-                        Password = SecureParameter (sprintf "password-for-%s" state.ServerName.ResourceName.Value) |} }
-    [<CustomOperation "server_name">]
+                if System.String.IsNullOrWhiteSpace state.AdministratorCredentials.UserName then failwith "You must specify an admin_username."
+                {| state.AdministratorCredentials with
+                    Password = SecureParameter (sprintf "password-for-%s" state.Name.Value) |} }
     /// Sets the name of the SQL server.
-    member __.ServerName(state:SqlAzureConfig, serverName) = { state with ServerName = AutomaticallyCreated serverName }
-    member this.ServerName(state:SqlAzureConfig, serverName:string) = this.ServerName(state, ResourceName serverName)
-    [<CustomOperation "link_to_server">]
-    /// Sets the name of the SQL server.
-    member __.LinkToServerName(state:SqlAzureConfig, serverName) = { state with ServerName = External serverName }
-    member this.LinkToServerName(state:SqlAzureConfig, serverName) = this.LinkToServerName(state, ResourceName serverName)
-    /// Sets the name of the database.
     [<CustomOperation "name">]
-    member __.Name(state:SqlAzureConfig, name) = { state with Name = name }
-    member this.Name(state:SqlAzureConfig, name:string) = this.Name(state, ResourceName name)
-    /// Sets the sku of the database.
-    [<CustomOperation "sku">]
-    member __.Sku(state:SqlAzureConfig, sku:DbSku) = { state with Sku = DbSku sku }
-    member __.Sku(state:SqlAzureConfig, sku:PoolSku) = { state with Sku = PoolSku sku }
-    /// Sets the collation of the database.
-    [<CustomOperation "collation">]
-    member __.Collation(state:SqlAzureConfig, collation:string) = { state with DbCollation = collation }
-    /// Enables encryption of the database.
-    [<CustomOperation "use_encryption">]
-    member __.Encryption(state:SqlAzureConfig) = { state with Encryption = Enabled }
-    /// Adds a custom firewall rule given a name, start and end IP address range.
+    member __.ServerName(state:SqlAzureConfig, serverName) = { state with Name = serverName }
+    member this.ServerName(state:SqlAzureConfig, serverName:string) = this.ServerName(state, ResourceName serverName)
+    /// Sets the sku of the server, to be shared on all databases that do not have an explicit sku set.
+    [<CustomOperation "elastic_pool_sku">]
+    member __.Sku(state:SqlAzureConfig, sku) = { state with ElasticPoolSku = sku }
+    [<CustomOperation "add_databases">]
+    member _.AddDatabases(state:SqlAzureConfig, databases) = { state with Databases = state.Databases @ databases }
     [<CustomOperation "add_firewall_rule">]
     member __.AddFirewallWall(state:SqlAzureConfig, name, startRange, endRange) =
         { state with
@@ -144,21 +128,14 @@ type SqlBuilder() =
             AdministratorCredentials =
                 {| state.AdministratorCredentials with
                     UserName = username |} }
-    [<CustomOperation "link_to_elastic_pool">]
-    member _.LinkToElasticPool(state:SqlAzureConfig) =
-        { state with
-            Sku =
-                match state.ServerName with
-                | External _ -> ExternalPool
-                | _ -> state.Sku
-        }
 
 open WebApp
 type WebAppBuilder with
     member this.DependsOn(state:WebAppConfig, sqlDb:SqlAzureConfig) =
-        this.DependsOn(state, sqlDb.ServerName.ResourceName)
+        this.DependsOn(state, sqlDb.Name)
 type FunctionsBuilder with
     member this.DependsOn(state:FunctionsConfig, sqlDb:SqlAzureConfig) =
-        this.DependsOn(state, sqlDb.ServerName.ResourceName)
+        this.DependsOn(state, sqlDb.Name)
 
-let sql = SqlBuilder()
+let sqlServer = SqlBuilder()
+let sqlDb = SqlDbBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -339,6 +339,8 @@ module Search =
         | StorageOptimisedL2
 
 module Sql =
+    [<Measure>]
+    type DTU
     type DbSku =
         | Free
         | Basic
@@ -501,6 +503,6 @@ module IotHub =
 
 module Maps =
     type Sku = S0 | S1
-    
+
 module SignalR =
     type Sku = Free | Standard


### PR DESCRIPTION
Closes #166. This replaces the current SQL builder model with one that is more flexible and can support elastic pools more readily:

```fsharp
open Farmer
open Farmer.Builders

let myDatabases = sqlServer {
    name "isaac_super_server"
    admin_username "admin_username"
    enable_azure_firewall
    add_databases [
        sqlDb { name "poolDb1" }
        sqlDb { name "poolDb2" }
        sqlDb { name "standaloneDb1"; sku Sql.DbSku.Basic }
    ]
}
```

* In the example above, the server contains 3 database. The first two, poolDb1 and poolDb2, will *automatically* be put into an elastic pool since they do not specify a SKU. standaloneDb1 will *not* be put into the pool, since it specifies a SKU.
* You can specify the elastic pool sku at the server level e.g. `elastic_pool_sku Sql.PoolSku.Basic100`.
* If all databases specify their own sku, no pool is created.
