### PR TITLE
Adds support for attaching volumes to Container Groups

### DIFF
--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -19,6 +19,7 @@ The Container Group builder is used to create Azure Container Group instances.
 | containerInstance | cpu_cores | Sets the maximum CPU cores the container may use. |
 | containerInstance | memory | Sets the maximum gigabytes of memory the container may use. |
 | containerInstance | env_vars | Sets a list of environment variables for the container. |
+| containerInstance | add_volume_mount | Adds a volume mount on a container from a volume in the container group. |
 | containerGroup | add_instances | Adds container instances to the group. |
 | containerGroup | os_type | Sets the OS type (default Linux). |
 | containerGroup | restart_policy | Sets the restart policy (default Always) |
@@ -28,6 +29,7 @@ The Container Group builder is used to create Azure Container Group instances.
 | containerGroup | network_profile | Name of a network profile resource for the subnet in a virtual network where the container group will attach. |
 | containerGroup | add_tcp_port | Adds a TCP port to be externally accessible. |
 | containerGroup | add_udp_port | Adds a UDP port to be externally accessible. |
+| containerGroup | add_volumes | Adds volumes to a container group so they are accessible to containers. |
 
 #### Example
 ```fsharp
@@ -46,6 +48,8 @@ let nginx = containerInstance {
         env_var "CONTENT_PATH" "/www"
         secure_env_var "SECRET_PASSWORD" "shhhhhh!"
     ]
+    add_volume_mount "secret-files" "/config/secrets"
+    add_volume_mount "source-code" "/src/farmer"
 }
 
 let group = containerGroup {
@@ -54,6 +58,10 @@ let group = containerGroup {
     restart_policy AlwaysRestart
     add_udp_port 123us
     add_instances [ nginx ]
+    add_volumes [
+        volume_mount.secret_string "secret-files" "secret1" "abcdefg"
+        volume_mount.git_repo "source-code" (Uri "https://github.com/CompositionalIT/farmer")
+    ]
 }
 ```
 

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -4,6 +4,7 @@ module Farmer.Arm.ContainerInstance
 open Farmer
 open Farmer.ContainerGroup
 open Farmer.CoreTypes
+open Newtonsoft.Json.Linq
 
 let containerGroups = ResourceType "Microsoft.ContainerInstance/containerGroups"
 
@@ -23,14 +24,29 @@ type ContainerGroup =
            Cpu : int
            Memory : float<Gb>
            EnvironmentVariables: Map<string, {| Value:string; Secure:bool |}>
+           VolumeMounts : Map<string,string>
         |} list
       OperatingSystem : OS
       RestartPolicy : RestartPolicy
       IpAddress : ContainerGroupIpAddress
-      NetworkProfile : ResourceName option }
+      NetworkProfile : ResourceName option
+      Volumes : Map<string, {| Volume:Volume |}> }
     member this.NetworkProfilePath =
         this.NetworkProfile
         |> Option.map (fun networkProfile -> ArmExpression.resourceId(Network.networkProfiles, networkProfile).Eval())
+    member private this.dependencies =
+        seq {
+            if this.NetworkProfilePath.IsSome then
+                yield this.NetworkProfilePath.Value
+            let fileShares =
+                this.Volumes |> Seq.choose (fun v ->
+                    match v.Value.Volume with
+                    | Volume.AzureFileShare (shareName, storageAccountName) -> Some (shareName, storageAccountName)
+                    | _ -> None)
+            for shareName, storageAccountName in fileShares do
+                let fullShareName = [ storageAccountName; "default"; shareName ] |> Seq.map ResourceName |> Array.ofSeq
+                yield ArmExpression.resourceId(Storage.fileShares, fullShareName).Eval()
+        }
 
     interface IArmResource with
         member this.ResourceName = this.Name
@@ -39,7 +55,7 @@ type ContainerGroup =
                apiVersion = "2018-10-01"
                name = this.Name.Value
                location = this.Location.ArmValue
-               dependsOn = this.NetworkProfilePath |> Option.toList
+               dependsOn = this.dependencies
                properties =
                    {| containers =
                        this.ContainerInstances
@@ -60,6 +76,7 @@ type ContainerGroup =
                                        {| cpu = container.Cpu
                                           memoryInGB = container.Memory |}
                                    |}
