### PR TITLE
Add hierarchical namespace / Data Lake Storage Gen2 support 

### DIFF
--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -14,6 +14,7 @@ type StorageAccount =
     { Name : ResourceName
       Location : Location
       Sku : Sku
+      HierarchicalNamespace : bool
       StaticWebsite : {| IndexPage : string; ErrorPage : string option; ContentPath : string |} option }
     interface IArmResource with
         member this.ResourceName = this.Name
@@ -24,6 +25,7 @@ type StorageAccount =
                name = this.Name.Value
                apiVersion = "2018-07-01"
                location = this.Location.ArmValue
+               properties = {|isHnsEnabled = this.HierarchicalNamespace|}
             |} :> _
     interface IPostDeploy with
         member this.Run _ =

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -132,7 +132,8 @@ type FunctionsConfig =
                 { StorageAccount.Name = resourceName
                   Location = location
                   Sku = Storage.Standard_LRS
-                  StaticWebsite = None }
+                  StaticWebsite = None
+                  HierarchicalNamespace = false}
             | AutomaticPlaceholder | External _ ->
                 ()
             match this.AppInsightsName with

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -22,6 +22,8 @@ type StorageAccountConfig =
       Name : ResourceName
       /// The sku of the storage account.
       Sku : Sku
+      /// Hierarchical namespace support, also known as Data Lake Storage Gen2
+      HierarchicalNamespace : bool
       /// Containers for the storage account.
       Containers : (ResourceName * StorageContainerAccess) list
       /// File shares
@@ -41,6 +43,7 @@ type StorageAccountConfig =
             { Name = this.Name
               Location = location
               Sku = this.Sku
+              HierarchicalNamespace = this.HierarchicalNamespace
               StaticWebsite = this.StaticWebsite }
             for name, access in this.Containers do
                 { Name = name
@@ -59,6 +62,7 @@ type StorageAccountBuilder() =
     member _.Yield _ = {
         Name = ResourceName.Empty
         Sku = Standard_LRS
+        HierarchicalNamespace = false
         Containers = []
         FileShares = []
         Queues = Set.empty
@@ -106,6 +110,9 @@ type StorageAccountBuilder() =
     [<CustomOperation "static_website_error_page">]
     member _.StaticWebsiteErrorPage(state:StorageAccountConfig, errorPage) =
         { state with StaticWebsite = state.StaticWebsite |> Option.map(fun staticWebsite -> {| staticWebsite with ErrorPage = Some errorPage |}) }
+    /// Enables support for hierarchical namespace, also known as Data Lake Storage Gen2.
+    [<CustomOperation "use_hns">]
+    member _.UseHns(state:StorageAccountConfig) = { state with HierarchicalNamespace = true }
 
 /// Allow adding storage accounts directly to CDNs
 type EndpointBuilder with

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -119,7 +119,8 @@ type VmConfig =
                 { Name = account
                   Location = location
                   Sku = Storage.Standard_LRS
-                  StaticWebsite = None }
+                  StaticWebsite = None
+                  HierarchicalNamespace = false}
             | Some AutomaticPlaceholder
             | Some (External _)
             | None ->

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -56,4 +56,20 @@ let tests = testList "Storage Tests" [
         Expect.equal resources.[1].Name "storage/default/share2" "file share name for 'share2' is wrong"
         Expect.equal resources.[1].ShareQuota (Nullable 1024) "file share quota for 'share2' is wrong"
     }
+    test "Can support hierarchical namespace" {
+        let resource =
+            let account = storageAccount {
+                name "myStorage123~@"
+                sku Premium_LRS
+                use_hns
+            }
+            arm { add_resource account }
+            |> findAzureResources<StorageAccount> client.SerializationSettings
+            |> List.head
+
+        resource.Validate()
+        Expect.equal resource.Name "mystorage123" "Account name is wrong"
+        Expect.equal resource.Sku.Name "Premium_LRS" "SKU is wrong"
+        Expect.equal resource.IsHnsEnabled.Value true "Hierarchical namespace not enabled"
+    }
 ]


### PR DESCRIPTION
Hi, 

thanks for the great tool!
I'm missing the option to enable hierarchical namespaces in storage accounts, so I added the option based on this template
https://gist.github.com/dazfuller/0740f1640225dc8ea0eb29a8e6f88a6a

Note that I already tried the new option and it worked for me, including creating private containers. 

Thanks,
Marc