### PR TITLE
Break out container group and instance again.

### DIFF
--- a/samples/scripts/container-instance.fsx
+++ b/samples/scripts/container-instance.fsx
@@ -1,0 +1,36 @@
+#r @"./libs/Newtonsoft.Json.dll"
+#r @"../../src/Farmer/bin/Debug/netstandard2.0/Farmer.dll"
+
+open Farmer
+open Farmer.Arm.ContainerInstance
+open Farmer.Builders
+
+let template =
+    createTemplate
+        Location.WestEurope [
+            containerGroup {
+                name "isaac-container-group"
+                operating_system Linux
+                restart_policy ContainerGroup.AlwaysRestart
+                add_instances [
+                    containerInstance {
+                        name "nginx"
+                        image "nginx:1.17.6-alpine"
+
+                        public_ports [ 80us; 443us ]
+                        internal_ports [ 123us ]
+
+                        ports PublicPort [ 80us; 443us ]
+                        ports InternalPort [ 123us ]
+
+                        memory 0.5<Gb>
+                        cpu_cores 1
+                    }
+                ]
+            }
+        ]
+
+Writer.quickWrite "generated-template" template
+
+Deploy.execute "my-resource-group" [] template
+

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -16,7 +16,7 @@ type ContainerGroup =
       ContainerInstances :
         {| Name : ResourceName
            Image : string
-           Ports : uint16 list
+           Ports : uint16 Set
            Cpu : int
            Memory : float<Gb> |} list
       OperatingSystem : OS
