### PR TITLE
Improve VNet, Gateway and VM integration.

### DIFF
--- a/samples/SampleApp/Program.fs
+++ b/samples/SampleApp/Program.fs
@@ -15,20 +15,20 @@ let developmentEnvironment = vm {
     name "test-isaac"
     username "isaac"
     no_public_ip
-    // link_to_vnet devVn
-    // vnet_subnet_name "Frontend"
+    link_to_vnet devVn
+    vnet_subnet_name "Frontend"
 }
 
-// let gw = gateway {
-//     name "dev-isaac-gateway"
-//     vnet devVn
-//     vpn_gateway_sku VpnGatewaySku.Basic
-// }
+let gw = gateway {
+    name "dev-isaac-gateway"
+    vnet devVn
+    sku VpnGatewaySku.Basic
+}
 
 let deployment = arm {
     add_resource developmentEnvironment
-    // add_resource gw
-    // add_resource devVn
+    add_resource gw
+    add_resource devVn
 }
 
 deployment

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -178,18 +178,19 @@ type NetworkInterface =
                     | None -> ()
                ]
                properties =
-                   {| ipConfigurations =
-                        this.IpConfigs
-                        |> List.mapi(fun index ipConfig ->
+                   {| ipConfigurations = [
+                        for index, ipConfig in Seq.indexed this.IpConfigs do
                             {| name = sprintf "ipconfig%i" (index + 1)
                                properties =
-                                {| privateIPAllocationMethod = "Dynamic"                                  
+                                {| privateIPAllocationMethod = "Dynamic"
                                    subnet = {| id = ArmExpression.resourceId(subnets, this.VirtualNetwork, ipConfig.SubnetName).Eval() |}
                                    publicIPAddress =
-                                    | Some publicIpName -> box {| id = ArmExpression.resourceId(publicIPAddresses, ipConfig.PublicIpName).Eval() |}
+                                    match ipConfig.PublicIpName with
+                                    | Some publicIpName -> box {| id = ArmExpression.resourceId(publicIPAddresses, publicIpName).Eval() |}
                                     | None -> null
                                 |}
-                            |})
+                            |}
+                      ]
                    |}
             |} :> _
 type NetworkProfile =

--- a/src/Farmer/Builders/Builders.VirtualNetworkGateway.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetworkGateway.fs
@@ -70,20 +70,18 @@ type VnetGatewayBuilder() =
     [<CustomOperation "name">]
     member _.Name(state:VNetGatewayConfig, name) = { state with Name = name }
     member this.Name(state:VNetGatewayConfig, name) = this.Name(state, ResourceName name)
-    /// Sets the virtual network where this gateway is attached.
+    /// Sets the virtual network to which this gateway is attached.
     [<CustomOperation "vnet">]
     member _.VNet(state:VNetGatewayConfig, vnet) = { state with VirtualNetwork = vnet }
     member this.VNet(state:VNetGatewayConfig, vnet) = this.VNet(state, ResourceName vnet)
     member this.VNet(state:VNetGatewayConfig, vnet:VirtualNetworkConfig) = this.VNet(state, vnet.Name)
     /// Sets the ExpressRoute gateway type with an ExpressRoute SKU.
-    [<CustomOperation "er_gateway_sku">]
-    member _.ErGatewaySku(state:VNetGatewayConfig, sku) = { state with GatewayType = GatewayType.ExpressRoute sku }
-    /// Sets the VPN gateway type with a VPN SKU.
-    [<CustomOperation "vpn_gateway_sku">]
-    member _.VpnType(state:VNetGatewayConfig, sku) = { state with GatewayType = GatewayType.Vpn sku }
+    [<CustomOperation "sku">]
+    member _.Sku(state:VNetGatewayConfig, sku) = { state with GatewayType = GatewayType.ExpressRoute sku }
+    member _.Sku(state:VNetGatewayConfig, sku) = { state with GatewayType = GatewayType.Vpn sku }
     /// Sets the VPN type with - RouteBased or PolicyBased.
     [<CustomOperation "vpn_type">]
-    member _.VpnGatewaySku(state:VNetGatewayConfig, vpnType) = { state with VpnType = vpnType }
+    member _.VpnType(state:VNetGatewayConfig, vpnType) = { state with VpnType = vpnType }
     /// Sets the default gateway IP config.
     [<CustomOperation "gateway_ip_config">]
     member _.GatewayIpConfig(state:VNetGatewayConfig, allocationMethod, publicIp) =
