### PR TITLE
Adds virtual network gateway support

### DIFF
--- a/docs/content/api-overview/resources/vnet-gateway.md
+++ b/docs/content/api-overview/resources/vnet-gateway.md
@@ -41,7 +41,6 @@ let gw = gateway {
     name "er-gateway"
     vnet "my-vnet" // Must contain a subnet named 'GatewaySubnet'
     er_gateway_sku ErGatewaySku.Standard
-    gateway_ip_config DynamicPrivateIp "gw-pip"
 }
 
 let privateNet = vnet {

--- a/docs/content/api-overview/resources/vnet-gateway.md
+++ b/docs/content/api-overview/resources/vnet-gateway.md
@@ -15,10 +15,12 @@ The Virtual Network Gateway builder creates virtual network gateways for Express
 | Keyword | Purpose |
 |-|-|
 | name | Specifies the name of the virtual network gateway |
-| gateway_type | Sets the type of gateway to create (ExpressRoute or VPN) and its SKU |
-| gateway_ip_config | Specifies the gateway public and private IP addresses |
 | vnet | The name of the virtual network to which the gateway connects |
-| active_active_ip_config | Specifies the second public and private IP configuration for an redundant gateway |
+| er_gateway_sku | SKU for an ExpressRoute gateway |
+| vpn_gateway_sku | SKU for a VPN gateway |
+| vpn_type | Sets the VPN type to route-based (default) or policy-based. |
+| gateway_ip_config | Specifies the gateway public and private IP addresses |
+| active_active_ip_config | Specifies the second public and private IP configuration for a redundant gateway |
 | disable_bgp | BGP is enabled by default, but this can disable it |
 
 #### Example
@@ -30,8 +32,21 @@ open Farmer.VirtualNetworkGateway
 
 let gw = gateway {
     name "er-gateway"
-    gateway_type (GatewayType.ExpressRoute ErGatewaySku.Standard)
-    vnet "my-vnet"
+    vnet "my-vnet" // Must contain a subnet named 'GatewaySubnet'
+    er_gateway_sku ErGatewaySku.Standard
     gateway_ip_config DynamicPrivateIp "gw-pip"
+}
+
+let privateNet = vnet {
+    name "my-vnet"
+    add_address_spaces [
+        "10.30.0.0/16"
+    ]
+    add_subnets [
+        subnet {
+            name "GatewaySubnet"
+            prefix "10.30.254.0/28"
+        }
+    ]
 }
 ```

--- a/docs/content/api-overview/resources/vnet-gateway.md
+++ b/docs/content/api-overview/resources/vnet-gateway.md
@@ -1,7 +1,7 @@
 ---
 title: "Virtual Network Gateway"
-date: 2020-02-05T08:53:46+01:00
-weight: 19
+date: 2020-06-19T10:40:00-04:00
+weight: 5
 chapter: false
 ---
 

--- a/docs/content/api-overview/resources/vnet-gateway.md
+++ b/docs/content/api-overview/resources/vnet-gateway.md
@@ -9,19 +9,26 @@ chapter: false
 The Virtual Network Gateway builder creates virtual network gateways for ExpressRoute or VPN connections to a virtual network.
 
 * Virtual Network Gateways (`Microsoft.Network/virtualNetworkGatways`)
+* Connections (`Microsoft.Network/connections`)
 
 #### Builder Keywords
 
-| Keyword | Purpose |
-|-|-|
-| name | Specifies the name of the virtual network gateway |
-| vnet | The name of the virtual network to which the gateway connects |
-| er_gateway_sku | SKU for an ExpressRoute gateway |
-| vpn_gateway_sku | SKU for a VPN gateway |
-| vpn_type | Sets the VPN type to route-based (default) or policy-based. |
-| gateway_ip_config | Specifies the gateway public and private IP addresses |
-| active_active_ip_config | Specifies the second public and private IP configuration for a redundant gateway |
-| disable_bgp | BGP is enabled by default, but this can disable it |
+| Applies To | Keyword | Purpose |
+|-|-|-|
+| Gateway | name | Specifies the name of the virtual network gateway |
+| Gateway | vnet | The name of the virtual network to which the gateway connects |
+| Gateway | er_gateway_sku | SKU for an ExpressRoute gateway |
+| Gateway | vpn_gateway_sku | SKU for a VPN gateway |
+| Gateway | vpn_type | Sets the VPN type to route-based (default) or policy-based. |
+| Gateway | gateway_ip_config | Specifies the gateway public and private IP addresses |
+| Gateway | active_active_ip_config | Specifies the second public and private IP configuration for a redundant gateway |
+| Gateway | disable_bgp | BGP is enabled by default, but this can disable it |
+| Connection | name | Specifies the name of the connection |
+| Connection | vnet_gateway1 | Name of the first vnet gateway this is connecting |
+| Connection | vnet_gateway2 | Name of the second vnet gateway this is connecting, for use when connecting two vnets |
+| Connection | local_gateway | Name of the local gateway connection for a VPN |
+| Connection | peer_id | Id of the peer, typically an ExpressRoute circuit Id |
+| Connection | auth_key | Authorization key used when peering across subscriptions |
 
 #### Example
 

--- a/docs/content/api-overview/resources/vnet-gateway.md
+++ b/docs/content/api-overview/resources/vnet-gateway.md
@@ -1,0 +1,37 @@
+---
+title: "Virtual Network Gateway"
+date: 2020-02-05T08:53:46+01:00
+weight: 19
+chapter: false
+---
+
+#### Overview
+The Virtual Network Gateway builder creates virtual network gateways for ExpressRoute or VPN connections to a virtual network.
+
+* Virtual Network Gateways (`Microsoft.Network/virtualNetworkGatways`)
+
+#### Builder Keywords
+
+| Keyword | Purpose |
+|-|-|
+| name | Specifies the name of the virtual network gateway |
+| gateway_type | Sets the type of gateway to create (ExpressRoute or VPN) and its SKU |
+| gateway_ip_config | Specifies the gateway public and private IP addresses |
+| vnet | The name of the virtual network to which the gateway connects |
+| active_active_ip_config | Specifies the second public and private IP configuration for an redundant gateway |
+| disable_bgp | BGP is enabled by default, but this can disable it |
+
+#### Example
+
+```fsharp
+open Farmer
+open Farmer.Builders
+open Farmer.VirtualNetworkGateway
+
+let gw = gateway {
+    name "er-gateway"
+    gateway_type (GatewayType.ExpressRoute ErGatewaySku.Standard)
+    vnet "my-vnet"
+    gateway_ip_config DynamicPrivateIp "gw-pip"
+}
+```

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -1,78 +1,12 @@
-﻿open Farmer
+open Farmer
 open Farmer.Builders
 
 //TODO: Create resources here!
-let privateNet = vnet {
-    name "private-vnet"
-    add_address_spaces [
-        "10.30.0.0/16"
-    ]
-    add_subnets [
-        (*
-        create_subnet "containersubnet" "10.30.12.0/24"
-        carve_subnet "containersubnet" "/24"
-        carve_subnet "vnet" "/24"
-        carve_subnet "dbs" "/24"
-        carve_subnet "gateways" "/29"
-        *)
-        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
-            name "ContainerSubnet"
-            prefix "10.30.19.0/28"
-            add_delegations [
-                SubnetDelegationService.ContainerGroups
-            ]
-        }
-        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
-            name "vms"
-            prefix "10.30.18.0/24"
-        }
-        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
-            name "databases"
-            prefix "10.30.22.0/24"
-        }
-    ]
-}
-
-let aciProfile = networkProfile {
-    name "vnet-aci-profile"
-    //vnet privateNet <- inside the CE, we could check that the subnets are within this vnet
-    vnet "private-vnet"
-    //subnet containerSubnet <- can be referenced instead of going by name
-    subnet "ContainerSubnet"
-}
-
-let myContainer = container {
-    name "helloworld"
-    image "microsoft/aci-helloworld"
-    network_profile "vnet-aci-profile" // same thing here, could reference object instead of string
-    //link_to_vnet privateNet containerSubnet
-    ports [ 80us ]
-    private_static_ip "10.30.19.4" [TCP, 80us]
-}
-
-open Farmer.VirtualNetworkGateway
-
-let gw = gateway {
-    name "er-gateway"
-    //gateway_vpn VpnGatewaySku.VpnGw1
-    //gateway_er ErGatewaySku.HighPerformance
-    vpn_gateway_sku VpnGatewaySku.VpnGw1
-    er_gateway_sku ErGatewaySku.Standard
-    vpn_type VpnType.RouteBased
-    vnet "my-vnet"
-    gateway_ip_config DynamicPrivateIp "gw-pip"
-    // active_active_ip_config DynamicPrivateIp "gw-pip2"
-}
-
 
 let deployment = arm {
-    location Location.WestEurope
+    location Location.NorthEurope
 
     //TODO: Assign resources here using the add_resource keyword
-    add_resource privateNet
-    add_resource aciProfile
-    add_resource myContainer
-    add_resource gw
 }
 
 // Generate the ARM template here...

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -1,34 +1,78 @@
 ﻿open Farmer
 open Farmer.Builders
-open Farmer.CoreTypes
 
-let myApp = functions {
-    name "isaacswebapp"
-    secret_setting "thesecret"
-    setting "thepublic" "value"
-    app_insights_off
-    enable_managed_identity
-}
-
-let users = [
-    "isaac@compositional-it.com"
-    "prashant@compositional-it.com"
-    "alican@compositional-it.com" ]
-
-let kv = keyVault {
-    name "isaacskeyvault"
-    add_access_policies [
-        for user in AccessPolicy.findUsers users do
-            AccessPolicy.create user.ObjectId
-        for group in AccessPolicy.findGroups [ "Developers" ] do
-            AccessPolicy.create group.ObjectId
+//TODO: Create resources here!
+let privateNet = vnet {
+    name "private-vnet"
+    add_address_spaces [
+        "10.30.0.0/16"
+    ]
+    add_subnets [
+        (*
+        create_subnet "containersubnet" "10.30.12.0/24"
+        carve_subnet "containersubnet" "/24"
+        carve_subnet "vnet" "/24"
+        carve_subnet "dbs" "/24"
+        carve_subnet "gateways" "/29"
+        *)
+        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
+            name "ContainerSubnet"
+            prefix "10.30.19.0/28"
+            add_delegations [
+                SubnetDelegationService.ContainerGroups
+            ]
+        }
+        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
+            name "vms"
+            prefix "10.30.18.0/24"
+        }
+        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
+            name "databases"
+            prefix "10.30.22.0/24"
+        }
     ]
 }
 
+let aciProfile = networkProfile {
+    name "vnet-aci-profile"
+    //vnet privateNet <- inside the CE, we could check that the subnets are within this vnet
+    vnet "private-vnet"
+    //subnet containerSubnet <- can be referenced instead of going by name
+    subnet "ContainerSubnet"
+}
+
+let myContainer = container {
+    name "helloworld"
+    image "microsoft/aci-helloworld"
+    network_profile "vnet-aci-profile" // same thing here, could reference object instead of string
+    //link_to_vnet privateNet containerSubnet
+    ports [ 80us ]
+    private_static_ip "10.30.19.4" [TCP, 80us]
+}
+
+open Farmer.VirtualNetworkGateway
+
+let gw = gateway {
+    name "er-gateway"
+    //gateway_vpn VpnGatewaySku.VpnGw1
+    //gateway_er ErGatewaySku.HighPerformance
+    vpn_gateway_sku VpnGatewaySku.VpnGw1
+    er_gateway_sku ErGatewaySku.Standard
+    vpn_type VpnType.RouteBased
+    vnet "my-vnet"
+    gateway_ip_config DynamicPrivateIp "gw-pip"
+    // active_active_ip_config DynamicPrivateIp "gw-pip2"
+}
+
+
 let deployment = arm {
-    location Location.NorthEurope
-    add_resource myApp
-    add_resource kv
+    location Location.WestEurope
+
+    //TODO: Assign resources here using the add_resource keyword
+    add_resource privateNet
+    add_resource aciProfile
+    add_resource myContainer
+    add_resource gw
 }
 
 // Generate the ARM template here...
@@ -36,6 +80,5 @@ deployment
 |> Writer.quickWrite @"generated-template"
 
 // Or deploy it directly to Azure here... (required Azure CLI installed!)
-deployment
-|> Deploy.execute "my-resource-group" [ "thesecret", "thevalue" ]
-|> printfn "%A"
+// deployment
+// |> Deploy.execute "my-resource-group" Deploy.NoParameters

--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -1,79 +1,34 @@
 ﻿open Farmer
 open Farmer.Builders
+open Farmer.CoreTypes
 
-//TODO: Create resources here!
-let privateNet = vnet {
-    name "private-vnet"
-    add_address_spaces [
-        "10.30.0.0/16"
-    ]
-    add_subnets [
-        (*
-        create_subnet "containersubnet" "10.30.12.0/24"
-        carve_subnet "containersubnet" "/24"
-        carve_subnet "vnet" "/24"
-        carve_subnet "dbs" "/24"
-        carve_subnet "gateways" "/29"
-        *)
-        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
-            name "ContainerSubnet"
-            prefix "10.30.19.0/28"
-            add_delegations [
-                SubnetDelegationService.ContainerGroups
-            ]
-        }
-        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
-            name "vms"
-            prefix "10.30.18.0/24"
-        }
-        subnet { // vnet __.Run - this runs when assigning the private net so could do this validation
-            name "databases"
-            prefix "10.30.22.0/24"
-        }
+let myApp = functions {
+    name "isaacswebapp"
+    secret_setting "thesecret"
+    setting "thepublic" "value"
+    app_insights_off
+    enable_managed_identity
+}
+
+let users = [
+    "isaac@compositional-it.com"
+    "prashant@compositional-it.com"
+    "alican@compositional-it.com" ]
+
+let kv = keyVault {
+    name "isaacskeyvault"
+    add_access_policies [
+        for user in AccessPolicy.findUsers users do
+            AccessPolicy.create user.ObjectId
+        for group in AccessPolicy.findGroups [ "Developers" ] do
+            AccessPolicy.create group.ObjectId
     ]
 }
-
-let aciProfile = networkProfile {
-    name "vnet-aci-profile"
-    //vnet privateNet <- inside the CE, we could check that the subnets are within this vnet
-    vnet "private-vnet"
-    //subnet containerSubnet <- can be referenced instead of going by name
-    subnet "ContainerSubnet"
-}
-
-let myContainer = container {
-    name "helloworld"
-    image "microsoft/aci-helloworld"
-    network_profile "vnet-aci-profile" // same thing here, could reference object instead of string
-    //link_to_vnet privateNet containerSubnet
-    ports [ 80us ]
-    private_static_ip "10.30.19.4" [TCP, 80us]
-}
-
-open Farmer.VirtualNetworkGateway
-
-let gw = gateway {
-    name "er-gateway"
-    //gateway_vpn VpnGatewaySku.VpnGw1
-    //gateway_er ErGatewaySku.HighPerformance
-    gateway_type (GatewayType.ExpressRoute ErGatewaySku.Standard)
-    //set_vpn_gateway VpnGatewaySku.VpnGw1
-    //set_er_gateway VpnGatewaySku.VpnGw1
-    gateway_type (GatewayType.Vpn(VpnGatewaySku.VpnGw1, VpnType.RouteBased, false))
-    vnet "my-vnet"
-    gateway_ip_config DynamicPrivateIp "gw-pip"
-    // active_active_ip_config DynamicPrivateIp "gw-pip2"
-}
-
 
 let deployment = arm {
-    location Location.WestEurope
-
-    //TODO: Assign resources here using the add_resource keyword
-    add_resource privateNet
-    add_resource aciProfile
-    add_resource myContainer
-    add_resource gw
+    location Location.NorthEurope
+    add_resource myApp
+    add_resource kv
 }
 
 // Generate the ARM template here...
@@ -81,5 +36,6 @@ deployment
 |> Writer.quickWrite @"generated-template"
 
 // Or deploy it directly to Azure here... (required Azure CLI installed!)
-// deployment
-// |> Deploy.execute "my-resource-group" Deploy.NoParameters
+deployment
+|> Deploy.execute "my-resource-group" [ "thesecret", "thevalue" ]
+|> printfn "%A"

--- a/samples/scripts/vnet-gateway.fsx
+++ b/samples/scripts/vnet-gateway.fsx
@@ -5,6 +5,7 @@
 open Farmer
 open Farmer.Builders
 open Farmer.VirtualNetworkGateway
+open Farmer.Arm.Network
 
 let privateNet = vnet {
     name "my-vnet"
@@ -19,10 +20,12 @@ let privateNet = vnet {
     ]
 }
 
+/// In case you need to specify public IP details, create a public IP
+/// and assign it to the gateway with 'gateway_ip_config'
 let gatewayIp = {
     Name = ResourceName "gw-pip"
     Location = Location.NorthEurope
-    DomainNameLabel = None
+    DomainNameLabel = Some "mygateway"
 }
 
 let myGateway = gateway {
@@ -30,7 +33,7 @@ let myGateway = gateway {
     er_gateway_sku ErGatewaySku.Standard
     vpn_type VpnType.RouteBased
     vnet "my-vnet"
-    gateway_ip_config DynamicPrivateIp gatewayIp.Name.Value
+    gateway_ip_config DynamicPrivateIp gatewayIp
 }
 
 let deployment = arm {

--- a/samples/scripts/vnet-gateway.fsx
+++ b/samples/scripts/vnet-gateway.fsx
@@ -1,0 +1,45 @@
+
+#r @"./libs/Newtonsoft.Json.dll"
+#r @"../../src/Farmer/bin/Debug/netstandard2.0/Farmer.dll"
+
+open Farmer
+open Farmer.Builders
+open Farmer.VirtualNetworkGateway
+
+let privateNet = vnet {
+    name "my-vnet"
+    add_address_spaces [
+        "10.30.0.0/16"
+    ]
+    add_subnets [
+        subnet {
+            name "GatewaySubnet"
+            prefix "10.30.254.0/28"
+        }
+    ]
+}
+
+let gatewayIp = {
+    Name = ResourceName "gw-pip"
+    Location = Location.NorthEurope
+    DomainNameLabel = None
+}
+
+let myGateway = gateway {
+    name "er-gateway"
+    er_gateway_sku ErGatewaySku.Standard
+    vpn_type VpnType.RouteBased
+    vnet "my-vnet"
+    gateway_ip_config DynamicPrivateIp gatewayIp.Name.Value
+}
+
+let deployment = arm {
+    location Location.NorthEurope
+    add_resource privateNet
+    add_resource myGateway
+    add_resource gatewayIp
+}
+
+deployment
+|> Deploy.whatIf "FarmerTest" Deploy.NoParameters
+|> printfn "%A"

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -63,6 +63,7 @@ type VirtualNetworkGateway =
                      PublicIpName : ResourceName |} list
       VirtualNetwork : ResourceName
       GatewayType : GatewayType
+      VpnType : VpnType
       EnableBgp : bool }
     interface IArmResource with
         member this.ResourceName = this.Name
@@ -92,11 +93,11 @@ type VirtualNetworkGateway =
                        sku =
                            match this.GatewayType with
                            | GatewayType.ExpressRoute sku -> {| name = sku.ArmValue; tier = sku.ArmValue |}
-                           | GatewayType.Vpn (sku, _, _) -> {| name = sku.ArmValue; tier = sku.ArmValue |}
+                           | GatewayType.Vpn sku -> {| name = sku.ArmValue; tier = sku.ArmValue |}
                        gatewayType = this.GatewayType.ArmValue
-                       vpnType = this.GatewayType.VpnType
+                       vpnType = this.VpnType.ArmValue
                        enableBgp = this.EnableBgp
-                       activeActive = this.GatewayType.ActiveActive
+                       activeActive = this.IpConfigs |> List.length > 1
                     |}
             |} :> _
 type NetworkInterface =

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -73,7 +73,7 @@ type VirtualNetworkGateway =
                name = this.Name.Value
                location = this.Location.ArmValue
                dependsOn = [
-                   sprintf "[resourceId('Microsoft.Network/virtualNetworks/subnets', '%s')]" this.VirtualNetwork.Value
+                   sprintf "[resourceId('Microsoft.Network/virtualNetworks', '%s')]" this.VirtualNetwork.Value
                    for config in this.IpConfigs do
                        sprintf "[resourceId('Microsoft.Network/publicIPAddresses','%s')]" config.PublicIpName.Value 
                ]

--- a/src/Farmer/Builders/Builders.VirtualNetworkGateway.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetworkGateway.fs
@@ -1,0 +1,79 @@
+[<AutoOpen>]
+module Farmer.Builders.VirtualNetworkGateway
+
+open Farmer
+open Farmer.VirtualNetworkGateway
+open Farmer.Arm.Network
+
+type VNetGatewayConfig =
+    { /// The name of the gateway
+      Name : ResourceName
+      /// Private IP allocation method for the gateway's primary interface
+      GatewayPrivateIpAllocationMethod : PrivateIpAllocationMethod
+      /// Public IP for the gateway's interface
+      GatewayPublicIpName: ResourceName
+      /// Private IP allocation method for the gateway's secondary interface if Active-Active
+      ActiveActivePrivateIpAllocationMethod : PrivateIpAllocationMethod
+      /// Public IP for the gateway's secondary interface if Active-Active
+      ActiveActivePublicIpName: ResourceName option
+      /// Virtual network where the gateway will be attached
+      VirtualNetwork : ResourceName
+      /// Gateway type - ExpressRoute or VPN
+      GatewayType : GatewayType
+      /// Enable Border Gateway Protocol on this gateway
+      EnableBgp : bool }
+    interface IBuilder with
+        member this.DependencyName = this.Name
+        member this.BuildResources location _ = [
+            { Name = this.Name
+              Location = location
+              IpConfigs = [
+                    yield {| Name = ResourceName "default"; PrivateIpAllocationMethod = this.GatewayPrivateIpAllocationMethod; PublicIpName = this.GatewayPublicIpName |}
+                    if this.ActiveActivePublicIpName.IsSome then
+                        yield {| Name = ResourceName "redundant"; PrivateIpAllocationMethod = this.ActiveActivePrivateIpAllocationMethod; PublicIpName = this.ActiveActivePublicIpName.Value |}
+              ]
+              VirtualNetwork = this.VirtualNetwork
+              GatewayType = this.GatewayType
+              EnableBgp = this.EnableBgp
+            }
+        ]
+
+type VnetGatewayBuilder() =
+    member __.Yield _ =
+      { Name = ResourceName.Empty
+        GatewayPrivateIpAllocationMethod = DynamicPrivateIp
+        GatewayPublicIpName = ResourceName.Empty
+        ActiveActivePrivateIpAllocationMethod = DynamicPrivateIp
+        ActiveActivePublicIpName = None
+        VirtualNetwork = ResourceName.Empty
+        GatewayType = GatewayType.Vpn (VpnGatewaySku.VpnGw1, VpnType.RouteBased, false)
+        EnableBgp = true }
+    /// Sets the name of the gateway
+    [<CustomOperation "name">]
+    member __.Name(state:VNetGatewayConfig, name) = { state with Name = ResourceName name }
+    /// Sets the virtual network where this gateway is attached.
+    [<CustomOperation "vnet">]
+    member __.VNet(state:VNetGatewayConfig, vnet) = { state with VirtualNetwork = ResourceName vnet }
+    /// Sets the gateway type with a SKU.
+    [<CustomOperation "gateway_type">]
+    member __.GatewayType(state:VNetGatewayConfig, gwType) = { state with GatewayType = gwType }
+    /// Sets the default gateway IP config.
+    [<CustomOperation "gateway_ip_config">]
+    member __.GatewayIpConfig(state:VNetGatewayConfig, allocationMethod, publicIpName) =
+        { state with GatewayPrivateIpAllocationMethod = allocationMethod; GatewayPublicIpName = ResourceName publicIpName  }
+    /// Sets the default gateway IP config and enables active-active if not already.
+    [<CustomOperation "active_active_ip_config">]
+    member __.ActiveActiveIpConfig(state:VNetGatewayConfig, allocationMethod, publicIpName) =
+        match state.GatewayType with
+        | GatewayType.ExpressRoute _ -> state // No active-active config on ER gateways
+        | GatewayType.Vpn (sku, vpnType, _) ->
+            { state with
+                ActiveActivePrivateIpAllocationMethod = allocationMethod
+                ActiveActivePublicIpName = Some (ResourceName publicIpName)
+                GatewayType = GatewayType.Vpn (sku, vpnType, true)
+            }
+    /// Disable BGP (enabled by default).
+    [<CustomOperation "disable_bgp">]
+    member __.DisableBgp(state:VNetGatewayConfig) = { state with EnableBgp = false }
+
+let gateway = VnetGatewayBuilder()

--- a/src/Farmer/Builders/Builders.VirtualNetworkGateway.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetworkGateway.fs
@@ -86,3 +86,55 @@ type VnetGatewayBuilder() =
     member __.DisableBgp(state:VNetGatewayConfig) = { state with EnableBgp = false }
 
 let gateway = VnetGatewayBuilder()
+
+type ConnectionConfig =
+    { Name : ResourceName
+      ConnectionType : ConnectionType
+      VirtualNetworkGateway1 : ResourceName
+      VirtualNetworkGateway2 : ResourceName option
+      LocalNetworkGateway : ResourceName option
+      PeerId : string option
+      AuthorizationKey : string option }
+    interface IBuilder with
+        member this.DependencyName = this.Name
+        member this.BuildResources location _ = [
+            { Name = this.Name
+              Location = location
+              ConnectionType = this.ConnectionType
+              VirtualNetworkGateway1 = this.VirtualNetworkGateway1
+              VirtualNetworkGateway2 = this.VirtualNetworkGateway2
+              LocalNetworkGateway = this.LocalNetworkGateway
+              PeerId = this.PeerId
+              AuthorizationKey = this.AuthorizationKey
+            }
+        ]
+
+type ConnectionBuilder() =
+    member __.Yield _ =
+      { Name = ResourceName.Empty
+        ConnectionType = ConnectionType.ExpressRoute
+        VirtualNetworkGateway1 = ResourceName.Empty
+        VirtualNetworkGateway2 = None
+        LocalNetworkGateway = None
+        PeerId = None
+        AuthorizationKey = None }
+    /// Sets the name of the connection
+    [<CustomOperation "name">]
+    member __.Name(state:ConnectionConfig, name) = { state with Name = ResourceName name }
+    /// Sets the first vnet gateway
+    [<CustomOperation "vnet_gateway1">]
+    member __.VNetGateway1(state:ConnectionConfig, vng1) = { state with VirtualNetworkGateway1 = vng1 }
+    /// Sets the first vnet gateway
+    [<CustomOperation "vnet_gateway2">]
+    member __.VNetGateway2(state:ConnectionConfig, vng2) = { state with VirtualNetworkGateway2 = vng2 }
+    /// Sets the first vnet gateway
+    [<CustomOperation "local_gateway">]
+    member __.LocalGateway(state:ConnectionConfig, lng) = { state with LocalNetworkGateway = lng }
+    /// Sets the first vnet gateway
+    [<CustomOperation "peer_id">]
+    member __.PeerId(state:ConnectionConfig, peer) = { state with PeerId = Some peer }
+    /// Sets the first vnet gateway
+    [<CustomOperation "auth_key">]
+    member __.Authorization(state:ConnectionConfig, auth) = { state with AuthorizationKey = Some auth }
+
+let connection = ConnectionBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -553,6 +553,16 @@ module VirtualNetworkGateway =
             match this with
             | ExpressRoute _ -> "ExpressRoute"
             | Vpn _ -> "Vpn"
+    [<RequireQualifiedAccess>]
+    type ConnectionType =
+        | ExpressRoute
+        | IPsec
+        | Vnet2Vnet
+        member this.ArmValue =
+            match this with
+            | ExpressRoute _ -> "ExpressRoute"
+            | IPsec -> "IPsec"
+            | Vnet2Vnet -> "Vnet2Vnet"
 module ServiceBus =
     type MessagingUnits = OneUnit | TwoUnits | FourUnits
     type Sku =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -489,6 +489,74 @@ module ExpressRoute =
     type Family = UnlimitedData | MeteredData
     type PeeringType = AzurePrivatePeering | MicrosoftPeering member this.Value = this.ToString()
 
+module VirtualNetworkGateway =
+    type PrivateIpAllocationMethod = DynamicPrivateIp | StaticPrivateIp of System.Net.IPAddress
+    [<RequireQualifiedAccess>]
+    type ErGatewaySku =
+        | Standard
+        | HighPerformance
+        | UltraPerformance
+        | ErGw1AZ
+        | ErGw2AZ
+        | ErGw3AZ
+        member this.ArmValue =
+            match this with
+            | Standard -> "Standard"
+            | HighPerformance -> "HighPerformance"
+            | UltraPerformance -> "UltraPerformance"
+            | ErGw1AZ -> "ErGw1AZ"
+            | ErGw2AZ -> "ErGw2AZ"
+            | ErGw3AZ -> "ErGw3AZ"
+    [<RequireQualifiedAccess>]
+    type VpnGatewaySku =
+        | Basic
+        | VpnGw1
+        | VpnGw1AZ
+        | VpnGw2
+        | VpnGw2AZ
+        | VpnGw3
+        | VpnGw3AZ
+        | VpnGw4
+        | VpnGw4AZ
+        | VpnGw5
+        | VpnGw5AZ
+        member this.ArmValue =
+            match this with
+            | Basic -> "Basic"
+            | VpnGw1 -> "VpnGw1"
+            | VpnGw1AZ -> "VpnGw1AZ"
+            | VpnGw2 -> "VpnGw2"
+            | VpnGw2AZ -> "VpnGw2AZ"
+            | VpnGw3 -> "VpnGw3"
+            | VpnGw3AZ -> "VpnGw3AZ"
+            | VpnGw4 -> "VpnGw4"
+            | VpnGw4AZ -> "VpnGw4AZ"
+            | VpnGw5 -> "VpnGw5"
+            | VpnGw5AZ -> "VpnGw5AZ"
+    [<RequireQualifiedAccess>]
+    type VpnType =
+        | PolicyBased
+        | RouteBased
+        member this.ArmValue =
+            match this with
+            | PolicyBased -> "PolicyBased"
+            | RouteBased-> "RouteBased"
+    [<RequireQualifiedAccess>]
+    type GatewayType =
+        | ExpressRoute of ErGatewaySku
+        | Vpn of VpnGatewaySku * VpnType * ActiveActive:bool
+        member this.ArmValue =
+            match this with
+            | ExpressRoute _ -> "ExpressRoute"
+            | Vpn _ -> "Vpn"
+        member this.VpnType =
+            match this with
+            | ExpressRoute _ -> "RouteBased"
+            | Vpn (_, vpnType, _) -> vpnType.ArmValue
+        member this.ActiveActive =
+            match this with
+            | ExpressRoute _ -> false
+            | Vpn (_, _, activeActive) -> activeActive
 module ServiceBus =
     type MessagingUnits = OneUnit | TwoUnits | FourUnits
     type Sku =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -548,19 +548,11 @@ module VirtualNetworkGateway =
     [<RequireQualifiedAccess>]
     type GatewayType =
         | ExpressRoute of ErGatewaySku
-        | Vpn of VpnGatewaySku * VpnType * ActiveActive:bool
+        | Vpn of VpnGatewaySku
         member this.ArmValue =
             match this with
             | ExpressRoute _ -> "ExpressRoute"
             | Vpn _ -> "Vpn"
-        member this.VpnType =
-            match this with
-            | ExpressRoute _ -> "RouteBased"
-            | Vpn (_, vpnType, _) -> vpnType.ArmValue
-        member this.ActiveActive =
-            match this with
-            | ExpressRoute _ -> false
-            | Vpn (_, _, activeActive) -> activeActive
 module ServiceBus =
     type MessagingUnits = OneUnit | TwoUnits | FourUnits
     type Sku =

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -94,5 +94,6 @@
     <Compile Include="Builders/Builders.IotHub.fs" />
     <Compile Include="Builders/Builders.Maps.fs" />
     <Compile Include="Builders/Builders.SignalR.fs" />
+    <Compile Include="Builders\Builders.VirtualNetworkGateway.fs" />
   </ItemGroup>
 </Project>

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>0.17.1</Version>
     <Version>0.17.2</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019, 2020 Compositional IT Ltd.</Copyright>


### PR DESCRIPTION
Adds support for virtual network gateways, with a focus on settings required to create one as an ExpressRoute gateway at this time.  Given the defaults, it can work for a simple VPN gateway as well, but more customization will come in later PR's as needed for common VPN configurations.