### PR TITLE
Support for raw JSON elements.

### DIFF
--- a/src/Farmer/ArmBuilder.fs
+++ b/src/Farmer/ArmBuilder.fs
@@ -4,18 +4,23 @@ module Farmer.ArmBuilder
 open Farmer.CoreTypes
 open Farmer
 
-module Helpers =
+module Resource =
     /// Creates a unique IArmResource from an arbitrary object.
-    let toArmResource armObject =
+    let ofObj armObject =
         { new IArmResource with
              member _.ResourceName = ResourceName (System.Guid.NewGuid().ToString())
              member _.JsonModel = armObject }
 
     /// Creates a unique IArmResource from a JSON string containing the output you want.
-    let toArmResourceRaw = Newtonsoft.Json.Linq.JObject.Parse >> toArmResource
+    let ofJson json = json |> Newtonsoft.Json.Linq.JObject.Parse |> ofObj
 
-    /// Creates a Builder that can be added to arm { } expressions.
-    let asBuilder quickBuilder =
+module Json =
+    /// Creates a unique IArmResource from a JSON string containing the output you want.
+    let toIArmResource = Resource.ofJson
+
+module Builder =
+    /// Quickly creates a Builder that can be added to arm { } expressions.
+    let fromFunction quickBuilder =
         let output : Builder = fun location _ -> quickBuilder location
         output
 

--- a/src/Farmer/ArmBuilder.fs
+++ b/src/Farmer/ArmBuilder.fs
@@ -11,8 +11,11 @@ module Helpers =
              member _.ResourceName = ResourceName (System.Guid.NewGuid().ToString())
              member _.JsonModel = armObject }
 
+    /// Creates a unique IArmResource from a JSON string containing the output you want.
+    let toArmResourceRaw = Newtonsoft.Json.Linq.JObject.Parse >> toArmResource
+
     /// Creates a Builder that can be added to arm { } expressions.
-    let asBuilder quickBuilder  =
+    let asBuilder quickBuilder =
         let output : Builder = fun location _ -> quickBuilder location
         output
 

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -15,7 +15,7 @@ type JavaRuntime =
     | Java8 | Java11
     member this.Version = match this with Java8 -> 8 | Java11 -> 11
     member this.Jre = match this with Java8 -> "jre8" | Java11 -> "java11"
-type WebAppRuntime =
+type Runtime =
     | DotNetCore of string
     | Node of string
     | Php of string
@@ -80,7 +80,7 @@ type WebAppConfig =
       RunFromPackage : bool
       WebsiteNodeDefaultVersion : string option
       AlwaysOn : bool
-      Runtime : WebAppRuntime
+      Runtime : Runtime
       ZipDeployPath : string option
       DockerImage : (string * string) option
       DockerCi : bool
@@ -268,7 +268,7 @@ type WebAppBuilder() =
           WebSocketsEnabled = None
           Settings = Map.empty
           Dependencies = []
-          Runtime = WebAppRuntime.DotNetCoreLts
+          Runtime = Runtime.DotNetCoreLts
           OperatingSystem = Windows
           ZipDeployPath = None
           DockerImage = None

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -19,7 +19,7 @@ module Az =
     open System.Runtime.InteropServices
     open System.Text
 
-    let MinimumVersion = Version "2.3.1"
+    let MinimumVersion = Version "2.5.0"
 
     [<AutoOpen>]
     module AzHelpers =
@@ -94,7 +94,7 @@ module Az =
             match parameters with
             | [] -> ""
             | parameters -> sprintf "--parameters %s" (parameters |> List.map(fun (a,b) -> sprintf "%s=%s" a b) |> String.concat " ")
-        let cmd = sprintf """deployment group %s -g %s -n %s --template-file %s %s""" deploymentCommand.Description resourceGroup deploymentName templateFilename parametersArgument
+        let cmd = sprintf """deployment group '%s' -g %s -n %s --template-file %s %s""" deploymentCommand.Description resourceGroup deploymentName templateFilename parametersArgument
         az cmd
     /// Deploys an ARM template to an existing resource group.
     let deploy resourceGroup deploymentName templateFilename parameters = deployOrValidate Create resourceGroup deploymentName templateFilename parameters

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -94,7 +94,7 @@ module Az =
             match parameters with
             | [] -> ""
             | parameters -> sprintf "--parameters %s" (parameters |> List.map(fun (a,b) -> sprintf "%s=%s" a b) |> String.concat " ")
-        let cmd = sprintf """deployment group '%s' -g %s -n %s --template-file %s %s""" deploymentCommand.Description resourceGroup deploymentName templateFilename parametersArgument
+        let cmd = sprintf """deployment group %s -g %s -n %s --template-file %s %s""" deploymentCommand.Description resourceGroup deploymentName templateFilename parametersArgument
         az cmd
     /// Deploys an ARM template to an existing resource group.
     let deploy resourceGroup deploymentName templateFilename parameters = deployOrValidate Create resourceGroup deploymentName templateFilename parameters


### PR DESCRIPTION
This PR allows you to work directly with raw JSON in Farmer. This is a useful way to migrate step-by-step from raw ARM resources into Farmer.

Here's an example of adding Data Lake support using a raw JSON string directly into the Farmer pipeline:

```fsharp
let myCogs = cognitiveServices { name "myCogs" }

let dataLake name =
    sprintf """{
            "name": "%s",
            "type": "Microsoft.DataLakeStore/accounts",
            "apiVersion": "2016-11-01",
            "location": "[resourceGroup().location]",
            "properties": {
                "newTier": "Consumption",
                "encryptionState": "Enabled"
            }
        }""" name
    |> Resource.ofJson

let deployment = arm {
    location Location.NorthEurope
    add_resource myCogs
    add_resource (dataLake "yourDataLake")
}

deployment |> Writer.quickWrite "output"
```

This could also prove to be a useful first step for authors adding new resources to Farmer! The code change was relatively simple to do.