@@ -95,12 +93,12 @@ type VnetGatewayBuilder() =
     member _.ActiveActiveIpConfig(state:VNetGatewayConfig, allocationMethod, publicIpName) =
         match state.GatewayType with
         | GatewayType.ExpressRoute _ ->
-            state // No active-active config on ER gateways
+            // No active-active config on ER gateways
+            state
         | GatewayType.Vpn _ ->
             { state with
                 ActiveActivePrivateIpAllocationMethod = allocationMethod
-                ActiveActivePublicIpName = Some (ResourceName publicIpName)
-            }
+                ActiveActivePublicIpName = Some (ResourceName publicIpName) }
     /// Disable BGP (enabled by default).
     [<CustomOperation "disable_bgp">]
     member _.DisableBgp(state:VNetGatewayConfig) = { state with EnableBgp = false }

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -27,103 +27,108 @@ type VmConfig =
       CustomScriptFiles : Uri list
 
       DomainNamePrefix : string option
+      UsePublicIp : bool
 
-      VNetName : ResourceRef
       AddressPrefix : string
       SubnetPrefix : string
+      VNetName : ResourceRef
       SubnetName : ResourceName option
 
       DependsOn : ResourceName list }
 
     member this.NicName = makeResourceName this.Name "nic"
-    member this.IpName = makeResourceName this.Name "ip"
-    member this.Hostname = sprintf "reference('%s').dnsSettings.fqdn" this.IpName.Value |> ArmExpression.create
+    member this.IpName = if this.UsePublicIp then Some (makeResourceName this.Name "ip") else None
+    member this.Hostname =
+        this.IpName
+        |> Option.map(fun name ->
+            sprintf "reference('%s').dnsSettings.fqdn" name.Value |> ArmExpression.create)
 
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
-            // VM itself
-            { Name = this.Name
-              Location = location
-              StorageAccount =
-                this.DiagnosticsStorageAccount
-                |> Option.bind(function
-                    | AutomaticPlaceholder -> None
-                    | AutomaticallyCreated r -> Some r
-                    | External r -> Some r)
-              NetworkInterfaceName = this.NicName
-              Size = this.Size
-              Credentials =
-                match this.Username with
-                | Some username ->
-                    {| Username = username
-                       Password = SecureParameter (sprintf "password-for-%s" this.Name.Value) |}
+            match this.SubnetName with
+            | None ->
+                failwith "Subnet Name must be set"
+            | Some subnetName ->
+                // VM itself
+                { Name = this.Name
+                  Location = location
+                  StorageAccount =
+                    this.DiagnosticsStorageAccount
+                    |> Option.bind(function
+                        | AutomaticPlaceholder -> None
+                        | AutomaticallyCreated r -> Some r
+                        | External r -> Some r)
+                  NetworkInterfaceName = this.NicName
+                  Size = this.Size
+                  Credentials =
+                    match this.Username with
+                    | Some username ->
+                        {| Username = username
+                           Password = SecureParameter (sprintf "password-for-%s" this.Name.Value) |}
+                    | None ->
+                        failwithf "You must specify a username for virtual machine %s" this.Name.Value
+                  Image = this.Image
+                  OsDisk = this.OsDisk
+                  DataDisks = this.DataDisks }
+
+                // Custom Script
+                match this.CustomScript with
+                | Some script ->
+                    { Name = this.Name.Map(sprintf "%s-custom-script")
+                      Location = location
+                      VirtualMachine = this.Name
+                      OS = this.Image.OS
+                      ScriptContents = script
+                      FileUris = this.CustomScriptFiles }
                 | None ->
-                    failwithf "You must specify a username for virtual machine %s" this.Name.Value
-              Image = this.Image
-              OsDisk = this.OsDisk
-              DataDisks = this.DataDisks }
+                    ()
 
