### PR TITLE
Simplify AccessPolicy on KeyVault

### DIFF
--- a/docs/content/api-overview/resources/keyvault.md
+++ b/docs/content/api-overview/resources/keyvault.md
@@ -59,8 +59,6 @@ The Key Vault builder contains access policies, secrets, and configuration infor
 | disable_recovery_mode | Sets the Creation Mode to Default. |
 | add_access_policy | Adds an access policy to the vault. |
 | add_access_policies | Adds access policies to the vault. |
-| add_reader_policy | Adds a simple policy for a principal that allows read-only access to secrets. |
-| add_reader_policies | Adds simple policies for a principal that allows read-only access to secrets. |
 | enable_azure_services_bypass | Allows Azure traffic can bypass network rules. |
 | disable_azure_services_bypass | Disallows Azure traffic can bypass network rules. |
 | allow_default_traffic | Allow traffic if no rule from ipRules and virtualNetworkRules match. This is only used after the bypass property has been evaluated. |
@@ -68,6 +66,9 @@ The Key Vault builder contains access policies, secrets, and configuration infor
 | add_ip_rule | Adds an IP address rule. This can be an IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78). |
 | add_vnet_rule | Adds a virtual network rule. This is the full resource id of a vnet subnet, such as '/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'. |
 | add_secret | Adds a secret to the vault. This can either be a "full" secret config created using the Secret Builder, a string literal value which represents the parameter name, or a string literal with a resource and an expression based on that resource e.g. a storage account and the Key member. |
+
+#### Utilities
+KeyVault comes with a set of utility functions to quickly create access policies if you do not wish to use the `AccessPolicy` builder, in the `Farmer.KeyVault.AccessPolicy` module, such as `create` and `createReader`, which enable creating an access policy for a `PrincipalId` with either a specific set of Secret access permissions, or the Get Secret permission.
 
 #### Example
 

--- a/samples/scripts/keyvault.fsx
+++ b/samples/scripts/keyvault.fsx
@@ -1,3 +1,6 @@
+
+open Farmer.CoreTypes
+
 #r @"./libs/Newtonsoft.Json.dll"
 #r @"../../src/Farmer/bin/Debug/netstandard2.0/Farmer.dll"
 
@@ -6,25 +9,26 @@ open Farmer.Builders
 open Farmer.KeyVault
 open System
 
-let vault =
-    let policy =
-        accessPolicy {
-            object_id Guid.Empty
-            certificate_permissions [ Certificate.List ]
-            secret_permissions Secret.All
-            key_permissions [ Key.List ]
-        }
-
-    let complexSecret = secret {
-        name "myComplexSecret"
-        content_type "application/text"
-        enable_secret
-        activation_date (DateTime.Today.AddDays -1.)
-        expiration_date (DateTime.Today.AddDays 1.)
+let policy =
+    accessPolicy {
+        object_id Guid.Empty
+        certificate_permissions [ Certificate.List ]
+        secret_permissions Secret.All
+        key_permissions [ Key.List ]
     }
 
-    let store = storageAccount { name "foo" }
+let complexSecret = secret {
+    name "myComplexSecret"
+    content_type "application/text"
+    enable_secret
+    activation_date (DateTime.Today.AddDays -1.)
+    expiration_date (DateTime.Today.AddDays 1.)
+}
 
+let store = storageAccount { name "foo" }
+let principal = PrincipalId (ArmExpression "GETS BACK OBJECT ID OF ACCOUNT")
+
+let vault =
     keyVault {
         name "MyVault"
         sku KeyVaultSku.Standard
@@ -33,6 +37,13 @@ let vault =
         enable_disk_encryption_access
         enable_resource_manager_access
         enable_soft_delete_with_purge_protection
+        
+        add_access_policy (AccessPolicy.createReader principal)
+        add_access_policies [
+            AccessPolicy.createReader principal
+            AccessPolicy.create [ Secret.Get ] principal
+            accessPolicy { object_id principal; secret_permissions [ Secret.Get ] }
+        ]
 
         disable_vm_access
         enable_recovery_mode

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -99,7 +99,7 @@ module FeatureFlag =
     let ofBool enabled = if enabled then Enabled else Disabled
 
 /// Represents an ARM expression that evaluates to a principal ID.
-type PrincipalId = PrincipalId of ArmExpression
+type PrincipalId = PrincipalId of ArmExpression member this.ArmValue = match this with PrincipalId e -> e 
 
 /// Represents a secret to be captured either via an ARM expression or a secure parameter.
 type SecretValue =


### PR DESCRIPTION
This removes the short-lived `add_reader_policy` keyword add goes back to just `add_access_policy`. However, I've added a couple of simple helper functions to enable the sample simple behaviour:

```fsharp
keyVault {
    add_access_policy (AccessPolicy.createReader principal)
    add_access_policy (AccessPolicy.create [ Secret.Get ] principal)
}
```

This also works great with `add_access_policies`. Here you can see several different ways of adding a policy to the vault.

```fsharp
keyVault {
        add_access_policies [
            AccessPolicy.createReader principal
            AccessPolicy.create [ Secret.Get ] principal
            accessPolicy { secret_permissions [ Secret.Get ]; object_id principal }
        ]
}
```

@forki does this work for you?