### PR TITLE
Ensure ARM Expressions don't double-wrap.

### DIFF
--- a/src/Farmer/Arm/Devices.fs
+++ b/src/Farmer/Arm/Devices.fs
@@ -90,7 +90,7 @@ type ProvisioningServices =
         sprintf "concat('HostName=%s.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=',%s)"
             this.IotHubName.Value
             this.IotHubKey.Value
-        |> ArmExpression
+        |> ArmExpression.create
     member this.IotHubPath =
         sprintf "%s.azure-devices.net" this.IotHubName.Value
     interface IArmResource with

--- a/src/Farmer/ArmBuilder.fs
+++ b/src/Farmer/ArmBuilder.fs
@@ -20,7 +20,7 @@ module Json =
 
 module Subscription =
     /// Gets an ARM expression pointing to the tenant id of the current subscription.
-    let TenantId = ArmExpression "subscription().tenantid"
+    let TenantId = ArmExpression.create "subscription().tenantid"
 
 /// Represents all configuration information to generate an ARM template.
 type ArmConfig =

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -16,7 +16,7 @@ let tryCreateAppInsightsName aiName rootName =
 
 let instrumentationKey (ResourceName accountName) =
     sprintf "reference('Microsoft.Insights/components/%s').InstrumentationKey" accountName
-    |> ArmExpression
+    |> ArmExpression.create
 
 type AppInsightsConfig =
     { Name : ResourceName }

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -12,7 +12,7 @@ type ContainerRegistryConfig =
       AdminUserEnabled : bool }
     member this.LoginServer =
         (sprintf "reference(resourceId('Microsoft.ContainerRegistry/registries', '%s'),'2019-05-01').loginServer" this.Name.Value)
-        |> ArmExpression
+        |> ArmExpression.create
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -26,10 +26,10 @@ type CosmosDbConfig =
     member this.PrimaryKey =
         sprintf "listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', '%s'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryMasterKey"
             this.AccountName.ResourceName.Value
-            |> ArmExpression
+            |> ArmExpression.create
     member this.Endpoint =
         sprintf "reference(concat('Microsoft.DocumentDb/databaseAccounts/', '%s')).documentEndpoint" this.AccountName.ResourceName.Value
-        |> ArmExpression
+        |> ArmExpression.create
     interface IBuilder with
         member this.DependencyName = this.AccountName.ResourceName
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -29,7 +29,7 @@ type FunctionsConfig =
     /// Gets the system-created managed principal for the functions instance. It must have been enabled using enable_managed_identity.
     member this.SystemIdentity =
         sprintf "reference(resourceId('Microsoft.Web/sites', '%s'), '2019-08-01', 'full').identity.principalId" this.Name.Value
-        |> ArmExpression
+        |> ArmExpression.create
         |> PrincipalId
     /// Gets the ARM expression path to the publishing password of this functions app.
     member this.PublishingPassword = publishingPassword this.Name
@@ -44,11 +44,11 @@ type FunctionsConfig =
     /// Gets the default key for the functions site
     member this.DefaultKey =
         sprintf "listkeys(concat(resourceId('Microsoft.Web/sites', '%s'), '/host/default/'),'2016-08-01').functionKeys.default" this.Name.Value
-        |> ArmExpression
+        |> ArmExpression.create
     /// Gets the master key for the functions site
     member this.MasterKey =
         sprintf "listkeys(concat(resourceId('Microsoft.Web/sites', '%s'), '/host/default/'),'2016-08-01').masterKey" this.Name.Value
-        |> ArmExpression
+        |> ArmExpression.create
     /// Gets the Service Plan name for this functions app.
     member this.ServicePlan = this.ServicePlanName.ResourceName
     /// Gets the App Insights name for this functions app, if it exists.

--- a/src/Farmer/Builders/Builders.IotHub.fs
+++ b/src/Farmer/Builders/Builders.IotHub.fs
@@ -15,14 +15,14 @@ type IotHubConfig =
       DeviceProvisioning : FeatureFlag }
     member private this.BuildKey (policy:Policy) =
         sprintf "listKeys('%s','2019-03-22').value[%d].primaryKey" this.Name.Value policy.Index
-    member this.GetKey policy = policy |> this.BuildKey |> ArmExpression
+    member this.GetKey policy = policy |> this.BuildKey |> ArmExpression.create
     member this.GetConnectionString policy =
         let endpoint = sprintf "reference('%s').eventHubEndpoints.events.endpoint" this.Name.Value
         sprintf "concat('Endpoint=',%s,';SharedAccessKeyName=%s;SharedAccessKey=',%s)"
             endpoint
             (policy.ToString().ToLower())
             (this.BuildKey policy)
