### PR TITLE
Derived resources

### DIFF
--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -5,15 +5,6 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.Arm.Insights
 
-let tryCreateAppInsightsName aiName rootName =
-    aiName
-    |> Option.map(function
-    | AutomaticPlaceholder ->
-        AutomaticallyCreated(ResourceName(sprintf "%s-ai" rootName))
-    | (External _ as resourceRef)
-    | (AutomaticallyCreated _ as resourceRef) ->
-        resourceRef)
-
 let instrumentationKey (ResourceName accountName) =
     sprintf "reference('Microsoft.Insights/components/%s').InstrumentationKey" accountName
     |> ArmExpression.create

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -56,14 +56,14 @@ type CosmosDbConfig =
         member this.BuildResources location = [
             // Account
             match this.AccountName with
-            | AutoCreate _ ->
+            | DeployableResource this _ ->
                 { Name = this.AccountResourceName
                   Location = location
                   ConsistencyPolicy = this.AccountConsistencyPolicy
                   PublicNetworkAccess = this.PublicNetworkAccess
                   FailoverPolicy = this.AccountFailoverPolicy
                   FreeTier = this.FreeTier }
-            | External _ ->
+            | _ ->
                 ()
 
             // Database

--- a/src/Farmer/Builders/Builders.EventGrid.fs
+++ b/src/Farmer/Builders/Builders.EventGrid.fs
@@ -134,7 +134,7 @@ type EventGridBuilder() =
     member _.Source(state:EventGridConfig<_>, source:ContainerRegistryConfig) = EventGridBuilder.ChangeTopic<ContainerRegistryEvent>(state, source.Name, Topics.ContainerRegistry)
     member _.Source(state:EventGridConfig<_>, source:ServiceBusConfig) = EventGridBuilder.ChangeTopic<ServiceBusEvent>(state, source.Name, Topics.ServiceBusNamespace)
     member _.Source(state:EventGridConfig<_>, source:IotHubConfig) = EventGridBuilder.ChangeTopic<IoTHubEvent>(state, source.Name, Topics.IoTHubAccount)
-    member _.Source(state:EventGridConfig<_>, source:EventHubConfig) = EventGridBuilder.ChangeTopic<EventHubEvent>(state, source.EventHubNamespace.ResourceName, Topics.EventHubsNamespace)
+    member _.Source(state:EventGridConfig<_>, source:EventHubConfig) = EventGridBuilder.ChangeTopic<EventHubEvent>(state, source.EventHubNamespace.CreateResourceName source, Topics.EventHubsNamespace)
 
     [<CustomOperation "add_queue_subscriber">]
     member _.AddQueueSubscription(state:EventGridConfig<'T> when 'T :> IEventGridEvent, storageAccount:StorageAccountConfig, queueName, events:'T list) =
@@ -146,6 +146,6 @@ type EventGridBuilder() =
         this.AddWebSubscription(state, webApp.Name, Uri (sprintf "https://%s/%s" webApp.Endpoint route), events)
     [<CustomOperation "add_eventhub_subscriber">]
     member _.AddEventHubSubscription(state:EventGridConfig<'T> when 'T :> IEventGridEvent, eventHub:EventHubConfig, events:'T list) =
-        EventGridBuilder.AddSub(state, eventHub.Name.Value + "-eventhub", eventHub.EventHubNamespace.ResourceName, EventHub eventHub.Name, events |> List.map (fun x -> x.ToEvent))
+        EventGridBuilder.AddSub(state, eventHub.Name.Value + "-eventhub", eventHub.EventHubNamespace.CreateResourceName eventHub, EventHub eventHub.Name, events |> List.map (fun x -> x.ToEvent))
 
 let eventGrid = EventGridBuilder()

--- a/src/Farmer/Builders/Builders.EventGrid.fs
+++ b/src/Farmer/Builders/Builders.EventGrid.fs
@@ -134,7 +134,7 @@ type EventGridBuilder() =
     member _.Source(state:EventGridConfig<_>, source:ContainerRegistryConfig) = EventGridBuilder.ChangeTopic<ContainerRegistryEvent>(state, source.Name, Topics.ContainerRegistry)
     member _.Source(state:EventGridConfig<_>, source:ServiceBusConfig) = EventGridBuilder.ChangeTopic<ServiceBusEvent>(state, source.Name, Topics.ServiceBusNamespace)
     member _.Source(state:EventGridConfig<_>, source:IotHubConfig) = EventGridBuilder.ChangeTopic<IoTHubEvent>(state, source.Name, Topics.IoTHubAccount)
-    member _.Source(state:EventGridConfig<_>, source:EventHubConfig) = EventGridBuilder.ChangeTopic<EventHubEvent>(state, source.EventHubNamespace.CreateResourceName source, Topics.EventHubsNamespace)
+    member _.Source(state:EventGridConfig<_>, source:EventHubConfig) = EventGridBuilder.ChangeTopic<EventHubEvent>(state, source.EventHubNamespaceName, Topics.EventHubsNamespace)
 
     [<CustomOperation "add_queue_subscriber">]
     member _.AddQueueSubscription(state:EventGridConfig<'T> when 'T :> IEventGridEvent, storageAccount:StorageAccountConfig, queueName, events:'T list) =
@@ -146,6 +146,6 @@ type EventGridBuilder() =
         this.AddWebSubscription(state, webApp.Name, Uri (sprintf "https://%s/%s" webApp.Endpoint route), events)
     [<CustomOperation "add_eventhub_subscriber">]
     member _.AddEventHubSubscription(state:EventGridConfig<'T> when 'T :> IEventGridEvent, eventHub:EventHubConfig, events:'T list) =
-        EventGridBuilder.AddSub(state, eventHub.Name.Value + "-eventhub", eventHub.EventHubNamespace.CreateResourceName eventHub, EventHub eventHub.Name, events |> List.map (fun x -> x.ToEvent))
+        EventGridBuilder.AddSub(state, eventHub.Name.Value + "-eventhub", eventHub.EventHubNamespaceName, EventHub eventHub.Name, events |> List.map (fun x -> x.ToEvent))
 
 let eventGrid = EventGridBuilder()

--- a/src/Farmer/Builders/Builders.EventHub.fs
+++ b/src/Farmer/Builders/Builders.EventHub.fs
@@ -26,22 +26,22 @@ type EventHubConfig =
       AuthorizationRules : Map<ResourceName, AuthorizationRuleRight Set>
       Dependencies : ResourceName list }
     member private _.ToKeyExpression = sprintf "listkeys(%s, '2017-04-01').primaryConnectionString"
-    member private this.NamespaceResourceName = this.EventHubNamespace.CreateResourceName this
+    member this.EventHubNamespaceName = this.EventHubNamespace.CreateResourceName this
     /// Gets an ARM expression for the path to the key of a specific authorization rule for this event hub.
     member this.GetKey (ruleName:string) =
         ArmExpression
-            .resourceId(authorizationRules, this.NamespaceResourceName, this.Name, ResourceName ruleName)
+            .resourceId(authorizationRules, this.EventHubNamespaceName, this.Name, ResourceName ruleName)
             .Map this.ToKeyExpression
 
     /// Gets an ARM expression for the path to the key of the default RootManageSharedAccessKey for the entire namespace.
     member this.DefaultKey =
         ArmExpression
-            .resourceId(authorizationRules, this.NamespaceResourceName, ResourceName "RootManageSharedAccessKey")
+            .resourceId(authorizationRules, this.EventHubNamespaceName, ResourceName "RootManageSharedAccessKey")
             .Map this.ToKeyExpression
     interface IBuilder with
-        member this.DependencyName = this.NamespaceResourceName
+        member this.DependencyName = this.EventHubNamespaceName
         member this.BuildResources location = [
-            let eventHubNamespaceName = this.NamespaceResourceName
+            let eventHubNamespaceName = this.EventHubNamespaceName
             let eventHubName = this.Name.Map(fun hubName -> sprintf "%s/%s" eventHubNamespaceName.Value hubName)
 
             // Namespace

--- a/src/Farmer/Builders/Builders.EventHub.fs
+++ b/src/Farmer/Builders/Builders.EventHub.fs
@@ -46,7 +46,7 @@ type EventHubConfig =
 
             // Namespace
             match this.EventHubNamespace with
-            | AutoCreate _ ->
+            | DeployableResource this _ ->
                 { Name = eventHubNamespaceName
                   Location = location
                   Sku =
@@ -55,7 +55,7 @@ type EventHubConfig =
                   ZoneRedundant = this.ZoneRedundant
                   AutoInflateSettings = this.ThroughputSettings
                   KafkaEnabled = this.KafkaEnabled }
-            | External _ ->
+            | _ ->
                 ()
 
             // Event hub

--- a/src/Farmer/Builders/Builders.EventHub.fs
+++ b/src/Farmer/Builders/Builders.EventHub.fs
@@ -26,73 +26,70 @@ type EventHubConfig =
       AuthorizationRules : Map<ResourceName, AuthorizationRuleRight Set>
       Dependencies : ResourceName list }
     member private _.ToKeyExpression = sprintf "listkeys(%s, '2017-04-01').primaryConnectionString"
+    member private this.NamespaceResourceName = this.EventHubNamespace.CreateResourceName this
     /// Gets an ARM expression for the path to the key of a specific authorization rule for this event hub.
     member this.GetKey (ruleName:string) =
         ArmExpression
-            .resourceId(authorizationRules, this.EventHubNamespace.CreateResourceName this, this.Name, ResourceName ruleName)
+            .resourceId(authorizationRules, this.NamespaceResourceName, this.Name, ResourceName ruleName)
             .Map this.ToKeyExpression
 
     /// Gets an ARM expression for the path to the key of the default RootManageSharedAccessKey for the entire namespace.
     member this.DefaultKey =
         ArmExpression
-            .resourceId(authorizationRules, this.EventHubNamespace.CreateResourceName this, ResourceName "RootManageSharedAccessKey")
+            .resourceId(authorizationRules, this.NamespaceResourceName, ResourceName "RootManageSharedAccessKey")
             .Map this.ToKeyExpression
     interface IBuilder with
-        member this.DependencyName = this.EventHubNamespace.CreateResourceName this
+        member this.DependencyName = this.NamespaceResourceName
         member this.BuildResources location = [
-            let eventHubNamespaceName = this.EventHubNamespace.CreateResourceName this
-            let eventHubNamespace =
-                match this.EventHubNamespace with
-                | External _ ->
-                    None
-                | AutoCreate _ ->
-                    { Name = eventHubNamespaceName
-                      Location = location
-                      Sku =
-                        {| Name = this.Sku
-                           Capacity = this.Capacity |}
-                      ZoneRedundant = this.ZoneRedundant
-                      AutoInflateSettings = this.ThroughputSettings
-                      KafkaEnabled = this.KafkaEnabled }
-                    |> Some
-            let eventHub =
-                { Name = this.Name.Map(sprintf "%s/%s" eventHubNamespaceName.Value)
-                  Location = location
-                  MessageRetentionDays = this.MessageRetentionInDays
-                  Partitions = this.Partitions
-                  CaptureDestination = this.CaptureDestination
-                  Dependencies = [
-                      eventHubNamespaceName
-                      match this.CaptureDestination with
-                      | Some (StorageAccount(name, _)) -> name
-                      | None -> ()
-                      yield! this.Dependencies
-                  ] }
-            let consumerGroups =
-                [ for consumerGroup in this.ConsumerGroups ->
-                    { Name = eventHub.Name.Map(fun name -> sprintf "%s/%s" eventHub.Name.Value consumerGroup)
-                      Location = location
-                      Dependencies = [
-                          eventHubNamespaceName
-                          ArmExpression.resourceId(eventHubs, eventHubNamespaceName, this.Name).Eval() |> ResourceName
-                      ]
-                    }
-                ]
-            let authRules =
-                [ for rule in this.AuthorizationRules ->
-                    { Name = rule.Key.Map(sprintf "%s/%s/%s" eventHubNamespaceName.Value this.Name.Value)
-                      Location = location
-                      Dependencies = [
-                          ArmExpression.resourceId(namespaces, eventHubNamespaceName).Eval() |> ResourceName
-                          ArmExpression.resourceId(eventHubs, eventHubNamespaceName, this.Name).Eval() |> ResourceName
-                      ]
-                      Rights = rule.Value }
-                ]
+            let eventHubNamespaceName = this.NamespaceResourceName
+            let eventHubName = this.Name.Map(fun hubName -> sprintf "%s/%s" eventHubNamespaceName.Value hubName)
 
-            match eventHubNamespace with Some ns -> ns | None -> ()
-            eventHub
-            for consumerGroup in consumerGroups do consumerGroup
-            for authRule in authRules do authRule
+            // Namespace
+            match this.EventHubNamespace with
+            | AutoCreate _ ->
+                { Name = eventHubNamespaceName
+                  Location = location
+                  Sku =
+                    {| Name = this.Sku
+                       Capacity = this.Capacity |}
+                  ZoneRedundant = this.ZoneRedundant
+                  AutoInflateSettings = this.ThroughputSettings
+                  KafkaEnabled = this.KafkaEnabled }
+            | External _ ->
+                ()
+
+            // Event hub
+            { Name = eventHubName
+              Location = location
+              MessageRetentionDays = this.MessageRetentionInDays
+              Partitions = this.Partitions
+              CaptureDestination = this.CaptureDestination
+              Dependencies = [
+                  eventHubNamespaceName
+                  match this.CaptureDestination with
+                  | Some (StorageAccount(name, _)) -> name
+                  | None -> ()
+                  yield! this.Dependencies
+              ] }
+
+            // Consumer groups
+            for consumerGroup in this.ConsumerGroups do
+              { Name = eventHubName.Map(fun hubName -> sprintf "%s/%s" hubName consumerGroup)
+                Location = location
+                Dependencies = [
+                    eventHubNamespaceName
+                    ArmExpression.resourceId(eventHubs, eventHubNamespaceName, this.Name).Eval() |> ResourceName
+                ] }
+
+            // Auth rules
+            for rule in this.AuthorizationRules do
+                { Name = rule.Key.Map(fun rule -> sprintf "%s/%s/%s" eventHubNamespaceName.Value this.Name.Value rule)
+                  Location = location
+                  Dependencies = [
+                      ArmExpression.resourceId(namespaces, eventHubNamespaceName).Eval() |> ResourceName
+                      ArmExpression.resourceId(eventHubs, eventHubNamespaceName, this.Name).Eval() |> ResourceName
+                  ]
+                  Rights = rule.Value }
         ]
 
 type EventHubBuilder() =
@@ -120,8 +117,8 @@ type EventHubBuilder() =
     member this.NamespaceName(state:EventHubConfig, name) = this.NamespaceName(state, ResourceName name)
     /// Sets the name of the Event Hub namespace.
     [<CustomOperation "link_to_namespace">]
-    member __.LinkToNamespaceName(state:EventHubConfig, name) = { state with EventHubNamespace = External name }
-    member this.LinkToNamespaceName(state:EventHubConfig, name) = this.NamespaceName(state, ResourceName name)
+    member __.LinkToNamespaceName(state:EventHubConfig, name) = { state with EventHubNamespace = External (Managed name) }
+    member this.LinkToNamespaceName(state:EventHubConfig, name) = this.LinkToNamespaceName(state, ResourceName name)
     /// Sets the sku of the Event Hub instance.
     [<CustomOperation "sku">]
     member __.Sku(state:EventHubConfig, sku) = { state with Sku = sku }

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -108,11 +108,11 @@ type WebAppConfig =
         sprintf "%s.azurewebsites.net" this.Name.Value
 
     interface IBuilder with
-        member this.DependencyName = this.ServicePlan.CreateResourceName this
+        member this.DependencyName = this.ServicePlanName
         member this.BuildResources location = [
             { Name = this.Name
               Location = location
-              ServicePlan = this.ServicePlan.CreateResourceName this
+              ServicePlan = this.ServicePlanName
               HTTPSOnly = this.HTTPSOnly
               HTTP20Enabled = this.HTTP20Enabled
               ClientAffinityEnabled = this.ClientAffinityEnabled

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -329,7 +329,7 @@ type WebAppBuilder() =
     /// Instead of creating a new service plan instance, configure this webapp to point to another unmanaged service plan instance.
     /// A dependency will automatically be set for this instance.
     [<CustomOperation "link_to_unmanaged_service_plan">]
-    member __.LinkToUnmanagedServicePlan(state:WebAppConfig, name) = { state with ServicePlanName = External (Unmanaged name) }
+    member __.LinkToUnmanagedServicePlan(state:WebAppConfig, name) = { state with ServicePlanName = External (Unmanaged (ResourceName name)) }
     [<CustomOperation "sku">]
     member __.Sku(state:WebAppConfig, sku) = { state with Sku = sku }
     /// Sets the size of the service plan worker.
@@ -355,7 +355,7 @@ type WebAppBuilder() =
     /// Instead of creating a new AI instance, configure this webapp to point to an unmanaged AI instance.
     /// A dependency will not be set for this instance.
     [<CustomOperation "link_to_unmanaged_app_insights">]
-    member __.LinkUnmanagedAppInsights(state:WebAppConfig, name) = { state with AppInsightsName = Some(External (Unmanaged name)) }
+    member __.LinkUnmanagedAppInsights(state:WebAppConfig, name) = { state with AppInsightsName = Some(External (Unmanaged (ResourceName name))) }
     /// Sets the web app to use "run from package" deployment capabilities.
     [<CustomOperation "run_from_package">]
     member __.RunFromPackage(state:WebAppConfig) = { state with RunFromPackage = true }

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -164,18 +164,14 @@ type WebAppConfig =
               ] |> String.concat ","
               Dependencies = [
                   match this.ServicePlanName with
-                  | AutoCreate e -> e.CreateResourceName this
-                  | External (Managed name) -> name
-                  | External (Unmanaged _) -> ()
+                  | DependencyResourceName this resourceName -> resourceName
+                  | _ -> ()
+
                   yield! this.Dependencies
+
                   match this.AppInsightsName with
-                  | Some (AutoCreate e) ->
-                    e.CreateResourceName this
-                  | Some (External (Managed name)) ->
-                    name
-                  | Some (External (Unmanaged _))
-                  | None ->
-                    ()
+                  | Some (DependencyResourceName this resourceName) -> resourceName
+                  | Some _ | None -> ()
               ]
               AlwaysOn = this.AlwaysOn
               LinuxFxVersion =
@@ -247,26 +243,26 @@ type WebAppConfig =
                 ()
 
             match this.AppInsightsName with
-            | Some (AutoCreate c) ->
-                { Name = c.CreateResourceName this
+            | Some (DeployableResource this resourceName) ->
+                { Name = resourceName
                   Location = location
                   LinkedWebsite =
                     match this.OperatingSystem with
                     | Windows -> Some this.Name
                     | Linux -> None }
-            | Some (External _)
+            | Some _
             | None ->
                 ()
 
             match this.ServicePlanName with
-            | AutoCreate c ->
-                { Name = c.CreateResourceName this
+            | DeployableResource this resourceName ->
+                { Name = resourceName
                   Location = location
                   Sku = this.Sku
                   WorkerSize = this.WorkerSize
                   WorkerCount = this.WorkerCount
                   OperatingSystem = this.OperatingSystem }
-            | External _ ->
+            | _ ->
                 ()
         ]
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -121,9 +121,8 @@ type ResourceRef<'T> =
         match this with
         | External (Managed r | Unmanaged r) -> r
         | AutoCreate r -> r.CreateResourceName config
-    member this.withDefault name = match this with AutoCreate (Derived _) -> AutoCreate (Named (ResourceName name)) | x -> x
 [<AutoOpen>]
-module PostResourceRef =
+module ResourceRef =
     let derived derivation = derivation |> Derived |> AutoCreate
     let (|DependencyResourceName|_|) config = function
         | External (Managed r) -> Some (DependencyResourceName r)

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -106,7 +106,13 @@ module ArmExpression =
 /// A ResourceRef represents a linked resource; typically this will be for two resources that have a relationship
 /// such as AppInsights on WebApp. WebApps can automatically create and configure an AI instance for the webapp,
 /// or configure the web app to an existing AI instance, or do nothing.
-type AutoCreationKind<'T> = Named of ResourceName | Derived of ('T -> ResourceName) member this.CreateResourceName config = match this with Named r -> r | Derived f -> f config
+type AutoCreationKind<'T> =
+    | Named of ResourceName
+    | Derived of ('T -> ResourceName)
+    member this.CreateResourceName config =
+        match this with
+        | Named r -> r
+        | Derived f -> f config
 type ExternalKind = Managed of ResourceName | Unmanaged of ResourceName
 type ResourceRef<'T> =
     | AutoCreate of AutoCreationKind<'T>

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -123,6 +123,7 @@ type ResourceRef<'T> =
         | AutoCreate r -> r.CreateResourceName config
 [<AutoOpen>]
 module ResourceRef =
+    /// Creates a ResourceRef which is automatically created and derived from the supplied config.
     let derived derivation = derivation |> Derived |> AutoCreate
     /// An active pattern that returns the resource name if the resource should be set as a dependency.
     /// In other words, all cases except External Unmanaged.

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -124,10 +124,17 @@ type ResourceRef<'T> =
 [<AutoOpen>]
 module ResourceRef =
     let derived derivation = derivation |> Derived |> AutoCreate
-    let (|DependencyResourceName|_|) config = function
-        | External (Managed r) -> Some (DependencyResourceName r)
-        | AutoCreate r -> Some(DependencyResourceName(r.CreateResourceName config))
+    /// An active pattern that returns the resource name if the resource should be set as a dependency.
+    /// In other words, all cases except External Unmanaged.
+    let (|DependableResource|_|) config = function
+        | External (Managed r) -> Some (DependableResource r)
+        | AutoCreate r -> Some(DependableResource(r.CreateResourceName config))
         | External (Unmanaged _) -> None
+    /// An active pattern that returns the resource name if the resource should be deployed. In other
+    /// words, AutoCreate only.
+    let (|DeployableResource|_|) config = function
+        | AutoCreate c -> Some (DeployableResource(c.CreateResourceName config))
+        | External _ -> None
 
 /// Whether a specific feature is active or not.
 type FeatureFlag = Enabled | Disabled member this.AsBoolean = match this with Enabled -> true | Disabled -> false

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -24,6 +24,7 @@ let allTests =
                 SignalR.tests
                 Sql.tests
                 EventGrid.tests
+                WebApp.tests
             ]
             testList "Control" [
                 Template.tests

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -27,12 +27,12 @@ let tests = testList "Cosmos" [
     }
     test "DB properties are correctly evaluated" {
         let db = cosmosDb { name "test" }
-        Expect.equal "[reference(concat('Microsoft.DocumentDb/databaseAccounts/', 'test-server')).documentEndpoint]" (db.Endpoint.Eval()) "Endpoint is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-server'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryMasterKey]" (db.PrimaryKey.Eval()) "Primary Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-server'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).secondaryMasterKey]" (db.SecondaryKey.Eval()) "Secondary Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-server'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryReadonlyMasterKey]" (db.PrimaryReadonlyKey.Eval()) "Primary Readonly Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-server'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).secondaryReadonlyMasterKey]" (db.SecondaryReadonlyKey.Eval()) "Secondary Readonly Key is incorrect"
-        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-server'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" (db.PrimaryConnectionString.Eval()) "Primary Connection String is incorrect"
-        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-server'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" (db.SecondaryConnectionString.Eval()) "Secondary Connection String is incorrect"
+        Expect.equal "[reference(concat('Microsoft.DocumentDb/databaseAccounts/', 'test-account')).documentEndpoint]" (db.Endpoint.Eval()) "Endpoint is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryMasterKey]" (db.PrimaryKey.Eval()) "Primary Key is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).secondaryMasterKey]" (db.SecondaryKey.Eval()) "Secondary Key is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryReadonlyMasterKey]" (db.PrimaryReadonlyKey.Eval()) "Primary Readonly Key is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).secondaryReadonlyMasterKey]" (db.SecondaryReadonlyKey.Eval()) "Secondary Readonly Key is incorrect"
+        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" (db.PrimaryConnectionString.Eval()) "Primary Connection String is incorrect"
+        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" (db.SecondaryConnectionString.Eval()) "Secondary Connection String is incorrect"
     }
 ]

--- a/src/Tests/EventGrid.fs
+++ b/src/Tests/EventGrid.fs
@@ -43,6 +43,6 @@ let tests = testList "Event Grid" [
         let sub = grid.Subscriptions.[0]
         Expect.equal sub.Name (ResourceName "ns-hub-eventhub") "Incorrect subscription name"
         Expect.equal sub.Endpoint (EndpointType.EventHub hub.Name) "Incorrect endpoint type"
-        Expect.equal sub.Destination (hub.EventHubNamespace.CreateResourceName hub) "Incorrect destination"
+        Expect.equal sub.Destination hub.EventHubNamespaceName "Incorrect destination"
     }
 ]

--- a/src/Tests/EventGrid.fs
+++ b/src/Tests/EventGrid.fs
@@ -43,6 +43,6 @@ let tests = testList "Event Grid" [
         let sub = grid.Subscriptions.[0]
         Expect.equal sub.Name (ResourceName "ns-hub-eventhub") "Incorrect subscription name"
         Expect.equal sub.Endpoint (EndpointType.EventHub hub.Name) "Incorrect endpoint type"
-        Expect.equal sub.Destination hub.EventHubNamespace.ResourceName "Incorrect destination"
+        Expect.equal sub.Destination (hub.EventHubNamespace.CreateResourceName hub) "Incorrect destination"
     }
 ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="Sql.fs" />
     <Compile Include="SignalR.fs" />
     <Compile Include="EventGrid.fs" />
+    <Compile Include="WebApp.fs" />
     <Compile Include="AllTests.fs" />
   </ItemGroup>
 

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -1,0 +1,45 @@
+module WebApp
+
+open Expecto
+open Farmer
+open Farmer.Builders
+open Farmer.WebApp
+open Farmer.Arm
+open System
+
+let getResource<'T when 'T :> IArmResource> (data:IArmResource list) = data |> List.choose(function :? 'T as x -> Some x | _ -> None)
+let tests = testList "Web App Tests" [
+    let getResources (wa:WebAppConfig) = (wa :> IBuilder).BuildResources Location.WestEurope
+    test "Basic Web App has service plan and AI dependencies set" {
+        let resources = webApp { name "test" } |> getResources
+        let wa = resources |> getResource<Web.Site> |> List.head
+
+        Expect.containsAll wa.Dependencies [ ResourceName "test-ai"; ResourceName "test-farm" ] "Missing dependencies"
+        Expect.hasLength (resources |> getResource<Insights.Components>) 1 "Should be one AI component"
+        Expect.hasLength (resources |> getResource<Web.ServerFarm>) 1 "Should be one server farm"
+    }
+    test "Web App allows renaming of service plan and AI" {
+        let resources = webApp { name "test"; service_plan_name "supersp"; app_insights_name "superai" } |> getResources
+        let wa = resources |> getResource<Web.Site> |> List.head
+
+        Expect.containsAll wa.Dependencies [ ResourceName "supersp"; ResourceName "superai" ] "Missing dependencies"
+        Expect.hasLength (resources |> getResource<Insights.Components>) 1 "Should be one AI component"
+        Expect.hasLength (resources |> getResource<Web.ServerFarm>) 1 "Should be one server farm"
+    }
+    test "Web App creates dependencies but no resources with linked AI and Server Farm configs" {
+        let sp = servicePlan { name "plan" }
+        let ai = appInsights { name "ai" }
+        let resources = webApp { name "test"; link_to_app_insights ai; link_to_service_plan sp } |> getResources
+        let wa = resources |> getResource<Web.Site> |> List.head
+        Expect.containsAll wa.Dependencies [ ResourceName "plan"; ResourceName "ai" ] "Missing dependencies"
+        Expect.isEmpty (resources |> getResource<Insights.Components>) "Should be no AI component"
+        Expect.isEmpty (resources |> getResource<Web.ServerFarm>) "Should be no server farm"
+    }
+    test "Web App does not create dependencies for unmanaged linked resources" {
+        let resources = webApp { name "test"; link_to_unmanaged_app_insights (ResourceName "test"); link_to_unmanaged_service_plan (ResourceName "test2") } |> getResources
+        let wa = resources |> getResource<Web.Site> |> List.head
+        Expect.isEmpty wa.Dependencies "Should be no dependencies"
+        Expect.isEmpty (resources |> getResource<Insights.Components>) "Should be no AI component"
+        Expect.isEmpty (resources |> getResource<Web.ServerFarm>) "Should be no server farm"
+    }
+]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -36,7 +36,7 @@ let tests = testList "Web App Tests" [
         Expect.isEmpty (resources |> getResource<Web.ServerFarm>) "Should be no server farm"
     }
     test "Web App does not create dependencies for unmanaged linked resources" {
-        let resources = webApp { name "test"; link_to_unmanaged_app_insights (ResourceName "test"); link_to_unmanaged_service_plan (ResourceName "test2") } |> getResources
+        let resources = webApp { name "test"; link_to_unmanaged_app_insights "test"; link_to_unmanaged_service_plan "test2" } |> getResources
         let wa = resources |> getResource<Web.Site> |> List.head
         Expect.isEmpty wa.Dependencies "Should be no dependencies"
         Expect.isEmpty (resources |> getResource<Insights.Components>) "Should be no AI component"


### PR DESCRIPTION
This solves a long-running issue with the `ResourceRef` type which had a state, `AutomaticPlaceholder`, that was effectively a representation of "none" but not quite - essentially a resource that would be automatically created using a derived name, and should have only been valid during the builder stage of the config (i.e. by the time Run finished it would be set).

Theoretically we would have two versions of each Builder config - one which worked with a ResourceRef type that allowed the AutomaticPlaceholder (used during building) and one without (used after building) to guarantee that we have assigned a name to every resource. Unfortunately this would have increased the complexity of types with lots of duplication throughout, so I ruled this out.

We also now have a need in #285 to allow adding a linked resource that is created entirely outside of Farmer. We have the `External` ResourceRef but this is designed for Farmer-created resources, whereas these are entirely external and should not e.g. implicitly create dependencies.

I've redesigned the ResourceRef to have four states:

* AutoCreate Named
* AutoCreate Derived
* External Managed
* External Unmanaged

The Derived case actually stores a function which, given the appropriate config, can generate the resource name. This way it is always valid, so many of the exceptions that were used as catch-alls are now removed. It also makes life a little clearer where and when things should be created.

Also fixes #285 :-)