### PR TITLE
Support for managed identity on web apps and integration with key vault.

### DIFF
--- a/docs/content/api-overview/resources/keyvault.md
+++ b/docs/content/api-overview/resources/keyvault.md
@@ -58,13 +58,14 @@ The Key Vault builder contains access policies, secrets, and configuration infor
 | enable_recovery_mode | Sets the Creation Mode to Recovery. |
 | disable_recovery_mode | Sets the Creation Mode to Default. |
 | add_access_policy | Adds an access policy to the vault. |
+| add_reader_policy | Adds a simple policy for a principal that allows read-only access to secrets. |
 | enable_azure_services_bypass | Allows Azure traffic can bypass network rules. |
 | disable_azure_services_bypass | Disallows Azure traffic can bypass network rules. |
 | allow_default_traffic | Allow traffic if no rule from ipRules and virtualNetworkRules match. This is only used after the bypass property has been evaluated. |
 | deny_default_traffic | Deny traffic when no rule from ipRules and virtualNetworkRules match. This is only used after the bypass property has been evaluated. |
 | add_ip_rule | Adds an IP address rule. This can be an IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78). |
 | add_vnet_rule | Adds a virtual network rule. This is the full resource id of a vnet subnet, such as '/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'. |
-| add_secret | Adds a secret to the vault. This can either be a "full" secret config created using the Secret Builder or a string literal value which represents the parameter name. |
+| add_secret | Adds a secret to the vault. This can either be a "full" secret config created using the Secret Builder, a string literal value which represents the parameter name, or a string literal with a resource and an expression based on that resource e.g. a storage account and the Key member. |
 
 #### Example
 

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -34,6 +34,8 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | docker_image | Sets the docker image to be pulled down from Docker Hub, and the command to execute as a second argument. Automatically sets the OS to Linux. |
 | Web App | docker_ci | Turns on continuous integration of the web app from the Docker source repository using a webhook.
 | Web App | docker_use_azure_registry | Uses the supplied Azure Container Registry name as the source of the Docker image, instead of Docker Hub. You do not need to specify the full url, but just the name of the registry itself.
+| Web App | enable_managed_identity | Creates a system-assigned identity for the web app. |
+| Web App | disable_managed_identity | Deletes the system-assigned identity for the web app. |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | always_on | Sets "Always On" flag. |
 | Service Plan | runtime_stack | Sets the runtime stack. |
@@ -60,6 +62,7 @@ The Web App builder contains special commands that are executed *after* the ARM 
 | PublishingPassword | Gets the ARM expression path to the publishing password of this web app. |
 | ServicePlan | Gets the Resource Name of the service plan for this web app. |
 | AppInsights | Gets the Resource Name of the service plan for the AI resource linked to this web app. |
+| SystemIdentity | Gets the system-created managed principal for the web app. It must have been enabled using enable_managed_identity. |
 
 #### Example
 

--- a/samples/scripts/keyvault.fsx
+++ b/samples/scripts/keyvault.fsx
@@ -10,7 +10,6 @@ let vault =
     let policy =
         accessPolicy {
             object_id Guid.Empty
-            application_id Guid.Empty
             certificate_permissions [ Certificate.List ]
             secret_permissions Secret.All
             key_permissions [ Key.List ]
@@ -24,10 +23,12 @@ let vault =
         expiration_date (DateTime.Today.AddDays 1.)
     }
 
