### PR TITLE
Adding private vnet support for container instances

### DIFF
--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -3,63 +3,10 @@ open Farmer.Builders
 
 //TODO: Create resources here!
 
-//TODO: Testing out the user experience
-
-let privateNetwork = vnet {
-    name "private-vnet"
-    add_address_spaces [
-        "10.30.0.0/16"
-    ]
-    add_subnets [
-        subnet {
-            name "ContainerSubnet"
-            prefix "10.30.19.0/24"
-            add_delegations [
-                SubnetDelegationService.ContainerGroups
-            ]
-        }
-    ]
-}
-
-let aciProfile = networkProfile {
-    name "vnet-aci-profile"
-    vnet "private-vnet"
-    subnet "ContainerSubnet"
-    // Typically just one subnet is needed
-    // but instead they might want to add many, like this
-    (* add_interface_configs [
-        interface_config {
-            add_ipconfigs [
-                ip_config { subnet "ContainerSubnet" }
-            ]
-        }
-    ]*)
-}
-
-
-
-let myContainer = container {
-    name "container1"
-    image "microsoft/aci-helloworld"
-    network_profile "vnet-aci-profile"
-    ports [ 80us ]
-    // the old member (marked obsolete)
-    //ip_address (ContainerGroup.PrivateAddressWithIp (System.Net.IPAddress.Parse "10.30.19.4")) [TCP, 80us]
-    // prefer one of these
-    public_dns "my-container" [TCP, 80us]
-    private_ip [TCP, 80us]
-    private_static_ip "10.30.19.4" [TCP, 80us]
-}
-
 let deployment = arm {
-    location Location.WestUS
-    
+    location Location.NorthEurope
+
     //TODO: Assign resources here using the add_resource keyword
-    add_resources [
-        myContainer
-        aciProfile
-        privateNetwork
-    ]
 }
 
 // Generate the ARM template here...

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -40,18 +40,19 @@ let aciProfile = networkProfile {
 
 let myContainer = container {
     name "container1"
-    image "aci-hello-world"
+    image "microsoft/aci-helloworld"
     network_profile "vnet-aci-profile"
+    ports [ 80us ]
     // the old member (marked obsolete)
-    ip_address (ContainerGroup.PrivateAddressWithIp (System.Net.IPAddress.Parse "10.100.200.3")) [TCP, 80us]
+    //ip_address (ContainerGroup.PrivateAddressWithIp (System.Net.IPAddress.Parse "10.30.19.4")) [TCP, 80us]
     // prefer one of these
     public_dns "my-container" [TCP, 80us]
     private_ip [TCP, 80us]
-    private_static_ip "10.100.200.3" [TCP, 80us]
+    private_static_ip "10.30.19.4" [TCP, 80us]
 }
 
 let deployment = arm {
-    location Location.NorthEurope
+    location Location.WestUS
     
     //TODO: Assign resources here using the add_resource keyword
     add_resources [

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -5,24 +5,21 @@ open Farmer.Builders
 
 //TODO: Testing out the user experience
 
-(*
-// Question - would it make sense to add a separate builder for vnets?
 let privateNetwork = vnet {
     name "private-vnet"
-    address_spaces [
-        address_space { prefix "10.30.0.0/16" }
+    add_address_spaces [
+        "10.30.0.0/16"
     ]
-    subnets [
+    add_subnets [
         subnet {
             name "ContainerSubnet"
             prefix "10.30.19.0/24"
-            delegations [
-                delegation { serviceName "Microsoft.ContainerInstance/containerGroups" }
+            add_delegations [
+                "Microsoft.ContainerInstance/containerGroups"
             ]
         }
     ]
 }
-*)
 
 let aciProfile = networkProfile {
     name "vnet-aci-profile"
@@ -60,6 +57,7 @@ let deployment = arm {
     add_resources [
         myContainer
         aciProfile
+        privateNetwork
     ]
 }
 

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -43,6 +43,7 @@ let myContainer = container {
     name "container1"
     image "aci-hello-world"
     network_profile "vnet-aci-profile"
+    ip_address (ContainerGroup.PrivateAddressWithIp (System.Net.IPAddress.Parse "10.100.200.3")) []
 }
 
 let deployment = arm {

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -55,8 +55,12 @@ let myContainer = container {
 
 let deployment = arm {
     location Location.NorthEurope
-
+    
     //TODO: Assign resources here using the add_resource keyword
+    add_resources [
+        myContainer
+        aciProfile
+    ]
 }
 
 // Generate the ARM template here...

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -39,11 +39,18 @@ let aciProfile = networkProfile {
     ]*)
 }
 
+
+
 let myContainer = container {
     name "container1"
     image "aci-hello-world"
     network_profile "vnet-aci-profile"
-    ip_address (ContainerGroup.PrivateAddressWithIp (System.Net.IPAddress.Parse "10.100.200.3")) []
+    // the old member (marked obsolete)
+    ip_address (ContainerGroup.PrivateAddressWithIp (System.Net.IPAddress.Parse "10.100.200.3")) [TCP, 80us]
+    // prefer one of these
+    public_dns "my-container" [TCP, 80us]
+    private_ip [TCP, 80us]
+    private_static_ip "10.100.200.3" [TCP, 80us]
 }
 
 let deployment = arm {

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -3,6 +3,48 @@ open Farmer.Builders
 
 //TODO: Create resources here!
 
+//TODO: Testing out the user experience
+
+(*
+// Question - would it make sense to add a separate builder for vnets?
+let privateNetwork = vnet {
+    name "private-vnet"
+    address_spaces [
+        address_space { prefix "10.30.0.0/16" }
+    ]
+    subnets [
+        subnet {
+            name "ContainerSubnet"
+            prefix "10.30.19.0/24"
+            delegations [
+                delegation { serviceName "Microsoft.ContainerInstance/containerGroups" }
+            ]
+        }
+    ]
+}
+*)
+
+let aciProfile = networkProfile {
+    name "vnet-aci-profile"
+    vnet "private-vnet"
+    subnet "ContainerSubnet"
+    // Typically just one subnet is needed
+    // but instead they might want to add many, like this
+    (* add_interface_configs [
+        interface_config {
+            add_ipconfigs [
+                ip_config { subnet "ContainerSubnet" }
+            ]
+        }
+    ]*)
+}
+
+let myContainer = container {
+    name "container1"
+    image "aci-hello-world"
+    network_profile "vnet-aci-profile"
+}
+
 let deployment = arm {
     location Location.NorthEurope
 

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -15,7 +15,7 @@ let privateNetwork = vnet {
             name "ContainerSubnet"
             prefix "10.30.19.0/24"
             add_delegations [
-                "Microsoft.ContainerInstance/containerGroups"
+                SubnetDelegationService.ContainerGroups
             ]
         }
     ]

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -33,6 +33,10 @@ type ContainerGroup =
                apiVersion = "2018-10-01"
                name = this.Name.Value
                location = this.Location.ArmValue
+               dependsOn =
+                   match this.NetworkProfile with
+                   | None -> []
+                   | Some networkProfile -> [ networkProfile.Value ]
                properties =
                    {| containers =
                        this.ContainerInstances
@@ -61,5 +65,6 @@ type ContainerGroup =
                                    Port = port.Port |}
                            ]
                         |}
+                      networkProfile = this.NetworkProfile |> Option.map (fun networkProfile -> {| id = sprintf "[resourceId('Microsoft.Network/networkProfiles','%s')]" networkProfile.Value |})
                    |}
             |} :> _

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -23,7 +23,8 @@ type ContainerGroup =
            Memory : float<Gb> |} list
       OsType : string
       RestartPolicy : RestartPolicy
-      IpAddress : ContainerGroupIpAddress }
+      IpAddress : ContainerGroupIpAddress
+      NetworkProfile : ResourceName option }
 
     interface IArmResource with
         member this.ResourceName = this.Name

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -55,15 +55,23 @@ type ContainerGroup =
                       osType = this.OsType
                       restartPolicy = this.RestartPolicy.ToString().ToLower()
                       ipAddress =
-                        {| Type =
+                        {| ``type`` =
                             match this.IpAddress.Type with
-                            | PublicAddress -> "Public"
-                            | PrivateAddress -> "Private"
-                           Ports = [
+                            | PublicAddress | PublicAddressWithDns _ -> "Public"
+                            | PrivateAddress _ | PrivateAddressWithIp _ -> "Private"
+                           ports = [
                                for port in this.IpAddress.Ports do
                                 {| Protocol = string port.Protocol
                                    Port = port.Port |}
                            ]
+                           ip = 
+                            match this.IpAddress.Type with
+                            | PrivateAddressWithIp ip -> Some ip
+                            | _ -> None
+                           dnsNameLabel =
+                            match this.IpAddress.Type with
+                            | PublicAddressWithDns dnsLabel -> Some dnsLabel
+                            | _ -> None
                         |}
                       networkProfile = this.NetworkProfile |> Option.map (fun networkProfile -> {| id = sprintf "[resourceId('Microsoft.Network/networkProfiles','%s')]" networkProfile.Value |})
                    |}

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -29,7 +29,7 @@ type VirtualNetwork =
     { Name : ResourceName
       Location : Location
       AddressSpacePrefixes : string list
-      Subnets : {| Name : ResourceName; Prefix : string |} list }
+      Subnets : {| Name : ResourceName; Prefix : string; Delegations: {| Name: ResourceName; ServiceName: string |} list |} list; }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -43,7 +43,14 @@ type VirtualNetwork =
                         this.Subnets
                         |> List.map(fun subnet ->
                            {| name = subnet.Name.Value
-                              properties = {| addressPrefix = subnet.Prefix |}
+                              properties =
+                                  {| addressPrefix = subnet.Prefix
+                                     delegations = subnet.Delegations
+                                     |> List.map (fun delegation ->
+                                         {| name = delegation.Name.Value
+                                            properties = {| serviceName = delegation.ServiceName |}
+                                         |})
+                                  |}
                            |})
                     |}
             |} :> _

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -138,7 +138,6 @@ type ExpressRouteCircuit =
            SharedKey : string option
            VlanId : int
         |} list }