-            // Custom Script
-            match this.CustomScript with
-            | Some script ->
-                { Name = this.Name.Map(sprintf "%s-custom-script")
+                // NIC
+                { Name = this.NicName
                   Location = location
-                  VirtualMachine = this.Name
-                  OS = this.Image.OS
-                  ScriptContents = script
-                  FileUris = this.CustomScriptFiles }
-            | None ->
-                ()
-
-            let vnetName =
-                this.VNetName.ResourceNameOpt
-                |> Option.defaultValue (makeResourceName this.Name "vnet")
-
-            let subnetName =
-                this.SubnetName
-                |> Option.defaultValue (makeResourceName this.Name "subnet")
-
-            // NIC
-            { Name = this.NicName
-              Location = location
-              IpConfigs = [
-                {| SubnetName = subnetName
-                   PublicIpName = this.IpName |} ]
-              VirtualNetwork = vnetName }
-
-            // VNET
-            match this.VNetName with
-            | AutomaticallyCreated _
-            | AutomaticPlaceholder ->
-                { Name = vnetName
-                  Location = location
-                  AddressSpacePrefixes = [ this.AddressPrefix ]
-                  Subnets = [
-                      {| Name = subnetName
-                         Prefix = this.SubnetPrefix
-                         Delegations = [] |}
+                  IpConfigs = [
+                    {| SubnetName = subnetName
+                       PublicIpName = this.IpName |}
                   ]
-                }
-            | External _ ->
-                ()
+                  VirtualNetwork = this.VNetName.ResourceName }
 
-            // IP Address
-            { Name = this.IpName
-              Location = location
-              DomainNameLabel = this.DomainNamePrefix }
+                // VNET
+                match this.VNetName with
+                | AutomaticallyCreated _
+                | AutomaticPlaceholder ->
+                    { Name = this.VNetName.ResourceName
+                      Location = location
+                      AddressSpacePrefixes = [ this.AddressPrefix ]
+                      Subnets = [
+                          {| Name = subnetName
+                             Prefix = this.SubnetPrefix
+                             Delegations = [] |}
+                      ]
+                    }
+                | External _ ->
+                    ()
 
-            // Storage account - optional
-            match this.DiagnosticsStorageAccount with
-            | Some (AutomaticallyCreated account) ->
-                { Name = account
-                  Location = location
-                  Sku = Storage.Standard_LRS
-                  StaticWebsite = None }
-            | Some AutomaticPlaceholder
-            | Some (External _)
-            | None ->
-                ()
+                // IP Address
+                match this.IpName with
+                | Some ipName ->
+                    { Name = ipName
+                      Location = location
+                      DomainNameLabel = this.DomainNamePrefix }
+                | None ->
+                    ()
+
+                // Storage account - optional
+                match this.DiagnosticsStorageAccount with
+                | Some (AutomaticallyCreated account) ->
+                    { Name = account
+                      Location = location
+                      Sku = Storage.Standard_LRS
+                      StaticWebsite = None }
+                | Some AutomaticPlaceholder
+                | Some (External _)
+                | None ->
+                    ()
         ]
 
 type VirtualMachineBuilder() =
@@ -141,11 +146,22 @@ type VirtualMachineBuilder() =
           AddressPrefix = "10.0.0.0/16"
           SubnetPrefix = "10.0.0.0/24"
           VNetName = AutomaticPlaceholder