+    let store = storageAccount { name "foo" }
+
     keyVault {
         name "MyVault"
         sku KeyVaultSku.Standard
-        tenant_id Guid.Empty
+        tenant_id Subscription.TenantId
 
         enable_disk_encryption_access
         enable_resource_manager_access
@@ -38,12 +39,11 @@ let vault =
         add_access_policy policy
         enable_azure_services_bypass
 
-        add_ip_rule "127.0.0.1"
-        add_vnet_rule "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1"
         allow_default_traffic
 
         add_secret complexSecret
         add_secret "simpleSecret"
+        add_secret ("thirdSecret", store, store.Key)
     }
 
 let deployment = arm {

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -57,7 +57,7 @@ type Vault =
       SoftDelete : SoftDeletionMode option
       CreateMode : CreateMode option
       AccessPolicies :
-        {| ObjectId : Guid
+        {| ObjectId : ArmExpression
            ApplicationId : Guid option
            Permissions :
             {| Keys : Key Set
@@ -102,7 +102,7 @@ type Vault =
                     vaultUri = this.Uri |> Option.map string |> Option.toObj
                     accessPolicies =
                          [| for policy in this.AccessPolicies do
-                             {| objectId = string policy.ObjectId
+                             {| objectId = ArmExpression.Eval policy.ObjectId
                                 tenantId = this.TenantId
                                 applicationId = policy.ApplicationId |> Option.map string |> Option.toObj
                                 permissions =

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -114,7 +114,7 @@ type Sites =
       WebSocketsEnabled : bool option
       Dependencies : ResourceName list
       Kind : string
-      Identity : bool
+      Identity : FeatureFlag option
       LinuxFxVersion : string option
       AppCommandLine : string option
       NetFrameworkVersion : string option
@@ -150,8 +150,10 @@ type Sites =
                dependsOn = this.Dependencies |> List.map(fun p -> p.Value)
                kind = this.Kind
                identity =
-                 if this.Identity then box {| ``type`` = "SystemAssigned" |}
-                 else null
+                 match this.Identity with
+                 | Some Enabled -> box {| ``type`` = "SystemAssigned" |}
+                 | Some Disabled -> box {| ``type`` = "None" |}
+                 | None -> null
                properties =
                    {| serverFarmId = this.ServicePlan.Value
                       httpsOnly = this.HTTPSOnly

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -114,6 +114,7 @@ type Sites =
       WebSocketsEnabled : bool option
       Dependencies : ResourceName list
       Kind : string
+      Identity : bool
       LinuxFxVersion : string option
       AppCommandLine : string option
       NetFrameworkVersion : string option
@@ -148,6 +149,9 @@ type Sites =
                location = this.Location.ArmValue
                dependsOn = this.Dependencies |> List.map(fun p -> p.Value)
                kind = this.Kind
+               identity =
+                 if this.Identity then box {| ``type`` = "SystemAssigned" |}
+                 else null
                properties =
                    {| serverFarmId = this.ServicePlan.Value
                       httpsOnly = this.HTTPSOnly

--- a/src/Farmer/ArmBuilder.fs
+++ b/src/Farmer/ArmBuilder.fs
@@ -18,6 +18,10 @@ module Json =
     /// Creates a unique IArmResource from a JSON string containing the output you want.
     let toIArmResource = Resource.ofJson
 
+module Subscription =
+    /// Gets an ARM expression pointing to the tenant id of the current subscription.
+    let TenantId = ArmExpression "subscription().tenantid"
+
 module Builder =
     /// Quickly creates a Builder that can be added to arm { } expressions.
     let fromFunction quickBuilder =

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -73,6 +73,7 @@ type FunctionsConfig =
                     "WEBSITE_CONTENTSHARE", this.Name.Value.ToLower()
               ]
 
+              Identity = false
               Kind =
                 match this.OperatingSystem with
                 | Windows -> "functionapp"

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -73,7 +73,7 @@ type FunctionsConfig =
                     "WEBSITE_CONTENTSHARE", this.Name.Value.ToLower()
               ]
 
-              Identity = false
+              Identity = None
               Kind =
                 match this.OperatingSystem with
                 | Windows -> "functionapp"

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -10,7 +10,7 @@ open Vaults
 
 type NonEmptyList<'T> = 'T * 'T List
 type AccessPolicy =
-    { ObjectId : Guid
+    { ObjectId : ArmExpression
       ApplicationId : Guid option
       Permissions :
         {| Keys : Key Set
@@ -49,7 +49,18 @@ type SecretConfig =
       ActivationDate : DateTime option
       ExpirationDate : DateTime option
       Dependencies : ResourceName list }
-    static member Create key =
+    static member Create (key:string) =
+        let charRulesPassed =
+            let charRules = [ Char.IsLetterOrDigit; (=) '-' ]
+            key |> Seq.forall(fun c -> charRules |> Seq.exists(fun r -> r c))
+        let stringRulesPassed =
+            [ (fun l -> String.length l <= 127)
+              String.IsNullOrWhiteSpace >> not ]
+            |> Seq.forall(fun r -> r key)
+
+        if not (charRulesPassed && stringRulesPassed) then
+            failwith "Key Vault key names must be a 1-127 character string, starting with a letter and containing only 0-9, a-z, A-Z, and -."
+
         { Key = key
           Value = ParameterSecret(SecureParameter key)
           ContentType = None
@@ -64,7 +75,7 @@ type SecretConfig =
 
 type KeyVaultConfig =
     { Name : ResourceName
-      TenantId : Guid
+      TenantId : ArmExpression
       Access : KeyVaultSettings
       Sku : KeyVaultSku
       Policies : CreateMode
@@ -77,7 +88,7 @@ type KeyVaultConfig =
             let keyVault =
                 { Name = this.Name
                   Location = location
-                  TenantId = this.TenantId.ToString()
+                  TenantId = this.TenantId |> ArmExpression.Eval
                   Sku = this.Sku.ToString().ToLower()
 
                   TemplateDeployment = this.Access.ResourceManagerAccess
@@ -125,13 +136,14 @@ type KeyVaultConfig =
 
 type AccessPolicyBuilder() =
     member __.Yield _ =
-        { ObjectId = Guid.Empty
+        { ObjectId = ArmExpression (string Guid.Empty)
           ApplicationId = None
           Permissions = {| Keys = Set.empty; Secrets = Set.empty; Certificates = Set.empty; Storage = Set.empty |} }
     /// Sets the Object ID of the permission set.
     [<CustomOperation "object_id">]
     member __.ObjectId(state:AccessPolicy, objectId) = { state with ObjectId = objectId }
-    member __.ObjectId(state:AccessPolicy, objectId) = { state with ObjectId = Guid.Parse objectId }
+    member this.ObjectId(state:AccessPolicy, objectId:Guid) = this.ObjectId(state, ArmExpression (sprintf "string('%O')" objectId))
+    member this.ObjectId(state:AccessPolicy, objectId) = this.ObjectId(state, Guid.Parse objectId)
     /// Sets the Application ID of the permission set.
     [<CustomOperation "application_id">]
     member __.ApplicationId(state:AccessPolicy, applicationId) = { state with ApplicationId = Some applicationId }
@@ -148,13 +160,15 @@ type AccessPolicyBuilder() =
     [<CustomOperation "certificate_permissions">]
     member __.SetCertificatePermissions(state:AccessPolicy, permissions) = { state with Permissions = {| state.Permissions with Certificates = set permissions |} }
 
+let accessPolicy = AccessPolicyBuilder()
+
 [<RequireQualifiedAccess>]
 type SimpleCreateMode = Recover | Default
 type KeyVaultBuilderState =
     { Name : ResourceName
       Access : KeyVaultSettings
       Sku : KeyVaultSku
-      TenantId : Guid
+      TenantId : ArmExpression
       NetworkAcl : NetworkAcl
       CreateMode : SimpleCreateMode option
       Policies : AccessPolicy list
@@ -164,8 +178,8 @@ type KeyVaultBuilderState =
 type KeyVaultBuilder() =
     member __.Yield (_:unit) =
         { Name = ResourceName.Empty
-          TenantId = Guid.Empty
-          Access = { VirtualMachineAccess = None; ResourceManagerAccess = None; AzureDiskEncryptionAccess = None; SoftDelete = None }
+          TenantId = Subscription.TenantId
+          Access = { VirtualMachineAccess = None; ResourceManagerAccess = Some Enabled; AzureDiskEncryptionAccess = None; SoftDelete = None }
           Sku = KeyVaultSku.Standard
           NetworkAcl = { IpRules = []; VnetRules = []; Bypass = None; DefaultAction = None }
           Policies = []
@@ -197,14 +211,15 @@ type KeyVaultBuilder() =
     /// Sets the Tenant ID of the vault.
     [<CustomOperation "tenant_id">]
     member __.SetTenantId(state:KeyVaultBuilderState, tenantId) = { state with TenantId = tenantId }
-    member __.SetTenantId(state:KeyVaultBuilderState, tenantId) = { state with TenantId = Guid.Parse tenantId }
+    member this.SetTenantId(state:KeyVaultBuilderState, tenantId) = this.SetTenantId(state, ArmExpression (sprintf "string('%O')" tenantId))
+    member this.SetTenantId(state:KeyVaultBuilderState, tenantId) = this.SetTenantId(state, Guid.Parse tenantId)
     /// Allows VM access to the vault.
     [<CustomOperation "enable_vm_access">]
     member __.EnableVmAccess(state:KeyVaultBuilderState) = { state with Access = { state.Access with VirtualMachineAccess = Some Enabled } }
     /// Disallows VM access to the vault.
     [<CustomOperation "disable_vm_access">]
     member __.DisableVmAccess(state:KeyVaultBuilderState) = { state with Access = { state.Access with VirtualMachineAccess = Some Disabled } }
-    /// Allows Resource Manager access to the vault.
+    /// Allows Resource Manager access to the vault so that you can deploy secrets during ARM deployments.
     [<CustomOperation "enable_resource_manager_access">]
     member __.EnableResourceManagerAccess(state:KeyVaultBuilderState) = { state with Access = { state.Access with ResourceManagerAccess = Some Enabled } }
     /// Disallows Resource Manager access to the vault.
@@ -234,6 +249,11 @@ type KeyVaultBuilder() =
     /// Adds an access policy to the vault.
     [<CustomOperation "add_access_policy">]
     member __.AddAccessPolicy(state:KeyVaultBuilderState, accessPolicy) = { state with Policies = accessPolicy :: state.Policies }
+    /// Adds an simple policy to permit getting secrets.
+    [<CustomOperation "add_reader_policy">]
+    member __.AddReaderPolicy(state:KeyVaultBuilderState, (PrincipalId principal)) =
+        let accessPolicy = accessPolicy { object_id principal; secret_permissions [ Secret.Get ] }
+        { state with Policies = accessPolicy :: state.Policies }
     // Allows Azure traffic can bypass network rules.
     [<CustomOperation "enable_azure_services_bypass">]
     member __.EnableBypass(state:KeyVaultBuilderState) = { state with NetworkAcl = { state.NetworkAcl with Bypass = Some AzureServices } }
@@ -253,8 +273,9 @@ type KeyVaultBuilder() =
     [<CustomOperation "add_vnet_rule">]
     member __.AddVnetRule(state:KeyVaultBuilderState, vnetRule) = { state with NetworkAcl = { state.NetworkAcl with VnetRules = vnetRule :: state.NetworkAcl.VnetRules } }
     [<CustomOperation "add_secret">]
+    member __.AddSecret(state:KeyVaultBuilderState, (key, builder:#IBuilder, value)) = { state with Secrets = SecretConfig.Create(key, value, builder.DependencyName) :: state.Secrets }
+    member __.AddSecret(state:KeyVaultBuilderState, (key, resourceName, value)) = { state with Secrets = SecretConfig.Create(key, value, resourceName) :: state.Secrets }
     member __.AddSecret(state:KeyVaultBuilderState, key) = { state with Secrets = SecretConfig.Create key :: state.Secrets }
-    member __.AddSecret(state:KeyVaultBuilderState, (key, value, resourceName)) = { state with Secrets = SecretConfig.Create(key, value, resourceName) :: state.Secrets }
     member __.AddSecret(state:KeyVaultBuilderState, key) = { state with Secrets = key :: state.Secrets }
 
 type SecretBuilder() =
@@ -279,5 +300,4 @@ type SecretBuilder() =
     member __.DependsOn(state:SecretConfig, resource:IArmResource) = { state with Dependencies = resource.ResourceName :: state.Dependencies }
 
 let secret = SecretBuilder()
-let accessPolicy = AccessPolicyBuilder()
 let keyVault = KeyVaultBuilder()

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -249,7 +249,7 @@ type KeyVaultBuilder() =
     /// Adds an access policy to the vault.
     [<CustomOperation "add_access_policy">]
     member __.AddAccessPolicy(state:KeyVaultBuilderState, accessPolicy) = { state with Policies = accessPolicy :: state.Policies }
-    /// Adds an simple policy to permit getting secrets.
+    /// Adds a simple policy to permit reading of secrets.
     [<CustomOperation "add_reader_policy">]
     member __.AddReaderPolicy(state:KeyVaultBuilderState, (PrincipalId principal)) =
         let accessPolicy = accessPolicy { object_id principal; secret_permissions [ Secret.Get ] }

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -407,7 +407,7 @@ type WebAppBuilder() =
     member _.EnableManagedIdentity(state:WebAppConfig) =
         { state with Identity = Some Enabled }
     [<CustomOperation "disable_managed_identity">]
-    member _.ManagedIdentity(state:WebAppConfig) =
+    member _.DisableManagedIdentity(state:WebAppConfig) =
         { state with Identity = Some Disabled }
 
 let webApp = WebAppBuilder()

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -82,7 +82,7 @@ type WebAppConfig =
       AlwaysOn : bool
       Runtime : Runtime
 
-      Identity : bool
+      Identity : FeatureFlag option
 
       ZipDeployPath : string option
 
@@ -278,7 +278,7 @@ type WebAppBuilder() =
           WebSocketsEnabled = None
           Settings = Map.empty
           Dependencies = []
-          Identity = false
+          Identity = None
           Runtime = Runtime.DotNetCoreLts
           OperatingSystem = Windows
           ZipDeployPath = None
@@ -402,8 +402,11 @@ type WebAppBuilder() =
             DockerAcrCredentials =
                 Some {| RegistryName = registryName
                         Password = SecureParameter (sprintf "docker-password-for-%s" registryName) |} }
-    [<CustomOperation "use_managed_identity">]
+    [<CustomOperation "enable_managed_identity">]
+    member _.EnableManagedIdentity(state:WebAppConfig) =
+        { state with Identity = Some Enabled }
+    [<CustomOperation "disable_managed_identity">]
     member _.ManagedIdentity(state:WebAppConfig) =
-        { state with Identity = true }
+        { state with Identity = Some Disabled }
 
 let webApp = WebAppBuilder()

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -96,6 +96,7 @@ type WebAppConfig =
     member this.ServicePlan = this.ServicePlanName.ResourceName
     /// Gets the App Insights name for this web app, if it exists.
     member this.AppInsights = this.AppInsightsName |> Option.map (fun ai -> ai.ResourceName)
+    /// Gets the system-created managed principal for the web app. It must have been enabled using enable_managed_identity.
     member this.SystemIdentity =
         sprintf "reference(resourceId('Microsoft.Web/sites', '%s'), '2019-08-01', 'full').identity.principalId" this.Name.Value
         |> ArmExpression

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -98,6 +98,9 @@ type FeatureFlag = Enabled | Disabled member this.AsBoolean = match this with En
 module FeatureFlag =
     let ofBool enabled = if enabled then Enabled else Disabled
 
+/// Represents an ARM expression that evaluates to a principal ID.
+type PrincipalId = PrincipalId of ArmExpression
+
 /// Represents a secret to be captured either via an ARM expression or a secure parameter.
 type SecretValue =
     | ParameterSecret of SecureParameter


### PR DESCRIPTION
Adds the ability to mark a web app with a system-generated managed identity. Also provides a couple of new helper keywords on Key Vault to keep things simple (easily adding a secret with an ARM expression as the value, and easily adding a managed identity without creating a full policy, if the identity just needs to be able to read secrets.

This same change can be rolled out across other resources that support identity e.g. Functions.