### PR TITLE
Secret app settings

### DIFF
--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -71,7 +71,7 @@ type FunctionsConfig =
                 if this.OperatingSystem = Windows then
                     "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", Storage.buildKey this.StorageAccountName.ResourceName |> ArmExpression.Eval
                     "WEBSITE_CONTENTSHARE", this.Name.Value.ToLower()
-              ]
+              ] |> List.map Setting.AsLiteral
 
               Identity = None
               Kind =
@@ -105,7 +105,6 @@ type FunctionsConfig =
               Metadata = []
               ZipDeployPath = None
               AppCommandLine = None
-              Parameters = []
             }
             match this.ServicePlanName with
             | External _

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -59,7 +59,7 @@ type SecretConfig =
             |> Seq.forall(fun r -> r key)
 
         if not (charRulesPassed && stringRulesPassed) then
-            failwith "Key Vault key names must be a 1-127 character string, starting with a letter and containing only 0-9, a-z, A-Z, and -."
+            failwithf "Key Vault key names must be a 1-127 character string, starting with a letter and containing only 0-9, a-z, A-Z, and -. '%s' is invalid." key
 
         { Key = key
           Value = ParameterSecret(SecureParameter key)

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -51,7 +51,7 @@ type ArmExpression =
 type SecureParameter =
     | SecureParameter of name:string
     member this.Value = match this with SecureParameter value -> value
-    /// Gets an ARM expression reference to the password e.g. parameters('my-password')
+    /// Gets an ARM expression reference to the parameter e.g. parameters('my-password')
     member this.AsArmRef = sprintf "parameters('%s')" this.Value |> ArmExpression
 
 /// Exposes parameters which are required by a specific IArmResource.
@@ -109,6 +109,15 @@ type SecretValue =
         match this with
         | ParameterSecret secureParameter -> secureParameter.AsArmRef.Eval()
         | ExpressionSecret armExpression -> armExpression.Eval()
+
+type Setting =
+    | ParameterSetting of SecureParameter
+    | LiteralSetting of string
+    member this.Value =
+        match this with
+        | ParameterSetting secureParameter -> secureParameter.AsArmRef.Eval()
+        | LiteralSetting value -> value
+    static member AsLiteral (a,b) = a, LiteralSetting b
 
 type ArmTemplate =
     { Parameters : SecureParameter list


### PR DESCRIPTION
This PR allows you to add settings that instead of coming in as literal values can be supplied by secure parameters. It's not quite keyvault (the setting values are still visible in the portal if you go to webapp settings) but this is a nice second-best I think.

I've had to also introduce a Setting type which has its value as either a literal or an expression, although I am considering removing this and maintaining two lists of strings (settings and secrets) instead. The benefit of the current approach is that both are stored in one Map so it makes it clearer that there's a relationship between them at the code level.