### PR TITLE
Display selected subscription when deploying.

### DIFF
--- a/src/Farmer/Result.fs
+++ b/src/Farmer/Result.fs
@@ -19,6 +19,7 @@ module Result =
     let ofExn thunk arg =
         try Ok(thunk arg)
         with ex -> Error (string ex)
+    let bindError onError = function Error s -> onError s | s -> s
 
     type ResultBuilder() =
         member __.Return(x) = Ok x


### PR DESCRIPTION
cc: @ctolkien. This now displays sub information on deploy, e.g.

```
Compatible version of Azure CLI 2.7.0 detected
Checking Azure CLI logged in status... logging you in.
Using subscription 'Your Sub' (1d9e2659-3a6v-4a2c-b152-96dbcc1c4af3).
```

```
Compatible version of Azure CLI 2.7.0 detected
Checking Azure CLI logged in status... you are already logged in, nothing to do.
Using subscription 'Your Sub' (1d9e2659-3a6v-4a2c-b152-96dbcc1c4af3).
```

Does this work for you?