### PR TITLE
IPAddressCidr subnet carving utilities

### DIFF
--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -133,8 +133,8 @@ type ExpressRouteCircuit =
         {| PeeringType : PeeringType
            AzureASN : int
            PeerASN : int64
-           PrimaryPeerAddressPrefix : {| Address : IPAddress; Prefix : int |}
-           SecondaryPeerAddressPrefix : {| Address : IPAddress; Prefix : int |}
+           PrimaryPeerAddressPrefix : IPAddressCidr
+           SecondaryPeerAddressPrefix : IPAddressCidr
            SharedKey : string option
            VlanId : int
         |} list }

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -40,8 +40,8 @@ type ExpressRouteCircuitPeeringBuilder() =
       { PeeringType = AzurePrivatePeering
         AzureASN = 0
         PeerASN = 0L
-        PrimaryPeerAddressPrefix = {| Address = IPAddress.None; Prefix = 0 |}
-        SecondaryPeerAddressPrefix = {| Address = IPAddress.None; Prefix = 0 |}
+        PrimaryPeerAddressPrefix = { Address = IPAddress.None; Prefix = 0 }
+        SecondaryPeerAddressPrefix = { Address = IPAddress.None; Prefix = 0 }
         SharedKey = None
         VlanId = 0 }
     /// Sets the peering type.

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -36,7 +36,7 @@ type SubnetConfig =
       Delegations: string list }
 
 type SubnetBuilder() =
-    member __.Yield _ = { Name = ResourceName.Empty; Prefix = {| Address = System.Net.IPAddress.Parse("10.100.0.0"); Prefix = 16 |}; Delegations = [] }
+    member __.Yield _ = { Name = ResourceName.Empty; Prefix = { Address = System.Net.IPAddress.Parse("10.100.0.0"); Prefix = 16 }; Delegations = [] }
     /// Sets the name of the subnet
     [<CustomOperation "name">]
     member __.Name(state:SubnetConfig, name) = { state with Name = ResourceName name }

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -23,6 +23,7 @@ let allTests =
             ]
             testList "Control" [
                 Template.tests
+                Common.tests
                 if Environment.GetEnvironmentVariable "TF_BUILD" = "True" then AzCli.tests
             ]
         ]

--- a/src/Tests/Common.fs
+++ b/src/Tests/Common.fs
@@ -1,0 +1,43 @@
+module Common
+
+open Expecto
+open Farmer
+let tests = testList "Common" [
+    test "IPAddressCidr creates correct range" {
+        let cidr = IPAddressCidr.parse "192.168.0.0/24"
+        let first, last = cidr |> IPAddressCidr.ipRange
+        Expect.equal (string first) "192.168.0.0" "First address incorrect"
+        Expect.equal (string last) "192.168.0.255" "Last address incorrect"
+    }
+
+    test "Can carve /22 into 4 /24 subnets" {
+        let cidr = IPAddressCidr.parse "192.168.0.0/22"
+        let subnets = [24; 24; 24; 24] |> IPAddressCidr.carveAddressSpace cidr |> Seq.map IPAddressCidr.format |> Array.ofSeq
+        Expect.equal subnets.Length 4 "Incorrect number of subnets"
+        Expect.equal subnets.[0] "192.168.0.0/24" "First subnet incorrect"
+        Expect.equal subnets.[1] "192.168.1.0/24" "Second subnet incorrect"
+        Expect.equal subnets.[2] "192.168.2.0/24" "Third subnet incorrect"
+        Expect.equal subnets.[3] "192.168.3.0/24" "Fourth subnet incorrect"
+    }
+    
+    test "Can carve /22 into 7 different subnets preventing overlap" {
+        let cidr = IPAddressCidr.parse "192.168.0.0/22"
+        let subnets = [24; 24; 24; 30; 30; 28; 26] |> IPAddressCidr.carveAddressSpace cidr |> Seq.map IPAddressCidr.format |> Array.ofSeq
+        Expect.equal subnets.Length 7 "Incorrect number of subnets"
+        Expect.equal subnets.[0] "192.168.0.0/24" "First subnet incorrect"
+        Expect.equal subnets.[1] "192.168.1.0/24" "Second subnet incorrect"
+        Expect.equal subnets.[2] "192.168.2.0/24" "Third subnet incorrect"
+        Expect.equal subnets.[3] "192.168.3.0/30" "Fourth subnet incorrect"
+        Expect.equal subnets.[4] "192.168.3.4/30" "Fifth subnet incorrect"
+        Expect.equal subnets.[5] "192.168.3.16/28" "Sixth subnet incorrect"
+        Expect.equal subnets.[6] "192.168.3.64/26" "Seventh subnet incorrect"
+    }
+    
+    test "Fails to carve /22 into 3 /24 and 1 /23 subnets" {
+        Expect.throws (
+            fun _ ->
+                let cidr = IPAddressCidr.parse "192.168.0.0/22"
+                [24; 24; 24; 23] |> IPAddressCidr.carveAddressSpace cidr |> List.ofSeq |> ignore
+        ) "Should have failed to carve /22 into subnets"
+    }
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="Helpers.fs" />
+    <Compile Include="Common.fs" />
     <Compile Include="ContainerGroup.fs" />
     <Compile Include="ExpressRoute.fs" />
     <Compile Include="Storage.fs" />


### PR DESCRIPTION
This gives us some helpful capabilities for dividing up a virtual network address space into subnets of various sizes using CIDR notation.