@@ -42,7 +42,7 @@ type ContainerGroup =
                            {| name = container.Name.Value.ToLowerInvariant ()
                               properties =
                                {| image = container.Image
-                                  ports = container.Ports |> List.map (fun port -> {| port = port |})
+                                  ports = container.Ports |> Set.map (fun port -> {| port = port |})
                                   resources =
                                    {| requests =
                                        {| cpu = container.Cpu

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -2,14 +2,13 @@
 module Farmer.Arm.ContainerInstance
 
 open Farmer
-open Farmer.CoreTypes
 open Farmer.ContainerGroup
 
 type ContainerGroupIpAddress =
     { Type : IpAddressType
       Ports :
         {| Protocol : TransmissionProtocol
-           Port : uint16 |} list }
+           Port : uint16 |} Set }
 
 type ContainerGroup =
     { Name : ResourceName

--- a/src/Farmer/ArmBuilder.fs
+++ b/src/Farmer/ArmBuilder.fs
@@ -117,3 +117,4 @@ type ArmBuilder() =
         |> Seq.fold(fun state builder -> this.AddResource(state, builder)) state
 
 let arm = ArmBuilder()
+let createTemplate resourceGroupLocation resources = arm { location resourceGroupLocation; add_resources resources }

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -2,151 +2,127 @@
 module Farmer.Builders.ContainerGroups
 
 open Farmer
-open Farmer.CoreTypes
 open Farmer.ContainerGroup
 open Farmer.Arm.ContainerInstance
 open Farmer.Arm.Network
 
 /// Represents configuration for a single Container.
-type ContainerConfig =
-    { /// The name of the container
+type ContainerInstanceConfig =
+    { /// The name of the container instance
       Name : ResourceName
-      /// The container image
+      /// The container instance image
       Image : string
-      /// List of ports the container listens on
+      /// List of ports the container instance listens on
       Ports : uint16 list
-      /// Max number of CPU cores the container may use
+      /// Max number of CPU cores the container instance may use
       Cpu : int
-      /// Max gigabytes of memory the container may use
-      Memory : float<Gb>
+      /// Max gigabytes of memory the container instance may use
+      Memory : float<Gb> }
 
-      /// The name of the container group.
-      ContainerGroupName : ResourceRef
+type ContainerGroupConfig =
+    { /// The name of the container group.
+      Name : ResourceName
       /// Container group OS.
-      OsType : OS
+      OperatingSystem : OS
       /// Restart policy for the container group.
       RestartPolicy : RestartPolicy
       /// IP address for the container group.
       IpAddress : ContainerGroupIpAddress
       /// Name of the network profile for this container's group.
-      NetworkProfile : ResourceName option }
-
-    member this.Key = buildKey this.Name
-    /// Gets the ARM expression path to the key of this container group.
-    member this.GroupKey = buildKey this.ContainerGroupName.ResourceName
-    /// Gets the name of the container group.
-    member this.GroupName = this.ContainerGroupName.ResourceName
+      NetworkProfile : ResourceName option
+      Instances : ContainerInstanceConfig list }
     interface IBuilder with
-        member this.DependencyName = this.ContainerGroupName.ResourceName
+        member this.DependencyName = this.Name
         member this.BuildResources location existingResources = [
-            let container =
-                {| Name = this.Name
-                   Image = this.Image
-                   Ports = this.Ports
-                   Cpu = this.Cpu
-                   Memory = this.Memory |}
-            match this.ContainerGroupName with
-            | AutomaticallyCreated groupName ->
-                { Location = location
-                  Name = groupName
-                  ContainerInstances = [ container ]
-                  OsType = this.OsType.ToString()
-                  RestartPolicy = this.RestartPolicy
-                  IpAddress = this.IpAddress
-                  NetworkProfile = this.NetworkProfile
-                }
-            | External containerGroupName ->
-                existingResources
-                |> Helpers.mergeResource containerGroupName (fun group -> { group with ContainerInstances = group.ContainerInstances @ [ container ] })
-            | AutomaticPlaceholder ->
-                failwith "Container Group Name has not been set."
+            { Location = location
+              Name = this.Name
+              ContainerInstances = [
+                  for instance in this.Instances do
+                    {| Name = instance.Name
+                       Image = instance.Image
+                       Ports = instance.Ports
+                       Cpu = instance.Cpu
+                       Memory = instance.Memory |} ]
+              OperatingSystem = this.OperatingSystem
+              RestartPolicy = this.RestartPolicy
+              IpAddress = this.IpAddress
+              NetworkProfile = this.NetworkProfile }
         ]
 
-type ContainerBuilder() =
+type ContainerGroupBuilder() =
+    member __.Yield _ =
+      { Name = ResourceName.Empty
+        OperatingSystem = Linux
+        RestartPolicy = AlwaysRestart
+        IpAddress = { Type = PublicAddress; Ports = [] }
+        NetworkProfile = None
+        Instances = [] }
+    [<CustomOperation "name">]
+    /// Sets the name of the container group.
+    member __.Name(state:ContainerGroupConfig, name) = { state with Name = name }
+    member this.Name(state:ContainerGroupConfig, name) = this.Name(state, ResourceName name)
+    /// Sets the OS type (default Linux)
+    [<CustomOperation "operating_system">]
+    member __.OsType(state:ContainerGroupConfig, os) = { state with OperatingSystem = os }
+    /// Sets the restart policy (default Always)
+    [<CustomOperation "restart_policy">]
+    member __.RestartPolicy(state:ContainerGroupConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
+    /// Sets the IP addresss to a public address with a DNS label
+    [<CustomOperation "public_dns">]
+    member __.PublicDns(state:ContainerGroupConfig, dnsLabel:string, ports) = { state with IpAddress = { Type = PublicAddressWithDns dnsLabel; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    /// Sets the IP addresss to a private address that is statically assigned
+    [<CustomOperation "private_static_ip">]
+    member __.PrivateStaticIp(state:ContainerGroupConfig, ip:string, ports) = { state with IpAddress = { Type = PrivateAddressWithIp (System.Net.IPAddress.Parse ip); Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    /// Sets the IP addresss to a private address assigned by the vnet
+    [<CustomOperation "private_ip">]
+    member __.PrivateIp(state:ContainerGroupConfig, ports) = { state with IpAddress = { Type = PrivateAddress; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    /// Sets a network profile for the container's group.
+    [<CustomOperation "network_profile">]
+    member __.NetworkProfile(state:ContainerGroupConfig, networkProfileName:string) = { state with NetworkProfile = Some (ResourceName networkProfileName) }
+    /// Adds a TCP port to be externally accessible
+    [<CustomOperation "add_tcp_port">]
+    member __.AddTcpPort(state:ContainerGroupConfig, port) = { state with IpAddress = { state.IpAddress with Ports = {| Protocol= TCP; Port = port |} :: state.IpAddress.Ports } }
+    /// Adds a UDP port to be externally accessible
+    [<CustomOperation "add_udp_port">]
+    member __.AddUdpPort(state:ContainerGroupConfig, port) = { state with IpAddress = { state.IpAddress with Ports = {| Protocol= UDP; Port = port |} :: state.IpAddress.Ports } }
+    /// Adds a collection of container instances to this group
+    [<CustomOperation "add_instances">]
+    member __.AddInstances(state:ContainerGroupConfig, instances) = { state with Instances = state.Instances @ (Seq.toList instances) }
+
+type ContainerInstanceBuilder() =
     member __.Yield _ =
       { Name = ResourceName.Empty
         Image = ""
         Ports = []
         Cpu = 1
-        Memory = 1.5<Gb>
-        ContainerGroupName = AutomaticPlaceholder
-        OsType = Linux
-        RestartPolicy = Always
-        IpAddress = { Type = PublicAddress; Ports = [] }
-        NetworkProfile = None }
-    member __.Run state =
-        { state with
-            ContainerGroupName =
-                match state.ContainerGroupName.ResourceNameOpt with
-                | Some _ -> state.ContainerGroupName
-                | None -> AutomaticallyCreated (ResourceName (sprintf "%s-group" state.Name.Value))
-        }
+        Memory = 1.5<Gb> }
     /// Sets the name of the container instance
     [<CustomOperation "name">]
-    member __.Name(state:ContainerConfig, name) = { state with Name = ResourceName name }
+    member __.Name(state:ContainerInstanceConfig, name) = { state with Name = name }
+    member this.Name(state:ContainerInstanceConfig, name) = this.Name(state, ResourceName name)
     /// Sets the container image.
     [<CustomOperation "image">]
-    member __.Image (state:ContainerConfig, image) = { state with Image = image }
+    member __.Image (state:ContainerInstanceConfig, image) = { state with Image = image }
     /// Sets the ports the container exposes
     [<CustomOperation "ports">]
-    member __.Ports (state:ContainerConfig, ports) = { state with Ports = ports }
+    member __.Ports (state:ContainerInstanceConfig, ports) = { state with Ports = ports }
     /// Sets the maximum CPU cores the container may use
     [<CustomOperationAttribute "cpu_cores">]
-    member __.CpuCount (state:ContainerConfig, cpuCount) = { state with Cpu = cpuCount }
+    member __.CpuCount (state:ContainerInstanceConfig, cpuCount) = { state with Cpu = cpuCount }
     /// Sets the maximum gigabytes of memory the container may use
     [<CustomOperationAttribute "memory">]
-    member __.Memory (state:ContainerConfig, memory) = { state with Memory = memory }
-    [<CustomOperation "group_name">]
-    /// Sets the name of the container group.
-    member __.GroupName(state:ContainerConfig, name) = { state with ContainerGroupName = AutomaticallyCreated name }
-    member this.GroupName(state:ContainerConfig, name) = this.GroupName(state, ResourceName name)
-    /// Links this container to an already-created container group.
-    [<CustomOperation "link_to_container_group">]
-    member __.LinkToGroup(state:ContainerConfig, group:ContainerConfig) = { state with ContainerGroupName = External group.GroupName }
-    /// Sets the OS type (default Linux)
-    [<CustomOperation "os_type">]
-    member __.OsType(state:ContainerConfig, osType) = { state with OsType = osType }
-    /// Sets the restart policy (default Always)
-    [<CustomOperation "restart_policy">]
-    member __.RestartPolicy(state:ContainerConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
-    /// Sets the IP addresss (default Public)
-    [<System.Obsolete("Prefer to use public_dns, private_ip, or private_static_ip")>]
-    [<CustomOperation "ip_address">]
-    member __.IpAddress(state:ContainerConfig, addressType, ports) = { state with IpAddress = { Type = addressType; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
-    /// Sets the IP addresss to a public address with a DNS label
-    [<CustomOperation "public_dns">]
-    member __.PublicDns(state:ContainerConfig, dnsLabel:string, ports) = { state with IpAddress = { Type = PublicAddressWithDns dnsLabel; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
-    /// Sets the IP addresss to a private address that is statically assigned
-    [<CustomOperation "private_static_ip">]
-    member __.PrivateStaticIp(state:ContainerConfig, ip:string, ports) = { state with IpAddress = { Type = PrivateAddressWithIp (System.Net.IPAddress.Parse ip); Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
-    /// Sets the IP addresss to a private address assigned by the vnet
-    [<CustomOperation "private_ip">]
-    member __.PrivateIp(state:ContainerConfig, ports) = { state with IpAddress = { Type = PrivateAddress; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
-    /// Sets a network profile for the container's group.
-    [<CustomOperation "network_profile">]
-    member __.NetworkProfile(state:ContainerConfig, networkProfileName:string) = { state with NetworkProfile = Some (ResourceName networkProfileName) }
-    /// Adds a TCP port to be externally accessible
-    [<CustomOperation "add_tcp_port">]
-    member __.AddTcpPort(state:ContainerConfig, port) = { state with IpAddress = { state.IpAddress with Ports = {| Protocol= TCP; Port = port |} :: state.IpAddress.Ports } }
-    /// Adds a UDP port to be externally accessible
-    [<CustomOperation "add_udp_port">]
-    member __.AddUdpPort(state:ContainerConfig, port) = { state with IpAddress = { state.IpAddress with Ports = {| Protocol= UDP; Port = port |} :: state.IpAddress.Ports } }
-let container = ContainerBuilder()
+    member __.Memory (state:ContainerInstanceConfig, memory) = { state with Memory = memory }
 
-type ContainerNetworkInterfaceIpConfig =
-    {
-        Subnet : string
-    }
-type ContainerNetworkInterfaceConfiguration =
-    {
-        IpConfigs : ContainerNetworkInterfaceIpConfig list
-    }
+let containerGroup = ContainerGroupBuilder()
+let containerInstance = ContainerInstanceBuilder()
+
+type ContainerNetworkInterfaceIpConfig = { Subnet : string }
+type ContainerNetworkInterfaceConfiguration = { IpConfigs : ContainerNetworkInterfaceIpConfig list }
+
 type NetworkProfileConfig =
-    {
-        Name : ResourceName
-        ContainerNetworkInterfaceConfigurations : ContainerNetworkInterfaceConfiguration list
-        VirtualNetwork : ResourceName
-    }
+    { Name : ResourceName
+      ContainerNetworkInterfaceConfigurations : ContainerNetworkInterfaceConfiguration list
+      VirtualNetwork : ResourceName }
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location _ = [

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -30,6 +30,7 @@ type ContainerGroupConfig =
       IpAddress : ContainerGroupIpAddress
       /// Name of the network profile for this container's group.
       NetworkProfile : ResourceName option
+      /// The instances in this container group.
       Instances : ContainerInstanceConfig list }
     interface IBuilder with
         member this.DependencyName = this.Name
@@ -54,9 +55,17 @@ type ContainerGroupBuilder() =
       { Name = ResourceName.Empty
         OperatingSystem = Linux
         RestartPolicy = AlwaysRestart
-        IpAddress = { Type = PublicAddress; Ports = [] }
+        IpAddress = { Type = PublicAddress; Ports = Set.empty }
         NetworkProfile = None
         Instances = [] }
+    member this.Run (state:ContainerGroupConfig) =
+        state.Instances
+        |> List.collect(fun i -> i.Ports)
+        |> List.fold (fun (state:ContainerGroupConfig) port ->
+            { state with IpAddress = { state.IpAddress with Ports = state.IpAddress.Ports.Add {| Protocol = TCP; Port = port |} } }) state
+
+    member __.AddTcpPort(state:ContainerGroupConfig, port) = { state with IpAddress = { state.IpAddress with Ports = state.IpAddress.Ports.Add {| Protocol = TCP; Port = port |} } }
+
     [<CustomOperation "name">]
     /// Sets the name of the container group.
     member __.Name(state:ContainerGroupConfig, name) = { state with Name = name }
@@ -67,24 +76,27 @@ type ContainerGroupBuilder() =
     /// Sets the restart policy (default Always)
     [<CustomOperation "restart_policy">]
     member __.RestartPolicy(state:ContainerGroupConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
+    member private _.SetIpAddress(state:ContainerGroupConfig, ipAddressType, ports) =
+      { state with
+          IpAddress =
+            { Type = ipAddressType
+              Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Set } }
+
     /// Sets the IP addresss to a public address with a DNS label
     [<CustomOperation "public_dns">]
-    member __.PublicDns(state:ContainerGroupConfig, dnsLabel:string, ports) = { state with IpAddress = { Type = PublicAddressWithDns dnsLabel; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    member this.PublicDns(state, dnsLabel, ports) = this.SetIpAddress(state, PublicAddressWithDns dnsLabel, ports)
     /// Sets the IP addresss to a private address that is statically assigned
     [<CustomOperation "private_static_ip">]
-    member __.PrivateStaticIp(state:ContainerGroupConfig, ip:string, ports) = { state with IpAddress = { Type = PrivateAddressWithIp (System.Net.IPAddress.Parse ip); Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    member this.PrivateStaticIp(state, ip, ports) = this.SetIpAddress(state, PrivateAddressWithIp (System.Net.IPAddress.Parse ip), ports)
     /// Sets the IP addresss to a private address assigned by the vnet
     [<CustomOperation "private_ip">]
-    member __.PrivateIp(state:ContainerGroupConfig, ports) = { state with IpAddress = { Type = PrivateAddress; Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Seq.toList } }
+    member this.PrivateIp(state:ContainerGroupConfig, ports) = this.SetIpAddress(state, PrivateAddress, ports)
     /// Sets a network profile for the container's group.
     [<CustomOperation "network_profile">]
     member __.NetworkProfile(state:ContainerGroupConfig, networkProfileName:string) = { state with NetworkProfile = Some (ResourceName networkProfileName) }
-    /// Adds a TCP port to be externally accessible
-    [<CustomOperation "add_tcp_port">]
-    member __.AddTcpPort(state:ContainerGroupConfig, port) = { state with IpAddress = { state.IpAddress with Ports = {| Protocol= TCP; Port = port |} :: state.IpAddress.Ports } }
     /// Adds a UDP port to be externally accessible
     [<CustomOperation "add_udp_port">]
-    member __.AddUdpPort(state:ContainerGroupConfig, port) = { state with IpAddress = { state.IpAddress with Ports = {| Protocol= UDP; Port = port |} :: state.IpAddress.Ports } }
+    member __.AddUdpPort(state:ContainerGroupConfig, port) = { state with IpAddress = { state.IpAddress with Ports = state.IpAddress.Ports.Add {| Protocol = UDP; Port = port |} } }
     /// Adds a collection of container instances to this group
     [<CustomOperation "add_instances">]
     member __.AddInstances(state:ContainerGroupConfig, instances) = { state with Instances = state.Instances @ (Seq.toList instances) }
@@ -96,20 +108,20 @@ type ContainerInstanceBuilder() =
         Ports = []
         Cpu = 1
         Memory = 1.5<Gb> }
-    /// Sets the name of the container instance
+    /// Sets the name of the container instance.
     [<CustomOperation "name">]
     member __.Name(state:ContainerInstanceConfig, name) = { state with Name = name }
     member this.Name(state:ContainerInstanceConfig, name) = this.Name(state, ResourceName name)
-    /// Sets the container image.
+    /// Sets the image of the container instance.
     [<CustomOperation "image">]
     member __.Image (state:ContainerInstanceConfig, image) = { state with Image = image }
-    /// Sets the ports the container exposes
+    /// Sets the ports the container instance exposes. These will automatically be applied to the container group.
     [<CustomOperation "ports">]
     member __.Ports (state:ContainerInstanceConfig, ports) = { state with Ports = ports }
-    /// Sets the maximum CPU cores the container may use
+    /// Sets the maximum CPU cores the container instance may use
     [<CustomOperationAttribute "cpu_cores">]
     member __.CpuCount (state:ContainerInstanceConfig, cpuCount) = { state with Cpu = cpuCount }
-    /// Sets the maximum gigabytes of memory the container may use
+    /// Sets the maximum gigabytes of memory the container instance may use
     [<CustomOperationAttribute "memory">]
     member __.Memory (state:ContainerInstanceConfig, memory) = { state with Memory = memory }
 

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -445,7 +445,7 @@ module Sql =
                 c
 
 module ContainerGroup =
-    type RestartPolicy = Never | Always | OnFailure
+    type RestartPolicy = NeverRestart | AlwaysRestart | RestartOnFailure
     type IpAddressType =
         | PublicAddress
         | PublicAddressWithDns of DnsName:string
@@ -542,7 +542,7 @@ module Maps =
 
 module SignalR =
     type Sku = Free | Standard
-  
+
 module DataLake =
     type Sku =
     | Consumption

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -445,6 +445,7 @@ module Sql =
                 c
 
 module ContainerGroup =
+    type PortAccess = PublicPort | InternalPort
     type RestartPolicy = NeverRestart | AlwaysRestart | RestartOnFailure
     type IpAddressType =
         | PublicAddress

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -9,22 +9,14 @@ open Microsoft.Azure.Management.ContainerInstance.Models
 open Microsoft.Rest
 open System
 
-let nginx = container {
-    group_name "appWithHttpFrontend"
-    os_type Linux
-    add_tcp_port 80us
-    add_tcp_port 443us
-    restart_policy Always
-
+let nginx = containerInstance {
     name "nginx"
     image "nginx:1.17.6-alpine"
     ports [ 80us; 443us ]
     memory 0.5<Gb>
     cpu_cores 1
 }
-
-let fsharpApp = container {
-    link_to_container_group nginx
+let fsharpApp = containerInstance {
     name "fsharpApp"
     image "myapp:1.7.2"
     ports [ 8080us ]
@@ -37,41 +29,49 @@ let dummyClient = new ContainerInstanceManagementClient (Uri "http://management.
 
 let tests = testList "Container Group" [
     test "Single container in a group is correctly created" {
+        let group = containerGroup {
+            name "appWithHttpFrontend"
+            operating_system Linux
+            add_tcp_port 80us
+            add_tcp_port 443us
+            restart_policy AlwaysRestart
+            add_instances [ nginx ]
+        }
         let group =
-            arm {
-                add_resource nginx
-            }
+            arm { add_resource group }
             |> findAzureResources<ContainerGroup> dummyClient.SerializationSettings
             |> List.head
 
         group.Validate()
 
-        Expect.equal group.Name "appWithHttpFrontend" ""
-        Expect.equal group.IpAddress.Ports.[0].PortProperty 443 ""
-        Expect.equal group.IpAddress.Ports.[1].PortProperty 80 ""
-        Expect.equal group.OsType "Linux" ""
+        Expect.equal group.Name "appWithHttpFrontend" "Group name is not set correctly."
+        Expect.equal group.IpAddress.Ports.[0].PortProperty 443 "Port #1 should be 443"
+        Expect.equal group.IpAddress.Ports.[1].PortProperty 80 "Port #2 should be 80"
+        Expect.equal group.OsType "Linux" "OS should be Linux"
 
-        Expect.equal group.Containers.[0].Image "nginx:1.17.6-alpine" ""
-        Expect.equal group.Containers.[0].Name "nginx" ""
-        Expect.equal group.Containers.[0].Resources.Requests.MemoryInGB 0.5 ""
-        Expect.equal group.Containers.[0].Resources.Requests.Cpu 1.0 ""
+        Expect.equal group.Containers.[0].Image "nginx:1.17.6-alpine" "Incorrect image"
+        Expect.equal group.Containers.[0].Name "nginx" "Incorrect instance name"
+        Expect.equal group.Containers.[0].Resources.Requests.MemoryInGB 0.5 "Incorrect memory"
+        Expect.equal group.Containers.[0].Resources.Requests.Cpu 1.0 "Incorrect CPU"
     }
 
-    test "Multiple containers correctly link to a common container group" {
+    test "Multiple containers are correctly added" {
+        let group = containerGroup {
+            name "test"
+            add_instances [ nginx; fsharpApp ]
+        }
+
         let group =
-            arm {
-                add_resource nginx
-                add_resource fsharpApp
-            }
+            arm { add_resource group }
             |> findAzureResources<ContainerGroup> dummyClient.SerializationSettings
             |> List.head
         group.Validate()
-        Expect.equal group.Containers.Count 2 ""
-        Expect.equal group.Containers.[0].Name "nginx" ""
-        Expect.equal group.Containers.[1].Name "fsharpapp" ""
-        Expect.equal group.Containers.[1].Resources.Requests.MemoryInGB 1.5 ""
-        Expect.equal group.Containers.[1].Resources.Requests.Cpu 2.0 ""
-        Expect.equal group.Containers.[1].Ports.[0].Port 8080 ""
+        Expect.equal group.Containers.Count 2 "Should be two containers"
+        Expect.equal group.Containers.[0].Name "nginx" "Nginx should be the first container"
+        Expect.equal group.Containers.[1].Name "fsharpapp" "FSharpApp should the second container"
+        Expect.equal group.Containers.[1].Resources.Requests.MemoryInGB 1.5 "Should have 1.5gb on FSharp App"
+        Expect.equal group.Containers.[1].Resources.Requests.Cpu 2.0 "Should have 2 CPUs on FSharp App"
+        Expect.equal group.Containers.[1].Ports.[0].Port 8080 "FSharp App port #1 should be 8080"
     }
 ]
 

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -12,14 +12,15 @@ open System
 let nginx = containerInstance {
     name "nginx"
     image "nginx:1.17.6-alpine"
-    ports [ 80us; 443us ]
+    add_ports PublicPort [ 80us; 443us ]
+    add_ports InternalPort [ 9090us; ]
     memory 0.5<Gb>
     cpu_cores 1
 }
 let fsharpApp = containerInstance {
     name "fsharpApp"
     image "myapp:1.7.2"
-    ports [ 8080us ]
+    add_ports PublicPort [ 8080us ]
     memory 1.5<Gb>
     cpu_cores 2
 }
@@ -27,21 +28,24 @@ let fsharpApp = containerInstance {
 /// Client instance needed to get the serializer settings.
 let dummyClient = new ContainerInstanceManagementClient (Uri "http://management.azure.com", TokenCredentials "NotNullOrWhiteSpace")
 
+let asAzureResource (group:ContainerGroupConfig) =
+    arm { add_resource group }
+    |> findAzureResources<ContainerGroup> dummyClient.SerializationSettings
+    |> List.head
+    |> fun r ->
+        r.Validate()
+        r
+
 let tests = testList "Container Group" [
     test "Single container in a group is correctly created" {
-        let group = containerGroup {
-            name "appWithHttpFrontend"
-            operating_system Linux
-            restart_policy AlwaysRestart
-            add_udp_port 123us
-            add_instances [ nginx ]
-        }
         let group =
-            arm { add_resource group }
-            |> findAzureResources<ContainerGroup> dummyClient.SerializationSettings
-            |> List.head
-
-        group.Validate()
+            containerGroup {
+                name "appWithHttpFrontend"
+                operating_system Linux
+                restart_policy AlwaysRestart
+                add_udp_port 123us
+                add_instances [ nginx ]
+            } |> asAzureResource
 
         Expect.equal group.Name "appWithHttpFrontend" "Group name is not set correctly."
         Expect.equal group.OsType "Linux" "OS should be Linux"
@@ -52,43 +56,43 @@ let tests = testList "Container Group" [
         Expect.equal containerInstance.Name "nginx" "Incorrect instance name"
         Expect.equal containerInstance.Resources.Requests.MemoryInGB 0.5 "Incorrect memory"
         Expect.equal containerInstance.Resources.Requests.Cpu 1.0 "Incorrect CPU"
-        Expect.equal containerInstance.Ports.[0].Port 80 "Incorrect port"
-        Expect.equal containerInstance.Ports.[1].Port 443 "Incorrect port"
+        let ports = containerInstance.Ports |> Seq.map(fun p -> p.Port) |> Seq.toList
+        Expect.equal ports [ 80; 443; 9090 ] "Incorrect ports on container"
     }
 
     test "Multiple containers are correctly added" {
-        let group = containerGroup {
-            name "test"
-            add_instances [ nginx; fsharpApp ]
-        }
-
-        let group =
-            arm { add_resource group }
-            |> findAzureResources<ContainerGroup> dummyClient.SerializationSettings
-            |> List.head
-
-        group.Validate()
+        let group = containerGroup { add_instances [ nginx; fsharpApp ] } |> asAzureResource
 
         Expect.hasLength group.Containers 2 "Should be two containers"
         Expect.equal group.Containers.[0].Name "nginx" "Incorrect container name"
-        Expect.equal group.Containers.[1].Name "fsharpapp" "Incorrect container name "
+        Expect.equal group.Containers.[1].Name "fsharpapp" "Incorrect container name"
         Expect.equal group.Containers.[1].Resources.Requests.MemoryInGB 1.5 "Incorrect memory"
         Expect.equal group.Containers.[1].Resources.Requests.Cpu 2.0 "Incorrect CPU count"
-        Expect.equal group.Containers.[1].Ports.[0].Port 8080 "Incorrect FSharp App port"
     }
 
-    test "Implicitly creates ports for group based on instances" {
-        let group = containerGroup {
-            name "test"
-            add_instances [ nginx ]
-        }
-        let group =
-            arm { add_resource group }
-            |> findAzureResources<ContainerGroup> dummyClient.SerializationSettings
-            |> List.head
+    test "Implicitly creates public ports for group based on instances" {
+        let group = containerGroup { add_instances [ nginx ] } |> asAzureResource
 
-        let ports = group.IpAddress.Ports |> Seq.map(fun p -> p.PortProperty) |> Set
-        Expect.equal ports (Set [ 443; 80 ]) "Incorrect implicitly created ports"
+        let ports = group.IpAddress.Ports |> Seq.map(fun p -> p.PortProperty) |> Seq.toList
+        Expect.equal ports ([ 80; 443 ]) "Incorrect implicitly created public ports"
+        Expect.hasLength group.Containers.[0].Ports 3 "Incorrect number of private port"
+    }
+
+    test "Does not create two ports with the same number across public and private" {
+        let group =
+            containerGroup {
+                add_instances [
+                    containerInstance {
+                        name "foo"
+                        add_ports PublicPort [ 123us ]
+                        add_ports InternalPort [ 123us ]
+                    }
+                ]
+            } |> asAzureResource
+
+        Expect.isEmpty group.IpAddress.Ports "Should not be any public ports"
+        Expect.equal group.Containers.[0].Ports.[0].Port 123 "Incorrect private port"
+        Expect.hasLength group.Containers.[0].Ports 1 "Should only be one port"
     }
 ]
 


### PR DESCRIPTION
Based on our chat on Friday @ninjarobot, this splits container groups and instances back out. I've looked at the naming and the term "container group" actually rarely shows up in the documentation - the service (somewhat misleadingly) is called Container Instance, or Container Instances!

I'm wondering whether it makes sense to rename the "group" one to `containerInstance` and the child to `containerImage` or similar?