### PR TITLE
Adding support for static website for Storage Account (Post-deploy task)

### DIFF
--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -33,7 +33,8 @@ The StorageAccount builder contains special commands that are executed *after* t
 
 | Keyword | Purpose |
 |-|-|
-| static_website | Supplying a index and error document path will instruct Farmer to enable static website feature and setup document paths once the ARM deployment is complete. |
+| static_website | Supplying an index and error document will instruct Farmer to enable static website feature and setup document paths once the ARM deployment is complete. |
+| static_website_with_content | Supplying an index, error document and path to content folder will instruct Farmer to enable static website feature, setup document paths and deploy content to $web container once the ARM deployment is complete. |
 
 #### Configuration Members
 
@@ -57,5 +58,6 @@ let storage = storageAccount {
     add_file_share "share1"
     add_file_share_with_quota "share2" 1024
     static_website "index.html" "error.html"
+    static_website_with_content "index.html" "error.html" "local/path/to/folder/content"
 }
 ```

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -28,11 +28,19 @@ The Storage Account builder creates storage accounts and their associated contai
 | add_queue | Adds a queue to the storage account. |
 | add_queues | Adds a list of queues to the storage account |
 
+#### Post-deployment Builder Keywords
+The StorageAccount builder contains special commands that are executed *after* the ARM deployment is completed.
+
+| Keyword | Purpose |
+|-|-|
+| static_website | Supplying a index and error document path will instruct Farmer to enable static website feature and setup document paths once the ARM deployment is complete. |
+
 #### Configuration Members
 
 | Member | Purpose |
 |-|-|
 | Key | Returns an ARM expression to retrieve the storage account's primary connection string. Useful for e.g. supplying the connection string to another resource e.g. KeyVault or an app setting in the App Service. |
+| WebsitePrimaryEndpoint | Returns the Primary endpoint for static website (if enabled). |
 
 #### Example
 
@@ -48,5 +56,6 @@ let storage = storageAccount {
     add_blob_container "myBlobContainer"
     add_file_share "share1"
     add_file_share_with_quota "share2" 1024
+    static_website "index.html" "error.html"
 }
 ```

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -14,7 +14,7 @@ type StorageAccount =
     { Name : ResourceName
       Location : Location
       Sku : Sku
-      StaticWebsite : (string * string) option }
+      StaticWebsite : (string * string * string option) option }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -28,10 +28,21 @@ type StorageAccount =
     interface IPostDeploy with
         member this.Run resourceGroupName =
             match this with
-            | { StaticWebsite = Some (indexDoc, errorDoc); Name = name } ->
+            | { StaticWebsite = Some (indexDoc, errorDoc, folder); Name = name } ->
                 printfn "Enabling static web site for storage account %s with Index document as %s, Error document as %s" name.Value indexDoc errorDoc 
-                Some (Deploy.Az.enableStaticWebsite name.Value indexDoc errorDoc)
+                Deploy.Az.enableStaticWebsite name.Value indexDoc errorDoc
+                |> Some
+                |> Option.bind (fun r1 ->
+                    folder
+                    |> Option.map (fun f ->
+                        printfn "Deploying content of %s folder to $web container for storage account %s" f name.Value
+                        Deploy.Az.batchUploadStaticWebsite name.Value f
+                    )
+                    |> Option.map (fun r2 -> [r1;r2] |> Result.sequence |> Result.map (String.concat ", "))
+                )
             | _ -> None
+                    
+                            
 module BlobServices =
     type Container =
         { Name : ResourceName

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -13,7 +13,8 @@ let queues = ResourceType "Microsoft.Storage/storageAccounts/queueServices/queue
 type StorageAccount =
     { Name : ResourceName
       Location : Location
-      Sku : Sku }
+      Sku : Sku
+      StaticWebsite : (string * string) option }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -24,7 +25,13 @@ type StorageAccount =
                apiVersion = "2018-07-01"
                location = this.Location.ArmValue
             |} :> _
-
+    interface IPostDeploy with
+        member this.Run resourceGroupName =
+            match this with
+            | { StaticWebsite = Some (indexDoc, errorDoc); Name = name } ->
+                printfn "Enabling static web site for storage account %s with Index document as %s, Error document as %s" name.Value indexDoc errorDoc 
+                Some (Deploy.Az.enableStaticWebsite name.Value indexDoc errorDoc)
+            | _ -> None
 module BlobServices =
     type Container =
         { Name : ResourceName

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -131,7 +131,8 @@ type FunctionsConfig =
             | AutomaticallyCreated resourceName ->
                 { StorageAccount.Name = resourceName
                   Location = location
-                  Sku = Storage.Standard_LRS }
+                  Sku = Storage.Standard_LRS
+                  StaticWebsite = None }
             | AutomaticPlaceholder | External _ ->
                 ()
             match this.AppInsightsName with

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -118,7 +118,8 @@ type VmConfig =
             | Some (AutomaticallyCreated account) ->
                 { Name = account
                   Location = location
-                  Sku = Storage.Standard_LRS }
+                  Sku = Storage.Standard_LRS
+                  StaticWebsite = None }
             | Some AutomaticPlaceholder
             | Some (External _)
             | None ->

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -118,6 +118,8 @@ module Az =
         az (sprintf "group delete --name %s --yes --no-wait" resourceGroup)
     let enableStaticWebsite name indexDoc errorDoc =
         az (sprintf "storage blob service-properties update --account-name %s --static-website  --index-document %s --404-document %s" name indexDoc errorDoc)
+    let batchUploadStaticWebsite name path =
+        az (sprintf "storage blob upload-batch --account-name %s --destination $web --source %s" name path)
 
 /// Represents an Azure subscription
 type Subscription = { ID : Guid; Name : string; IsDefault : bool }

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -116,6 +116,8 @@ module Az =
     let zipDeployFunctionApp = zipDeploy "functionapp"
     let delete resourceGroup =
         az (sprintf "group delete --name %s --yes --no-wait" resourceGroup)
+    let enableStaticWebsite name indexDoc errorDoc =
+        az (sprintf "storage blob service-properties update --account-name %s --static-website  --index-document %s --404-document %s" name indexDoc errorDoc)
 
 /// Represents an Azure subscription
 type Subscription = { ID : Guid; Name : string; IsDefault : bool }


### PR DESCRIPTION
At Farmer CE:

```fsharp
let store = storageAccount {
    name "romanstaticweb"
    static_website "index.html" "error.html"
}
```

on Azure:

![image](https://user-images.githubusercontent.com/851307/87349697-05e5e300-c557-11ea-9f36-375242aed4fd.png)

Also added docs + configuration member for getting *primary endpoint*

```fsharp
store.WebsitePrimaryEndpoint
```