-          SubnetName = None//makeResourceName ResourceName.Empty "subnet"
-          DependsOn = [] }
+          SubnetName = None
+          DependsOn = []
+          UsePublicIp = true }
 
     member __.Run (state:VmConfig) =
         { state with
+            VNetName =
+                match state.VNetName with
+                | AutomaticPlaceholder -> AutomaticallyCreated (makeResourceName state.Name "vnet")
+                | other -> other
+
+            SubnetName =
+                state.SubnetName
+                |> Option.defaultValue (makeResourceName state.Name "subnet")
+                |> Some
+
             DiagnosticsStorageAccount =
                 state.DiagnosticsStorageAccount
                 |> Option.map(fun account ->
@@ -203,26 +219,32 @@ type VirtualMachineBuilder() =
     /// Sets the prefix for the domain name of the VM.
     [<CustomOperation "domain_name_prefix">]
     member __.DomainNamePrefix(state:VmConfig, prefix) = { state with DomainNamePrefix = prefix }
-    /// Sets the IP address prefix of the VM.
-    [<CustomOperation "address_prefix">]
+    /// Sets the address prefix of the vnet of the VM, unless you are linking to an external vnet.
+    [<CustomOperation "vnet_address_prefix">]
     member __.AddressPrefix(state:VmConfig, prefix) = { state with AddressPrefix = prefix }
-    /// Sets the subnet prefix of the VM.
-    [<CustomOperation "subnet_prefix">]
+    /// Sets the subnet prefix of the vnet of the VM, unless you are linking to an external vnet.
+    [<CustomOperation "vnet_subnet_prefix">]
     member __.SubnetPrefix(state:VmConfig, prefix) = { state with SubnetPrefix = prefix }
-    /// Sets the subnet name of the VM.
-    [<CustomOperation "subnet_name">]
+    /// Sets the subnet name of the vnet of the VM, unless you are linking to an external vnet.
+    [<CustomOperation "vnet_subnet_name">]
     member __.SubnetName(state:VmConfig, name) = { state with SubnetName = Some name }
     member this.SubnetName(state:VmConfig, name) = this.SubnetName(state, ResourceName name)
     /// Uses an external VNet instead of creating a new one.
     [<CustomOperation "link_to_vnet">]
-    member __.VNetName(state:VmConfig, name) = { state with VNetName = External (ResourceName name) }
-    member __.VNetName(state:VmConfig, vnet:Arm.Network.VirtualNetwork) = { state with VNetName = External vnet.Name }
+    member _.LinkVnet(state:VmConfig, name) = { state with VNetName = External name }
+    member this.LinkVnet(state:VmConfig, name) = this.LinkVnet(state, ResourceName name)
+    member this.LinkVnet(state:VmConfig, vnet:VirtualNetworkConfig) = this.LinkVnet(state, vnet.Name)
+    /// Makes the VM only accessible via the virtual network with no public IP address.
+    [<CustomOperation "no_public_ip">]
+    member _.NoPublicIp(state:VmConfig) = { state with UsePublicIp = false }
     [<CustomOperation "depends_on">]
     member __.DependsOn(state:VmConfig, resourceName) = { state with DependsOn = resourceName :: state.DependsOn }
     member __.DependsOn(state:VmConfig, resource:IBuilder) = { state with DependsOn = resource.DependencyName :: state.DependsOn }
     member __.DependsOn(state:VmConfig, resource:IArmResource) = { state with DependsOn = resource.ResourceName :: state.DependsOn }
+    /// Sets the custom script that should be executed on the VM once provisioning is complete.
     [<CustomOperation "custom_script">]
     member _.CustomScript(state:VmConfig, script:string) = { state with CustomScript = Some script }
+    /// Specifies the list of files which should be downloaded as part of the provisioning process.
     [<CustomOperation "custom_script_files">]
     member _.CustomScriptFiles(state:VmConfig, uris:string list) = { state with CustomScriptFiles = uris |> List.map Uri }
 

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -80,6 +80,7 @@
     <Compile Include="Builders/Builders.Storage.fs" />
     <Compile Include="Builders/Builders.Redis.fs" />
     <Compile Include="Builders/Builders.KeyVault.fs" />
+    <Compile Include="Builders/Builders.VirtualNetwork.fs" />
     <Compile Include="Builders/Builders.Vm.fs" />
     <Compile Include="Builders/Builders.ServicePlan.fs" />
     <Compile Include="Builders/Builders.AppInsights.fs" />
@@ -98,7 +99,6 @@
     <Compile Include="Builders/Builders.Maps.fs" />
     <Compile Include="Builders/Builders.SignalR.fs" />
     <Compile Include="Builders/Builders.VirtualNetworkGateway.fs" />
-    <Compile Include="Builders/Builders.VirtualNetwork.fs" />
     <Compile Include="Builders/Builders.EventGrid.fs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Ignore the accidental commits on `Program.fs` and the `vm.fsx`, I've made a few changes that I think ease working with VNets, Gateways and VMs:

1. Public IP is now optional so you can have a purely private VM.
1. Merge both sku keywords into a single, overloaded `sku` keyword. 
1. Gateway can now be configured with a VNet directly (instead of the name).
1. VNet commands on the VM are now prefixed with `vnet_` for clarity.

Plus some formatting refactoring.

I was hoping to do something more ambitious around them all but I think this is a decent start:

```fsharp
let devVn = vnet {
    name "dev-isaac-vnet"
    add_address_spaces [ "10.0.0.0/16" ]
    add_subnets [
        subnet { name "GatewaySubnet"; prefix "10.0.0.0/24" }
        subnet { name "Frontend"; prefix "10.0.2.0/24" }
    ]
}

let developmentEnvironment = vm {
    name "test-isaac"
    username "isaac"
    no_public_ip
    link_to_vnet devVn
    vnet_subnet_name "Frontend"
}

let gw = gateway {
    name "dev-isaac-gateway"
    vnet devVn
    sku VpnGatewaySku.Basic
}

let deployment = arm {
    add_resource developmentEnvironment
    add_resource gw
    add_resource devVn
}
```

* I would still like it to be easier to create all of these resources together - or at least the VNet and Gateway.
* I don't like the work required to hook up the gateway subnet to the Vnet - you need to know the magic "GatewaySubnet" name (which is nuts) and have to manually connect the vnet subnet to the VM.

This is all boilerplate which should be doable by a builder, IMHO. But this can be a future enhancement.

@ninjarobot could you give this a quick once over?

Thanks