-    static member FormatCidr address prefix = sprintf "%O/%d" address prefix
 
     interface IArmResource with
         member this.ResourceName = this.Name
@@ -159,8 +158,8 @@ type ExpressRouteCircuit =
                                    {| peeringType = peer.PeeringType.Value
                                       azureASN = peer.AzureASN
                                       peerASN = peer.PeerASN
-                                      primaryPeerAddressPrefix = ExpressRouteCircuit.FormatCidr peer.PrimaryPeerAddressPrefix.Address peer.PrimaryPeerAddressPrefix.Prefix
-                                      secondaryPeerAddressPrefix = ExpressRouteCircuit.FormatCidr peer.SecondaryPeerAddressPrefix.Address peer.SecondaryPeerAddressPrefix.Prefix
+                                      primaryPeerAddressPrefix = IPAddressCidr.format peer.PrimaryPeerAddressPrefix
+                                      secondaryPeerAddressPrefix = IPAddressCidr.format peer.SecondaryPeerAddressPrefix
                                       vlanId = peer.VlanId
                                       sharedKey = peer.SharedKey |}
                             |}

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -101,7 +101,7 @@ type NetworkProfile =
                apiVersion = "2020-04-01"
                name = this.Name.Value
                location = this.Location.ArmValue
-               dependsOn = [ this.VirtualNetwork.Value ]
+               dependsOn = [ sprintf "[resourceId('Microsoft.Network/virtualNetworks','%s')]" this.VirtualNetwork.Value ]
                properties =
                    {| containerNetworkInterfaceConfigurations =
                        this.ContainerNetworkInterfaceConfigurations

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -172,7 +172,7 @@ type NetworkProfileBuilder() =
     member __.SubnetName(state:NetworkProfileConfig, subnet) = { state with ContainerNetworkInterfaceConfigurations = [ { IpConfigs = [ { Subnet = subnet } ] } ] }
     /// Sets a single target subnet for the network profile (typical case of single subnet)
     [<CustomOperation "add_ip_configs">]
-    member __.AddIpConfigs(state:NetworkProfileConfig, configs) = { state with ContainerNetworkInterfaceConfigurations = configs }
+    member __.AddIpConfigs(state:NetworkProfileConfig, configs) = { state with ContainerNetworkInterfaceConfigurations = state.ContainerNetworkInterfaceConfigurations @ configs }
     /// Sets the virtual network for the profile
     [<CustomOperation "vnet">]
     member __.VirtualNetwork(state:NetworkProfileConfig, vnet) = { state with VirtualNetwork = ResourceName vnet }

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -109,8 +109,18 @@ type ContainerBuilder() =
     [<CustomOperation "restart_policy">]
     member __.RestartPolicy(state:ContainerConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
     /// Sets the IP addresss (default Public)
+    [<System.Obsolete("Prefer to use public_dns, private_ip, or private_static_ip")>]
     [<CustomOperation "ip_address">]
     member __.IpAddress(state:ContainerConfig, addressType, ports) = { state with IpAddress = { Type = addressType; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    /// Sets the IP addresss (default Public)
+    [<CustomOperation "public_dns">]
+    member __.PublicDns(state:ContainerConfig, dnsLabel:string, ports) = { state with IpAddress = { Type = PublicAddressWithDns dnsLabel; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    /// Sets the IP addresss (default Public)
+    [<CustomOperation "private_ip">]
+    member __.PrivateIp(state:ContainerConfig, ports) = { state with IpAddress = { Type = PrivateAddressWithIp (System.Net.IPAddress.Parse ip); Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    /// Sets the IP addresss (default Public)
+    [<CustomOperation "private_static_ip">]
+    member __.PrivateStaticIp(state:ContainerConfig, ip:string, ports) = { state with IpAddress = { Type = PrivateAddress; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
     /// Sets a network profile for the container's group.
     [<CustomOperation "network_profile">]
     member __.NetworkPolicy(state:ContainerConfig, networkProfileName:string) = { state with NetworkProfile = Some (ResourceName networkProfileName) }

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -112,15 +112,15 @@ type ContainerBuilder() =
     [<System.Obsolete("Prefer to use public_dns, private_ip, or private_static_ip")>]
     [<CustomOperation "ip_address">]
     member __.IpAddress(state:ContainerConfig, addressType, ports) = { state with IpAddress = { Type = addressType; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
-    /// Sets the IP addresss (default Public)
+    /// Sets the IP addresss to a public address with a DNS label
     [<CustomOperation "public_dns">]
     member __.PublicDns(state:ContainerConfig, dnsLabel:string, ports) = { state with IpAddress = { Type = PublicAddressWithDns dnsLabel; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
-    /// Sets the IP addresss (default Public)
-    [<CustomOperation "private_ip">]
-    member __.PrivateIp(state:ContainerConfig, ports) = { state with IpAddress = { Type = PrivateAddressWithIp (System.Net.IPAddress.Parse ip); Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
-    /// Sets the IP addresss (default Public)
+    /// Sets the IP addresss to a private address that is statically assigned
     [<CustomOperation "private_static_ip">]
-    member __.PrivateStaticIp(state:ContainerConfig, ip:string, ports) = { state with IpAddress = { Type = PrivateAddress; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    member __.PrivateStaticIp(state:ContainerConfig, ip:string, ports) = { state with IpAddress = { Type = PrivateAddressWithIp (System.Net.IPAddress.Parse ip); Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    /// Sets the IP addresss to a private address assigned by the vnet
+    [<CustomOperation "private_ip">]
+    member __.PrivateIp(state:ContainerConfig, ports) = { state with IpAddress = { Type = PrivateAddress; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
     /// Sets a network profile for the container's group.
     [<CustomOperation "network_profile">]
     member __.NetworkPolicy(state:ContainerConfig, networkProfileName:string) = { state with NetworkProfile = Some (ResourceName networkProfileName) }

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -4,25 +4,10 @@ module Farmer.Builders.ExpressRoute
 open Farmer
 open Farmer.CoreTypes
 open Farmer.ExpressRoute
-open System
 open System.Net
 open Farmer.Arm.Network
 
 /// An IP address block in CIDR notation, such as 10.100.0.0/16.
-type internal IPAddressCidr =
-    {| Address : IPAddress
-       Prefix : int |}
-
-module IPAddressCidr =
-    let parse (s:string) : IPAddressCidr =
-        match s.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries) with
-        [| ip; prefix |] ->
-            {| Address = IPAddress.Parse (ip.Trim ())
-               Prefix = int prefix |}
-        | _ -> raise (ArgumentOutOfRangeException "Malformed CIDR, expecting and IP and prefix separated by '/'")
-    let safeParse (s:string) : Result<IPAddressCidr, Exception> =
-        try parse s |> Ok
-        with ex -> Error ex
 type ExpressRouteCircuitPeering =
     { PeeringType : PeeringType
       AzureASN : int

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -1,0 +1,82 @@
+[<AutoOpen>]
+module Farmer.Builders.VirtualNetwork
+
+open Farmer
+open Farmer.CoreTypes
+open Farmer.Arm.Network
+
+type SubnetDelegationService =
+    /// Microsoft.ApiManagement/service
+    static member ApiManagementService = "Microsoft.ApiManagement/service"
+    /// Microsoft.AzureCosmosDB/clusters
+    static member CosmosDBClusters = "Microsoft.AzureCosmosDB/clusters"
+    /// Microsoft.BareMetal/AzureVMware
+    static member BareMetalVMware = "Microsoft.BareMetal/AzureVMware"
+    /// Microsoft.BareMetal/CrayServers
+    static member BareMetalCrayServers = "Microsoft.BareMetal/CrayServers"
+    /// Microsoft.Batch/batchAccounts
+    static member BatchAccounts = "Microsoft.Batch/batchAccounts"
+    /// Microsoft.ContainerInstance/containerGroups
+    static member ContainerGroups = "Microsoft.ContainerInstance/containerGroups"
+    /// Microsoft.Databricks/workspaces
+    static member DatabricksWorkspaces = "Microsoft.Databricks/workspaces"
+    /// Microsoft.MachineLearningServices/workspaces
+    static member MachineLearningWorkspaces = "Microsoft.MachineLearningServices/workspaces"
+    /// Microsoft.Netapp/volumes
+    static member NetappVolumes = "Microsoft.Netapp/volumes"
+    /// Microsoft.ServiceFabricMesh/networks
+    static member ServiceFabricMeshNetworks = "Microsoft.ServiceFabricMesh/networks"
+    /// Microsoft.Sql/managedInstances
+    static member SqlManagedInstances = "Microsoft.Sql/managedInstances"
+
+type SubnetConfig =
+    { Name: ResourceName
+      Prefix: IPAddressCidr
+      Delegations: string list }
+
+type SubnetBuilder() =
+    member __.Yield _ = { Name = ResourceName.Empty; Prefix = {| Address = System.Net.IPAddress.Parse("10.100.0.0"); Prefix = 16 |}; Delegations = [] }
+    /// Sets the name of the subnet
+    [<CustomOperation "name">]
+    member __.Name(state:SubnetConfig, name) = { state with Name = ResourceName name }
+    /// Sets the network prefix in CIDR notation
+    [<CustomOperation "prefix">]
+    member __.Prefix(state:SubnetConfig, prefix) = { state with Prefix = IPAddressCidr.parse prefix }
+    /// Sets the network prefix in CIDR notation
+    [<CustomOperation "add_delegations">]
+    member __.AddDelegations(state:SubnetConfig, delegations) = { state with Delegations = state.Delegations @ delegations }
+    
+let subnet = SubnetBuilder ()
+    
+type VirtualNetworkConfig =
+    { Name : ResourceName
+      AddressSpacePrefixes : string list
+      Subnets : SubnetConfig list; }
+    interface IBuilder with
+        member this.DependencyName = this.Name
+        member this.BuildResources location _ = [
+            { Name = this.Name
+              Location = location
+              AddressSpacePrefixes = this.AddressSpacePrefixes
+              Subnets = this.Subnets |> List.map (fun subnetConfig ->
+                  {| Name = subnetConfig.Name
+                     Prefix = (sprintf "%O/%d" subnetConfig.Prefix.Address subnetConfig.Prefix.Prefix)
+                     Delegations = subnetConfig.Delegations |> List.map (fun delegation ->
+                         {| Name = ResourceName delegation; ServiceName = delegation |})
+                  |})
+            }
+        ]
+
+type VirtualNetworkBuilder() =
+    member __.Yield _ = { Name = ResourceName.Empty; AddressSpacePrefixes = []; Subnets = [] }
+    /// Sets the name of the virtual network
+    [<CustomOperation "name">]
+    member __.Name(state:VirtualNetworkConfig, name) = { state with Name = ResourceName name }
+    /// Adds address spaces prefixes
+    [<CustomOperation "add_address_spaces">]
+    member __.AddAddressSpaces(state:VirtualNetworkConfig, prefixes) = { state with AddressSpacePrefixes = state.AddressSpacePrefixes @ prefixes }
+    /// Adds subnets
+    [<CustomOperation "add_subnets">]
+    member __.AddSubnets(state:VirtualNetworkConfig, subnets) = { state with Subnets = state.Subnets @ subnets }
+
+let vnet = VirtualNetworkBuilder ()

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -4,6 +4,7 @@ module Farmer.Builders.VirtualNetwork
 open Farmer
 open Farmer.CoreTypes
 open Farmer.Arm.Network
+open Helpers
 
 type SubnetDelegationService =
     /// Microsoft.ApiManagement/service
@@ -60,7 +61,7 @@ type VirtualNetworkConfig =
               AddressSpacePrefixes = this.AddressSpacePrefixes
               Subnets = this.Subnets |> List.map (fun subnetConfig ->
                   {| Name = subnetConfig.Name
-                     Prefix = (sprintf "%O/%d" subnetConfig.Prefix.Address subnetConfig.Prefix.Prefix)
+                     Prefix = IPAddressCidr.format subnetConfig.Prefix
                      Delegations = subnetConfig.Delegations |> List.map (fun delegation ->
                          {| Name = ResourceName delegation; ServiceName = delegation |})
                   |})

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -85,7 +85,8 @@ type VmConfig =
                   AddressSpacePrefixes = [ this.AddressPrefix ]
                   Subnets = [
                       {| Name = subnetName
-                         Prefix = this.SubnetPrefix |}
+                         Prefix = this.SubnetPrefix
+                         Delegations = [] |}
                   ]
                 }
             | External _ ->

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -510,3 +510,19 @@ module Maps =
 
 module SignalR =
     type Sku = Free | Standard
+  
+type internal IPAddressCidr =
+    {| Address : System.Net.IPAddress
+       Prefix : int |}
+
+module IPAddressCidr =
+    let parse (s:string) : IPAddressCidr =
+        match s.Split([|'/'|], System.StringSplitOptions.RemoveEmptyEntries) with
+        [| ip; prefix |] ->
+            {| Address = System.Net.IPAddress.Parse (ip.Trim ())
+               Prefix = int prefix |}
+        | _ -> raise (System.ArgumentOutOfRangeException "Malformed CIDR, expecting and IP and prefix separated by '/'")
+    let safeParse (s:string) : Result<IPAddressCidr, System.Exception> =
+        try parse s |> Ok
+        with ex -> Error ex
+    let format (cidr:IPAddressCidr) = sprintf "%O/%d" cidr.Address cidr.Prefix

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -425,7 +425,11 @@ module Sql =
 
 module ContainerGroup =
     type RestartPolicy = Never | Always | OnFailure
-    type IpAddressType = PublicAddress | PrivateAddress
+    type IpAddressType =
+        | PublicAddress
+        | PublicAddressWithDns of DnsName:string
+        | PrivateAddress
+        | PrivateAddressWithIp of System.Net.IPAddress
 
 module Redis =
     type Sku = Basic | Standard | Premium

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -92,5 +92,6 @@
     <Compile Include="Builders/Builders.IotHub.fs" />
     <Compile Include="Builders/Builders.Maps.fs" />
     <Compile Include="Builders/Builders.SignalR.fs" />
+    <Compile Include="Builders\Builders.VirtualNetwork.fs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Adds network profile resource for specifying a container subnet IP configuration
* Adds service delegations to vnet subnets to allow delegation to `Microsoft.ContainerInstance/containerGroups`
* Adds optional container group dependency for network profile that indicates which subnet in a vnet to attach the container group