-        |> ArmExpression
+        |> ArmExpression.create
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -141,13 +141,13 @@ type KeyVaultConfig =
 
 type AccessPolicyBuilder() =
     member __.Yield _ =
-        { ObjectId = ArmExpression (string Guid.Empty)
+        { ObjectId = ArmExpression.create (string Guid.Empty)
           ApplicationId = None
           Permissions = {| Keys = Set.empty; Secrets = Set.empty; Certificates = Set.empty; Storage = Set.empty |} }
     /// Sets the Object ID of the permission set.
     [<CustomOperation "object_id">]
     member __.ObjectId(state:AccessPolicyConfig, objectId:ArmExpression) = { state with ObjectId = objectId }
-    member this.ObjectId(state:AccessPolicyConfig, objectId:Guid) = this.ObjectId(state, ArmExpression (sprintf "string('%O')" objectId))
+    member this.ObjectId(state:AccessPolicyConfig, objectId:Guid) = this.ObjectId(state, ArmExpression.create (sprintf "string('%O')" objectId))
     member this.ObjectId(state:AccessPolicyConfig, (ObjectId objectId)) = this.ObjectId(state, objectId)
     member this.ObjectId(state:AccessPolicyConfig, objectId:string) = this.ObjectId(state, Guid.Parse objectId)
     member this.ObjectId(state:AccessPolicyConfig, PrincipalId principalId) = this.ObjectId(state, principalId)
@@ -237,7 +237,7 @@ type KeyVaultBuilder() =
     /// Sets the Tenant ID of the vault.
     [<CustomOperation "tenant_id">]
     member __.SetTenantId(state:KeyVaultBuilderState, tenantId) = { state with TenantId = tenantId }
-    member this.SetTenantId(state:KeyVaultBuilderState, tenantId) = this.SetTenantId(state, ArmExpression (sprintf "string('%O')" tenantId))
+    member this.SetTenantId(state:KeyVaultBuilderState, tenantId) = this.SetTenantId(state, ArmExpression.create (sprintf "string('%O')" tenantId))
     member this.SetTenantId(state:KeyVaultBuilderState, tenantId) = this.SetTenantId(state, Guid.Parse tenantId)
     /// Allows VM access to the vault.
     [<CustomOperation "enable_vm_access">]

--- a/src/Farmer/Builders/Builders.Redis.fs
+++ b/src/Farmer/Builders/Builders.Redis.fs
@@ -11,7 +11,7 @@ let internal buildRedisKey (ResourceName name) =
         "concat('%s.redis.cache.windows.net,abortConnect=false,ssl=true,password=', listKeys('%s', '2015-08-01').primaryKey)"
             name
             name
-    |> ArmExpression
+    |> ArmExpression.create
 
 type RedisConfig =
     { Name : ResourceName

--- a/src/Farmer/Builders/Builders.Search.fs
+++ b/src/Farmer/Builders/Builders.Search.fs
@@ -15,11 +15,11 @@ type SearchConfig =
     /// Gets an ARM expression for the admin key of the search instance.
     member this.AdminKey =
         sprintf "listAdminKeys('Microsoft.Search/searchServices/%s', '2015-08-19').primaryKey" this.Name.Value
-        |> ArmExpression
+        |> ArmExpression.create
     /// Gets an ARM expression for the query key of the search instance.
     member this.QueryKey =
         sprintf "listQueryKeys('Microsoft.Search/searchServices/%s', '2015-08-19').value[0].key" this.Name.Value
-        |> ArmExpression
+        |> ArmExpression.create
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -125,7 +125,7 @@ type ServiceBusConfig =
             "listkeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '%s', 'RootManageSharedAccessKey'), '2017-04-01').%s"
             sbNsName
             property
-        |> ArmExpression
+        |> ArmExpression.create
     member this.NamespaceDefaultConnectionString = this.GetKeyPath this.Name.Value "primaryConnectionString"
     member this.DefaultSharedAccessPolicyPrimaryKey = this.GetKeyPath this.Name.Value "primaryKey"
     interface IBuilder with

--- a/src/Farmer/Builders/Builders.SignalR.fs
+++ b/src/Farmer/Builders/Builders.SignalR.fs
@@ -22,8 +22,8 @@ type SignalRConfig =
               AllowedOrigins = this.AllowedOrigins }
         ]
     member this.Key =
-        sprintf "[listKeys(resourceId('Microsoft.SignalRService/SignalR', variables('%s')), providers('Microsoft.SignalRService','SignalR').apiVersions[0]).primaryConnectionString]" this.Name.Value
-        |> ArmExpression
+        sprintf "listKeys(resourceId('Microsoft.SignalRService/SignalR', '%s'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).primaryConnectionString" this.Name.Value
+        |> ArmExpression.create
 
 type SignalRBuilder() =
     member _.Yield _ =

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -12,7 +12,7 @@ let internal buildKey (ResourceName name) =
         "concat('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=', listKeys('%s', '2017-10-01').keys[0].value)"
             name
             name
