### PR TITLE
User support in KeyVault

### DIFF
--- a/docs/content/api-overview/resources/keyvault.md
+++ b/docs/content/api-overview/resources/keyvault.md
@@ -68,7 +68,8 @@ The Key Vault builder contains access policies, secrets, and configuration infor
 | add_secret | Adds a secret to the vault. This can either be a "full" secret config created using the Secret Builder, a string literal value which represents the parameter name, or a string literal with a resource and an expression based on that resource e.g. a storage account and the Key member. |
 
 #### Utilities
-KeyVault comes with a set of utility functions to quickly create access policies if you do not wish to use the `AccessPolicy` builder, in the `Farmer.KeyVault.AccessPolicy` module, such as `create` and `createReader`, which enable creating an access policy for a `PrincipalId` with either a specific set of Secret access permissions, or the Get Secret permission.
+* The KeyVault module comes with a set of utility functions to quickly create access policies if you do not wish to use the `AccessPolicy` builder, in the `Farmer.KeyVault.AccessPolicy` module which enable creating an access policy for a `PrincipalId` or an `ObjectId` which will have the GET Secret permission.
+* In addition, the `AccessPolicy` module also contains helpers to search for users or groups in active directory (*requires Azure CLI installed*), as well as their Object IDs. These can be used to rapidly create Access Policies for specific users.
 
 #### Example
 

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -76,8 +76,12 @@ module Az =
     let listSubscriptions() = az "account list"
     let setSubscription subscriptionId = az (sprintf "account set --subscription %s" subscriptionId)
     /// Creates a resource group.
-    let createResourceGroup location resourceGroup =
-        az (sprintf "group create -l %s -n %s" location resourceGroup) |> Result.ignore
+    let createResourceGroup location resourceGroup = az (sprintf "group create -l %s -n %s" location resourceGroup) |> Result.ignore
+    /// Searches for users in AD using the supplied filter.
+    let searchUsers filter = az ("ad user list --filter " + filter)
+    /// Searches for groups in AD using the supplied filter.
+    let searchGroups filter = az ("ad group list --filter " + filter)
+
 
     type DeploymentCommand =
     | Create
@@ -123,6 +127,7 @@ let listSubscriptions() = result {
     let! response = Az.listSubscriptions()
     return response |> JsonConvert.DeserializeObject<Subscription array>
 }
+
 
 /// Checks that the version of the Azure CLI meets minimum version.
 let checkVersion minimum = result {

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -30,6 +30,7 @@ type IBuilder =
 namespace Farmer.CoreTypes
 
 open Farmer
+open System
 
 /// Represents an expression used within an ARM template
 type ArmExpression =
@@ -99,7 +100,8 @@ module FeatureFlag =
     let ofBool enabled = if enabled then Enabled else Disabled
 
 /// Represents an ARM expression that evaluates to a principal ID.
-type PrincipalId = PrincipalId of ArmExpression member this.ArmValue = match this with PrincipalId e -> e 
+type PrincipalId = PrincipalId of ArmExpression member this.ArmValue = match this with PrincipalId e -> e
+type ObjectId = ObjectId of Guid
 
 /// Represents a secret to be captured either via an ARM expression or a secure parameter.
 type SecretValue =


### PR DESCRIPTION
Adds the ability to list users and groups based on a filter, and retrieve the object ids. These may then be passed into KeyVault as access policies e.g.

```fsharp
let users = [ "user@company.com"; "user2@company.com" ]

let kv = keyVault {
    name "myVault"
    add_access_policies [
        for user in AccessPolicy.findUsers users do
            AccessPolicy.create user.ObjectId
        for group in AccessPolicy.findGroups [ "Developers" ] do
            AccessPolicy.create group.ObjectId
    ]
}
```

cc: @forki - does this work for you?