+                                  volumeMounts = container.VolumeMounts |> Seq.map (fun kvp -> {| name=kvp.Key; mountPath=kvp.Value |}) |> List.ofSeq
                                |}
                            |})
                       osType = string this.OperatingSystem
@@ -91,5 +108,42 @@ type ContainerGroup =
                         this.NetworkProfilePath
                         |> Option.map(fun path -> box {| id = path |})
                         |> Option.toObj
+                      volumes = this.Volumes |> Seq.map (fun volume ->
+                          match volume.Key, volume.Value.Volume with
+                          |  volumeName, Volume.AzureFileShare (shareName, accountName) ->
+                              {| name = volumeName
+                                 azureFile =
+                                     {| shareName = shareName
+                                        storageAccountName = accountName
+                                        storageAccountKey = sprintf "[listKeys('Microsoft.Storage/storageAccounts/%s', '2018-07-01').keys[0].value]" accountName |}
+                                 emptyDir = null
+                                 gitRepo = Unchecked.defaultof<_>
+                                 secret = Unchecked.defaultof<_> |}
+                          |  volumeName, Volume.EmptyDirectory ->
+                              {| name = volumeName
+                                 azureFile = Unchecked.defaultof<_>
+                                 emptyDir = obj()
+                                 gitRepo = Unchecked.defaultof<_>
+                                 secret = Unchecked.defaultof<_> |}
+                          |  volumeName, Volume.GitRepo (repository, directory, revision) ->
+                              {| name = volumeName
+                                 azureFile = Unchecked.defaultof<_>
+                                 emptyDir = null
+                                 gitRepo = {| repository = repository
+                                              directory = directory |> Option.toObj
+                                              revision = revision |> Option.toObj |}
+                                 secret = Unchecked.defaultof<_> |}
+                          |  volumeName, Volume.Secret secrets->
+                              {| name = volumeName
+                                 azureFile = Unchecked.defaultof<_>
+                                 emptyDir = null
+                                 gitRepo = Unchecked.defaultof<_>
+                                 secret =
+                                     let jobj = JObject()
+                                     for (SecretFile (name, secret)) in secrets do
+                                         jobj.Add (name, secret |> System.Convert.ToBase64String |> JValue)
+                                     jobj
+                                 |}
+                      )
                    |}
             |} :> _

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -457,6 +457,19 @@ module ContainerGroup =
         | PublicAddressWithDns of DnsName:string
         | PrivateAddress
         | PrivateAddressWithIp of System.Net.IPAddress
+    /// A secret file which will be encoded as base64 and attached to a container group.
+    type SecretFile = SecretFile of Name:string * Secret:byte array
+    /// A container group volume.
+    [<RequireQualifiedAccess>]
+    type Volume =
+        /// Mounts an empty directory on the container group.
+        | EmptyDirectory
+        /// Mounts an Azure File Share in the same resource group, performing a key lookup.
+        | AzureFileShare of ShareName:string * StorageAccountName:string
+        /// A git repo volume, clonable by public HTTPS access.
+        | GitRepo of Repository:Uri * Directory:string option * Revision:string option
+        /// Mounts a volume containing secret files.
+        | Secret of SecretFile list
 
 module Redis =
     type Sku = Basic | Standard | Premium


### PR DESCRIPTION
This lets you attach all four supported types of volumes to a container group where they can become volume mounts on the local filesystem for the containers.

```fsharp
let hello = containerInstance {
    name "hello"
    image "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
    add_ports PublicPort [ 80us ]
    add_volume_mount "shared-socket" "/var/lib/shared/hello"
    add_volume_mount "source-code" "/src/farmer"
    add_volume_mount "secret-files" "/config/secrets"
    add_volume_mount "azure-file" "/var/lib/files"
}
let group =
    containerGroup {
        name "containersWithFiles"
        add_instances [ hello ]
        add_volumes [
            volume_mount.azureFile "azure-file" "fileShare1" "storageAccount1"
            volume_mount.secret_string "secret-files" "secret1" "abcdefg"
            volume_mount.empty_dir "shared-socket"
            volume_mount.git_repo "source-code" (Uri "https://github.com/CompositionalIT/farmer")
        ]
    }
```