-    |> ArmExpression
+    |> ArmExpression.create
 
 type StorageAccountConfig =
     { /// The name of the storage account.

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -37,7 +37,7 @@ type VmConfig =
 
     member this.NicName = makeResourceName this.Name "nic"
     member this.IpName = makeResourceName this.Name "ip"
-    member this.Hostname = sprintf "reference('%s').dnsSettings.fqdn" this.IpName.Value |> ArmExpression
+    member this.Hostname = sprintf "reference('%s').dnsSettings.fqdn" this.IpName.Value |> ArmExpression.create
 
     interface IBuilder with
         member this.DependencyName = this.Name

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -62,7 +62,7 @@ module AppSettings =
 
 let publishingPassword (ResourceName name) =
     sprintf "list(resourceId('Microsoft.Web/sites/config', '%s', 'publishingcredentials'), '2014-06-01').properties.publishingPassword" name
-    |> ArmExpression
+    |> ArmExpression.create
 
 type WebAppConfig =
     { Name : ResourceName
@@ -103,7 +103,7 @@ type WebAppConfig =
     /// Gets the system-created managed principal for the web app. It must have been enabled using enable_managed_identity.
     member this.SystemIdentity =
         sprintf "reference(resourceId('Microsoft.Web/sites', '%s'), '2019-08-01', 'full').identity.principalId" this.Name.Value
-        |> ArmExpression
+        |> ArmExpression.create
         |> PrincipalId
     member this.Endpoint =
         sprintf "%s.azurewebsites.net" this.Name.Value

--- a/src/Tests/SignalR.fs
+++ b/src/Tests/SignalR.fs
@@ -23,12 +23,12 @@ let tests = testList "SignalR" [
             arm { add_resource mySignalR }
             |> findAzureResources<SignalRResource> client.SerializationSettings
             |> List.head
-  
+
         resource.Validate()
         Expect.equal resource.Name "my-signalr" "Name does not match"
         Expect.equal resource.Sku.Name "Free_F1" "SKU does not match"
     }
-  
+
     test "Can create a SignalR account with specific allowed origins" {
         let resource =
             let mySignalR =
@@ -40,7 +40,7 @@ let tests = testList "SignalR" [
             arm { add_resource mySignalR }
             |> findAzureResources<SignalRResource> client.SerializationSettings
             |> List.head
-  
+
         resource.Validate()
         Expect.equal resource.Name "my-signalr" "Name does not match"
         Expect.equal resource.Sku.Name "Free_F1" "SKU does not match"
@@ -49,7 +49,7 @@ let tests = testList "SignalR" [
             [ "https://github.com"; "https://duckduckgo.com" ]
             "Missing some or all allowed origins"
     }
-    
+
     test "Can create a SignalR account with specific capacity" {
         let resource =
             let mySignalR =
@@ -61,10 +61,15 @@ let tests = testList "SignalR" [
             arm { add_resource mySignalR }
             |> findAzureResources<SignalRResource> client.SerializationSettings
             |> List.head
-  
+
         resource.Validate()
         Expect.equal resource.Name "my-signalr" "Name does not match"
         Expect.equal resource.Sku.Name "Standard_S1" "SKU does not match"
         Expect.equal resource.Sku.Capacity (Nullable 10) "Capacity does not match"
+    }
+
+    test "Key is correctly emitted" {
+        let mySignalR = signalR { name "my-signalr" }
+        Expect.equal "[listKeys(resourceId('Microsoft.SignalRService/SignalR', 'my-signalr'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).primaryConnectionString]" (mySignalR.Key.Eval()) "Key is incorrect"
     }
 ]

--- a/src/Tests/Template.fs
+++ b/src/Tests/Template.fs
@@ -153,4 +153,12 @@ let tests = testList "Template" [
         let id = rid.Eval()
         Expect.equal id "[resourceId('5ed984d9-9e7e-4550-b73b-7af020a7620d','myGroup','Microsoft.Network/connections','test')]" "resourceId template function should match"
     }
+
+    test "Fails if ARM expression is already quoted" {
+        Expect.throws(fun () -> ArmExpression.create "[test]" |> ignore ) "Should fail on quoted ARM expression"
+    }
+
+    test "Does not fail if ARM expression contains an inner quote" {
+        Expect.equal "[foo[test]]" ((ArmExpression.create "foo[test]").Eval()) "Failed on quoted ARM expression"
+    }
 ]


### PR DESCRIPTION
Stop allowing us to directly create `ARMExpression` values and instead force us to use a factory method. Also fixed the SignalR key at the same time.