### PR TITLE
Make Cosmos Properties ARM expressions

### DIFF
--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -24,10 +24,12 @@ type CosmosDbConfig =
       PublicNetworkAccess : FeatureFlag
       FreeTier : bool }
     member this.PrimaryKey =
-        sprintf "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', '%s'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryMasterKey]"
+        sprintf "listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', '%s'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryMasterKey"
             this.AccountName.ResourceName.Value
+            |> ArmExpression
     member this.Endpoint =
-        sprintf "[reference(concat('Microsoft.DocumentDb/databaseAccounts/', '%s')).documentEndpoint]" this.AccountName.ResourceName.Value
+        sprintf "reference(concat('Microsoft.DocumentDb/databaseAccounts/', '%s')).documentEndpoint" this.AccountName.ResourceName.Value
+        |> ArmExpression
     interface IBuilder with
         member this.DependencyName = this.AccountName.ResourceName
         member this.BuildResources location = [

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -12,7 +12,7 @@ open System
 let tests = testList "Cosmos" [
     test "Cosmos container should ignore duplicate unique keys" {
 
-        let container = 
+        let container =
             cosmosContainer {
                 name "people"
                 partition_key [ "/id" ] CosmosDb.Hash
@@ -24,5 +24,10 @@ let tests = testList "Cosmos" [
         Expect.equal container.UniqueKeys.Count 2 "There should be 2 unique keys."
         Expect.contains container.UniqueKeys ["/FirstName"] "UniqueKeys should contain /FirstName"
         Expect.contains container.UniqueKeys ["/LastName"] "UniqueKeys should contain /LastName"
+    }
+    test "DB properties are correctly evaluated" {
+        let db = cosmosDb { name "test" }
+        Expect.equal "[reference(concat('Microsoft.DocumentDb/databaseAccounts/', 'test-server')).documentEndpoint]" (db.Endpoint.Eval()) "Endpoint is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-server'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryMasterKey]" (db.PrimaryKey.Eval()) "Primary Key is incorrect"
     }
 ]


### PR DESCRIPTION
Fixes #264 - Cosmos properties weren't being returned as ARM expressions.