### PR TITLE
Introduce Tag support for all currently supported resources

### DIFF
--- a/docs/content/api-overview/resources/nsg.md
+++ b/docs/content/api-overview/resources/nsg.md
@@ -1,0 +1,117 @@
+---
+title: "Network Security Group"
+date: 2020-07-19T16:44:00-04:00
+weight: 5
+chapter: false
+---
+
+#### Overview
+The Network Security Group builder creates network security groups with rules for securing network access to resources.
+
+* Network Security Groups (`Microsoft.Network/networkSecurityGroups`)
+* Security Rules (`Microsoft.Network/networkSecurityGroups/securityRules`)
+
+#### Builder Keywords
+
+| Applies To | Keyword | Purpose |
+|-|-|-|
+| nsg | name | Specifies the name of the network security group |
+| nsg | add_rules | Adds security rules to the network security group |
+| securityRule | name | The name of the security rule |
+| securityRule | description | The description  of the security rule |
+| securityRule | service | The service port(s) and protocol(s) protected by this security rule |
+| securityRule | add_source | Specify access from any source protocol, address, and port |
+| securityRule | add_source_any | Specify access from any address and any port |
+| securityRule | add_source_address | Specify access from a specific address and any port |
+| securityRule | add_source_network | Specify access from a specific network and any port |
+| securityRule | add_source_tag | Specify access from a tagged source such as "Internet", "VirtualNetwork", or "AzureLoadBalancer" |
+| securityRule | add_destination | Specify access to any source protocol, address, and port |
+| securityRule | add_destination_any | Specify access to any address and any port |
+| securityRule | add_destination_address | Specify access to a specific address and any port |
+| securityRule | add_destination_network | Specify access from a specific network and any port |
+| securityRule | add_destination_tag | Specify access to a tagged destination such as "Internet", "VirtualNetwork", or "AzureLoadBalancer" |
+| securityRule | allow | Allows this traffic (the default) |
+| securityRule | deny | Denies this traffic |
+
+#### Basic Example
+
+```fsharp
+open Farmer
+open Farmer.Builders
+open Farmer.NetworkSecurity
+
+// Create a rule for https services accessible from the internet
+let httpsAccess = securityRule {
+    name "web-servers"
+    service (Service ("https", Port 443us))
+    add_source_tag TCP "Internet"
+    add_destination_any
+}
+// Create an NSG and add the rule to it.
+let myNsg = nsg {
+    name "my-nsg"
+    add_rules [
+        httpsAccess
+    ]
+}
+```
+
+#### Multiple Tier Private Network Example
+
+```fsharp
+open Farmer
+open Farmer.Builders
+open Farmer.NetworkSecurity
+
+// Many services have a few ports, such as web services that are often on 80 and 443.
+let web = Services ("web", [
+    Service ("http", Port 80us)
+    Service ("https", Port 443us)
+])
+// Some services only have a single port
+let app = Service ("http", Port 8080us)
+let database = Service ("postgres", Port 5432us)
+
+// Different tiers may reside on different network segments
+let corporateNet = "172.24.0.0/20"
+let webNet = "10.100.30.0/24"
+let appNet = "10.100.31.0/24"
+let dbNet = "10.100.32.0/24"
+
+// Create a rule for web servers - the 'web' service, accessible from the corporate network
+let webAccess = securityRule {
+    name "web-servers"
+    description "Public web server access"
+    service web
+    add_source_network TCP corporateNet
+    add_destination_network webNet
+}
+
+// Create another rule for app servers - accessible only from network with the web servers
+let appAccess= securityRule {
+    name "app-servers"
+    description "Internal app server access"
+    service app
+    add_source_network TCP webNet
+    add_destination_network appNet
+}
+
+// Create another rule for DB servers - accessible only from network with the app servers
+let dbAccess = securityRule {
+    name "db-servers"
+    description "Internal database server access"
+    service database
+    add_source_network TCP appNet
+    add_destination_network dbNet
+}
+
+// Create an NSG and add all 3 rules to it.
+let myNsg = nsg {
+    name "my-nsg"
+    add_rules [
+        webAccess
+        appAccess
+        dbAccess
+    ]
+}
+```

--- a/src/Farmer/Arm/Cache.fs
+++ b/src/Farmer/Arm/Cache.fs
@@ -16,7 +16,8 @@ type Redis =
       RedisConfiguration : Map<string, string>
       NonSslEnabled : bool option
       ShardCount : int option
-      MinimumTlsVersion : TlsVersion option }
+      MinimumTlsVersion : TlsVersion option
+      Tags: Map<string,string> }
       member this.Family =
         match this.Sku.Sku with
         | Basic | Standard -> 'C'
@@ -46,4 +47,5 @@ type Redis =
                          |> Option.toObj
                        redisConfiguration = this.RedisConfiguration
                    |}
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/Cdn.fs
+++ b/src/Farmer/Arm/Cdn.fs
@@ -12,7 +12,8 @@ let customDomains = ResourceType "Microsoft.Cdn/profiles/endpoints/customDomains
 
 type Profile =
     { Name : ResourceName
-      Sku : Sku }
+      Sku : Sku
+      Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -22,6 +23,7 @@ type Profile =
                location = "global"
                sku = {| name = string this.Sku |}
                properties = {||}
+               tags = this.Tags
             |} |> box
 
 module Profiles =
@@ -35,7 +37,8 @@ module Profiles =
           Https : FeatureFlag
           Compression : FeatureFlag
           Origin : string
-          OptimizationType : OptimizationType }
+          OptimizationType : OptimizationType
+          Tags: Map<string,string>  }
         interface IArmResource with
             member this.ResourceName: ResourceName = this.Name
             member this.JsonModel =
@@ -62,6 +65,7 @@ module Profiles =
                                |}
                            ]
                         |}
+                   tags = this.Tags
                 |} :> _
 
     module Endpoints =

--- a/src/Farmer/Arm/CognitiveServices.fs
+++ b/src/Farmer/Arm/CognitiveServices.fs
@@ -10,7 +10,8 @@ type Accounts =
     { Name : ResourceName
       Location : Location
       Sku : CognitiveServices.Sku
-      Kind : CognitiveServices.Kind }
+      Kind : CognitiveServices.Kind
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -21,4 +22,5 @@ type Accounts =
                kind = this.Kind.ToString().Replace("_", ".")
                location = this.Location.ArmValue
                tags = {||}
-               properties = {||} |} :> _
+               properties = {||}
+               tags = this.Tags |} :> _

--- a/src/Farmer/Arm/Compute.fs
+++ b/src/Farmer/Arm/Compute.fs
@@ -16,7 +16,8 @@ type CustomScriptExtension =
       VirtualMachine : ResourceName
       FileUris : Uri list
       ScriptContents : string
-      OS : OS }
+      OS : OS
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -51,6 +52,7 @@ type CustomScriptExtension =
                             |> Encoding.UTF8.GetBytes
                             |> Convert.ToBase64String |}
                     |} :> _
+               tags = this.Tags
             |} :> _
 
 type VirtualMachine =
@@ -62,7 +64,8 @@ type VirtualMachine =
       Image : ImageDefinition
       OsDisk : DiskInfo
       DataDisks : DiskInfo list
-      NetworkInterfaceName : ResourceName }
+      NetworkInterfaceName : ResourceName
+      Tags: Map<string,string>  }
     interface IParameters with
         member this.SecureParameters = [ this.Credentials.Password ]
     interface IArmResource with
@@ -125,4 +128,5 @@ type VirtualMachine =
                        | None ->
                            box {| bootDiagnostics = {| enabled = false |} |}
                |}
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -30,7 +30,8 @@ type ContainerGroup =
       RestartPolicy : RestartPolicy
       IpAddress : ContainerGroupIpAddress
       NetworkProfile : ResourceName option
-      Volumes : Map<string, {| Volume:Volume |}> }
+      Volumes : Map<string, {| Volume:Volume |}>
+      Tags: Map<string,string>  }
     member this.NetworkProfilePath =
         this.NetworkProfile
         |> Option.map (fun networkProfile -> ArmExpression.resourceId(Network.networkProfiles, networkProfile).Eval())
@@ -146,4 +147,5 @@ type ContainerGroup =
                                  |}
                       )
                    |}
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/ContainerRegistry.fs
+++ b/src/Farmer/Arm/ContainerRegistry.fs
@@ -11,7 +11,8 @@ type Registries =
     { Name : ResourceName
       Location : Location
       Sku : Sku
-      AdminUserEnabled : bool }
+      AdminUserEnabled : bool
+      Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -20,6 +21,6 @@ type Registries =
                apiVersion = "2019-05-01"
                sku = {| name = this.Sku.ToString() |}
                location = this.Location.ArmValue
-               tags = {||}
+               tags = this.Tags
                properties = {| adminUserEnabled = this.AdminUserEnabled |}
             |} :> _

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -57,7 +57,8 @@ type Server =
       Family : PostgreSQLFamily
       GeoRedundantBackup : FeatureFlag
       StorageAutoGrow : FeatureFlag
-      BackupRetention : int<Days> }
+      BackupRetention : int<Days>
+      Tags: Map<string,string>  }
 
     member this.Sku =
         {| name = sprintf "%s_%O_%d" this.Tier.Name this.Family this.Capacity
@@ -97,7 +98,7 @@ type Server =
                 apiVersion = "2017-12-01"
                 name = this.Name.Value
                 location = this.Location.ArmValue
-                tags = {| displayName = this.Name.Value |}
+                tags = this.Tags |> Map.add "displayName" this.Name.Value
                 sku = this.Sku
                 properties = this.GetProperties()
             |} :> _

--- a/src/Farmer/Arm/DataLakeStore.fs
+++ b/src/Farmer/Arm/DataLakeStore.fs
@@ -11,7 +11,8 @@ type Account =
     { Name : ResourceName
       Location : Location
       EncryptionState : FeatureFlag
-      Sku : Sku }
+      Sku : Sku
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -22,4 +23,5 @@ type Account =
                properties =
                 {| newTier = this.Sku.ToString()
                    encryptionState = this.EncryptionState.ToString() |}
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/Devices.fs
+++ b/src/Farmer/Arm/Devices.fs
@@ -43,7 +43,8 @@ type iotHubs =
       DefaultTtl : IsoDateTime option
       MaxDeliveryCount : int option
       Feedback : DeliveryDetails option
-      FileNotifications : DeliveryDetails option }
+      FileNotifications : DeliveryDetails option
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -79,13 +80,15 @@ type iotHubs =
                sku =
                 {| name = this.Sku.Name
                    capacity = this.Sku.Capacity |}
+               tags = this.Tags
             |} :> _
 
 type ProvisioningServices =
     { Name : ResourceName
       Location : Location
       IotHubName : ResourceName
-      IotHubKey : ArmExpression }
+      IotHubKey : ArmExpression
+      Tags: Map<string,string>  }
     member this.IotHubConnection =
         sprintf "concat('HostName=%s.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=',%s)"
             this.IotHubName.Value
@@ -111,4 +114,5 @@ type ProvisioningServices =
                    ]
                  |}
                dependsOn = [ this.IotHubName.Value ]
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -87,7 +87,8 @@ type DatabaseAccount =
       ConsistencyPolicy : ConsistencyPolicy
       FailoverPolicy : FailoverPolicy
       PublicNetworkAccess : FeatureFlag
-      FreeTier : bool }
+      FreeTier : bool
+      Tags: Map<string,string>  }
     member this.MaxStatelessPrefix =
         match this.ConsistencyPolicy with
         | BoundedStaleness (staleness, _) -> Some staleness
@@ -144,4 +145,5 @@ type DatabaseAccount =
                       publicNetworkAccess = string this.PublicNetworkAccess
                       enableFreeTier = this.FreeTier
                    |} |> box
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/EventGrid.fs
+++ b/src/Farmer/Arm/EventGrid.fs
@@ -33,7 +33,8 @@ type Topic =
     { Name : ResourceName
       Location : Location
       Source : ResourceName
-      TopicType : TopicType }
+      TopicType : TopicType
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -43,8 +44,9 @@ type Topic =
                location = this.Location.ArmValue
                dependsOn = [ this.Source.Value ]
                properties =
-               {| source = ArmExpression.resourceId(this.TopicType.ResourceType, this.Source).Eval()
-                  topicType = this.TopicType.Value |}
+                  {| source = ArmExpression.resourceId(this.TopicType.ResourceType, this.Source).Eval()
+                     topicType = this.TopicType.Value |}
+               tags = this.Tags
              |} :> _
 
 type Subscription =

--- a/src/Farmer/Arm/EventHub.fs
+++ b/src/Farmer/Arm/EventHub.fs
@@ -19,7 +19,8 @@ type Namespace =
       Sku : {| Name : EventHubSku; Capacity : int |}
       ZoneRedundant : bool option
       AutoInflateSettings : InflateSetting option
-      KafkaEnabled : bool option }
+      KafkaEnabled : bool option
+      Tags: Map<string,string>  }
     member this.MaxThroughputUnits =
         this.AutoInflateSettings
         |> Option.bind (function
@@ -46,6 +47,7 @@ type Namespace =
                         |> Option.toNullable
                        maximumThroughputUnits = this.MaxThroughputUnits |> Option.toNullable
                        kafkaEnabled = this.KafkaEnabled |> Option.toNullable |}
+               tags = this.Tags
             |} :> _
 module Namespaces =
     type EventHub =
@@ -54,7 +56,8 @@ module Namespaces =
           MessageRetentionDays : int option
           Partitions : int
           Dependencies : ResourceName list
-          CaptureDestination : CaptureDestination option }
+          CaptureDestination : CaptureDestination option
+          Tags: Map<string,string>  }
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
@@ -83,6 +86,7 @@ module Namespaces =
                         | None ->
                             null
                     |}
+                  tags = this.Tags
                |} :> _
     module EventHubs =
         type ConsumerGroup =

--- a/src/Farmer/Arm/Insights.fs
+++ b/src/Farmer/Arm/Insights.fs
@@ -9,7 +9,8 @@ let components = ResourceType "Microsoft.Insights/components"
 type Components =
     { Name : ResourceName
       Location : Location
-      LinkedWebsite : ResourceName option }
+      LinkedWebsite : ResourceName option
+      Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -23,7 +24,7 @@ type Components =
                      | Some linkedWebsite -> sprintf "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', '%s')]" linkedWebsite.Value, "Resource"
                      | None -> ()
                      "displayName", "AppInsightsComponent" ]
-                   |> Map.ofList
+                   |> List.fold (fun map (key,value) -> Map.add key value map ) this.Tags
                properties =
                 {| name = this.Name.Value
                    Application_Type = "web"

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -71,7 +71,8 @@ type Vault =
       DefaultAction : DefaultAction option
       Bypass: Bypass option
       IpRules : string list
-      VnetRules : string list }
+      VnetRules : string list
+      Tags: Map<string,string>  }
       member this.PurgeProtection =
         match this.SoftDelete with
         | None
@@ -121,5 +122,6 @@ type Vault =
                         ipRules = this.IpRules
                         virtualNetworkRules = this.VnetRules |}
                  |}
+               tags = this.Tags
              |} :> _
 

--- a/src/Farmer/Arm/Maps.fs
+++ b/src/Farmer/Arm/Maps.fs
@@ -10,7 +10,8 @@ let accounts = ResourceType "Microsoft.Maps/accounts"
 type Maps =
     { Name : ResourceName
       Location : Location
-      Sku : Sku }
+      Sku : Sku
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -24,4 +25,5 @@ type Maps =
                          match this.Sku with
                          | S0 -> "S0"
                          | S1 -> "S1" |}
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -19,7 +19,8 @@ let localNetworkGateways = ResourceType "Microsoft.Network/localNetworkGateways"
 type PublicIpAddress =
     { Name : ResourceName
       Location : Location
-      DomainNameLabel : string option }
+      DomainNameLabel : string option
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -33,13 +34,15 @@ type PublicIpAddress =
                         match this.DomainNameLabel with
                         | Some label -> box {| domainNameLabel = label.ToLower() |}
                         | None -> null |}
+               tags = this.Tags
             |} :> _
 
 type VirtualNetwork =
     { Name : ResourceName
       Location : Location
       AddressSpacePrefixes : string list
-      Subnets : {| Name : ResourceName; Prefix : string; Delegations: {| Name: ResourceName; ServiceName: string |} list |} list; }
+      Subnets : {| Name : ResourceName; Prefix : string; Delegations: {| Name: ResourceName; ServiceName: string |} list |} list;
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -63,6 +66,7 @@ type VirtualNetwork =
                                   |}
                            |})
                     |}
+               tags = this.Tags
             |} :> _
 type VirtualNetworkGateway =
     { Name : ResourceName
@@ -73,7 +77,8 @@ type VirtualNetworkGateway =
       VirtualNetwork : ResourceName
       GatewayType : GatewayType
       VpnType : VpnType
-      EnableBgp : bool }
+      EnableBgp : bool
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -109,6 +114,7 @@ type VirtualNetworkGateway =
                        enableBgp = this.EnableBgp
                        activeActive = this.IpConfigs |> List.length > 1
                     |}
+               tags = this.Tags
             |} :> _
 type Connection =
     { Name : ResourceName
@@ -118,7 +124,8 @@ type Connection =
       VirtualNetworkGateway2 : ResourceName option
       LocalNetworkGateway : ResourceName option
       PeerId : string option
-      AuthorizationKey : string option }
+      AuthorizationKey : string option
+      Tags: Map<string,string>  }
     member private this.VNetGateway1ResourceId = ArmExpression.resourceId(virtualNetworkGateways, this.VirtualNetworkGateway1)
     member private this.VNetGateway2ResourceId = this.VirtualNetworkGateway2 |> Option.map(fun gw -> ArmExpression.resourceId(virtualNetworkGateways, gw))
     member private this.LocalNetworkGatewayResourceId = this.LocalNetworkGateway |> Option.map(fun lng -> ArmExpression.resourceId(localNetworkGateways, lng))
@@ -155,6 +162,7 @@ type Connection =
                             | Some peerId -> box {| id = peerId |}
                             | None -> null
                     |}
+               tags = this.Tags
             |} :> _
 type NetworkInterface =
     { Name : ResourceName
@@ -162,7 +170,8 @@ type NetworkInterface =
       IpConfigs :
         {| SubnetName : ResourceName
            PublicIpName : ResourceName |} list
-      VirtualNetwork : ResourceName }
+      VirtualNetwork : ResourceName
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -187,6 +196,7 @@ type NetworkInterface =
                                 |}
                             |})
                    |}
+               tags = this.Tags
             |} :> _
 type NetworkProfile =
     { Name : ResourceName
@@ -195,7 +205,8 @@ type NetworkProfile =
         {| IpConfigs :
             {| SubnetName : ResourceName |} list
         |} list
-      VirtualNetwork : ResourceName }
+      VirtualNetwork : ResourceName
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -225,6 +236,7 @@ type NetworkProfile =
                            |}
                        )
                    |}
+               tags = this.Tags
             |} :> _
 type ExpressRouteCircuit =
     { Name : ResourceName
@@ -243,7 +255,8 @@ type ExpressRouteCircuit =
            SecondaryPeerAddressPrefix : IPAddressCidr
            SharedKey : string option
            VlanId : int
-        |} list }
+        |} list
+      Tags: Map<string,string>  }
 
     interface IArmResource with
         member this.ResourceName = this.Name
@@ -275,4 +288,5 @@ type ExpressRouteCircuit =
                            peeringLocation = this.PeeringLocation
                            bandwidthInMbps = this.Bandwidth |}
                       globalReachEnabled = this.GlobalReachEnabled |}
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/NetworkSecurityGroup.fs
+++ b/src/Farmer/Arm/NetworkSecurityGroup.fs
@@ -10,14 +10,16 @@ let securityRules = ResourceType "Microsoft.Network/networkSecurityGroups/securi
 
 type NetworkSecurityGroup =
     { Name : ResourceName
-      Location : Location }
+      Location : Location
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
             {| ``type`` = networkSecurityGroups.ArmValue
                apiVersion = "2020-04-01"
                name = this.Name.Value
-               location = this.Location.ArmValue |} :> _
+               location = this.Location.ArmValue
+               tags = this.Tags |} :> _
 
 type SecurityRule =
     { Name : ResourceName

--- a/src/Farmer/Arm/NetworkSecurityGroup.fs
+++ b/src/Farmer/Arm/NetworkSecurityGroup.fs
@@ -10,16 +10,14 @@ let securityRules = ResourceType "Microsoft.Network/networkSecurityGroups/securi
 
 type NetworkSecurityGroup =
     { Name : ResourceName
-      Location : Location
-    }
+      Location : Location }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
             {| ``type`` = networkSecurityGroups.ArmValue
                apiVersion = "2020-04-01"
                name = this.Name.Value
-               location = this.Location.ArmValue
-            |} :> _
+               location = this.Location.ArmValue |} :> _
 
 type SecurityRule =
     { Name : ResourceName
@@ -46,18 +44,17 @@ type SecurityRule =
                name = sprintf "%s/%s" this.SecurityGroup.Name.Value this.Name.Value
                dependsOn = [ ArmExpression.resourceId(networkSecurityGroups, this.SecurityGroup.Name).Eval() ]
                properties =
-                    {| description = this.Description |> Option.toObj
-                       protocol = this.Protocol.ArmValue
-                       sourcePortRanges = this.SourcePorts |> List.map Port.ArmValue
-                       sourcePortRange = this.SourcePort |> Option.map Port.ArmValue |> Option.toObj
-                       destinationPortRanges = this.DestinationPorts |> List.map Port.ArmValue
-                       destinationPortRange = this.DestinationPort |> Option.map Port.ArmValue |> Option.toObj
-                       sourceAddressPrefix = this.SourceAddress |> Option.map Endpoint.ArmValue |> Option.toObj
-                       sourceAddressPrefixes = this.SourceAddresses |> List.map Endpoint.ArmValue
-                       destinationAddressPrefix = this.DestinationAddress |> Option.map Endpoint.ArmValue |> Option.toObj
-                       destinationAddressPrefixes = this.DestinationAddresses |> List.map Endpoint.ArmValue
-                       access = this.Access.ArmValue 
-                       priority = this.Priority
-                       direction = this.Direction.ArmValue
-                    |}
+                {| description = this.Description |> Option.toObj
+                   protocol = this.Protocol.ArmValue
+                   sourcePortRanges = this.SourcePorts |> List.map Port.ArmValue
+                   sourcePortRange = this.SourcePort |> Option.map Port.ArmValue |> Option.toObj
+                   destinationPortRanges = this.DestinationPorts |> List.map Port.ArmValue
+                   destinationPortRange = this.DestinationPort |> Option.map Port.ArmValue |> Option.toObj
+                   sourceAddressPrefix = this.SourceAddress |> Option.map Endpoint.ArmValue |> Option.toObj
+                   sourceAddressPrefixes = this.SourceAddresses |> List.map Endpoint.ArmValue
+                   destinationAddressPrefix = this.DestinationAddress |> Option.map Endpoint.ArmValue |> Option.toObj
+                   destinationAddressPrefixes = this.DestinationAddresses |> List.map Endpoint.ArmValue
+                   access = this.Access.ArmValue
+                   priority = this.Priority
+                   direction = this.Direction.ArmValue |}
             |} :> _

--- a/src/Farmer/Arm/NetworkSecurityGroup.fs
+++ b/src/Farmer/Arm/NetworkSecurityGroup.fs
@@ -1,0 +1,63 @@
+[<AutoOpen>]
+module Farmer.Arm.NetworkSecurityGroup
+
+open Farmer
+open Farmer.CoreTypes
+open Farmer.NetworkSecurity
+
+let networkSecurityGroups = ResourceType "Microsoft.Network/networkSecurityGroups"
+let securityRules = ResourceType "Microsoft.Network/networkSecurityGroups/securityRules"
+
+type NetworkSecurityGroup =
+    { Name : ResourceName
+      Location : Location
+    }
+    interface IArmResource with
+        member this.ResourceName = this.Name
+        member this.JsonModel =
+            {| ``type`` = networkSecurityGroups.ArmValue
+               apiVersion = "2020-04-01"
+               name = this.Name.Value
+               location = this.Location.ArmValue
+            |} :> _
+
+type SecurityRule =
+    { Name : ResourceName
+      Description : string option
+      SecurityGroup : NetworkSecurityGroup
+      Protocol : NetworkProtocol
+      SourcePort : Port option
+      SourcePorts : Port list
+      DestinationPort : Port option
+      DestinationPorts : Port list
+      SourceAddress : Endpoint option
+      SourceAddresses : Endpoint list
+      DestinationAddress : Endpoint option
+      DestinationAddresses : Endpoint list
+      Access : Operation
+      Direction : TrafficDirection
+      Priority : int
+    }
+    interface IArmResource with
+        member this.ResourceName = this.Name
+        member this.JsonModel =
+            {| ``type`` = securityRules.ArmValue
+               apiVersion = "2020-04-01"
+               name = sprintf "%s/%s" this.SecurityGroup.Name.Value this.Name.Value
+               dependsOn = [ ArmExpression.resourceId(networkSecurityGroups, this.SecurityGroup.Name).Eval() ]
+               properties =
+                    {| description = this.Description |> Option.toObj
+                       protocol = this.Protocol.ArmValue
+                       sourcePortRanges = this.SourcePorts |> List.map Port.ArmValue
+                       sourcePortRange = this.SourcePort |> Option.map Port.ArmValue |> Option.toObj
+                       destinationPortRanges = this.DestinationPorts |> List.map Port.ArmValue
+                       destinationPortRange = this.DestinationPort |> Option.map Port.ArmValue |> Option.toObj
+                       sourceAddressPrefix = this.SourceAddress |> Option.map Endpoint.ArmValue |> Option.toObj
+                       sourceAddressPrefixes = this.SourceAddresses |> List.map Endpoint.ArmValue
+                       destinationAddressPrefix = this.DestinationAddress |> Option.map Endpoint.ArmValue |> Option.toObj
+                       destinationAddressPrefixes = this.DestinationAddresses |> List.map Endpoint.ArmValue
+                       access = this.Access.ArmValue 
+                       priority = this.Priority
+                       direction = this.Direction.ArmValue
+                    |}
+            |} :> _

--- a/src/Farmer/Arm/Search.fs
+++ b/src/Farmer/Arm/Search.fs
@@ -12,7 +12,8 @@ type SearchService =
       Location : Location
       Sku :Sku
       ReplicaCount : int
-      PartitionCount : int }
+      PartitionCount : int
+      Tags: Map<string,string>  }
     member this.HostingMode =
         match this.Sku with
         | Standard3 HighDensity -> "highDensity"
@@ -38,4 +39,5 @@ type SearchService =
                 {| replicaCount = this.ReplicaCount
                    partitionCount = this.PartitionCount
                    hostingMode = this.HostingMode |}
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -144,7 +144,8 @@ type Namespace =
     { Name : ResourceName
       Location : Location
       Sku : Sku
-      DependsOn : ResourceName list }
+      DependsOn : ResourceName list
+      Tags: Map<string,string>  }
     member this.Capacity =
         match this.Sku with
         | Basic -> None
@@ -164,4 +165,5 @@ type Namespace =
                        tier = string this.Sku
                        capacity = this.Capacity |> Option.toNullable |}
                dependsOn = this.DependsOn |> List.map (fun r -> r.Value)
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/SignalR.fs
+++ b/src/Farmer/Arm/SignalR.fs
@@ -12,7 +12,8 @@ type SignalR =
       Location : Location
       Sku : Sku
       Capacity : int option
-      AllowedOrigins : string list }
+      AllowedOrigins : string list
+      Tags: Map<string,string>  }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -34,4 +35,5 @@ type SignalR =
                           match this.AllowedOrigins with
                           | [] -> null
                           | aos -> box {| allowedOrigins = aos |} |}
+               tags = this.Tags
             |} :> _

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -18,6 +18,7 @@ type Server =
     { ServerName : ResourceName
       Location : Location
       Credentials : {| Username : string; Password : SecureParameter |}
+      Tags: Map<string,string> 
     }
     interface IParameters with
         member this.SecureParameters = [ this.Credentials.Password ]
@@ -28,7 +29,8 @@ type Server =
                name = this.ServerName.Value
                apiVersion = "2019-06-01-preview"
                location = this.Location.ArmValue
-               tags = {| displayName = this.ServerName.Value |}
+               tags = this.Tags
+                   |> Map.add "displayName" this.ServerName.Value 
                properties =
                    {| administratorLogin = this.Credentials.Username
                       administratorLoginPassword = this.Credentials.Password.AsArmRef.Eval()

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -15,7 +15,8 @@ type StorageAccount =
       Location : Location
       Sku : Sku
       EnableHierarchicalNamespace : bool
-      StaticWebsite : {| IndexPage : string; ErrorPage : string option; ContentPath : string |} option }
+      StaticWebsite : {| IndexPage : string; ErrorPage : string option; ContentPath : string |} option
+      Tags: Map<string,string>}
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
@@ -26,6 +27,7 @@ type StorageAccount =
                apiVersion = "2018-07-01"
                location = this.Location.ArmValue
                properties = {| isHnsEnabled = this.EnableHierarchicalNamespace |}
+               tags = this.Tags
             |} :> _
     interface IPostDeploy with
         member this.Run _ =

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -16,7 +16,8 @@ type ServerFarm =
       Sku: Sku
       WorkerSize : WorkerSize
       WorkerCount : int
-      OperatingSystem : OS }
+      OperatingSystem : OS 
+      Tags: Map<string,string> }
     member this.IsDynamic =
         match this.Sku, this.WorkerSize with
         | Isolated "Y1", Serverless -> true
@@ -76,6 +77,7 @@ type ServerFarm =
                        perSiteScaling = if this.IsDynamic then Nullable() else Nullable false
                        reserved = this.Reserved |}
                kind = this.Kind |> Option.toObj
+               tags = this.Tags
             |} :> _
 
 module ZipDeploy =

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -132,6 +132,7 @@ type Site =
       JavaContainerVersion : string option
       PhpVersion : string option
       PythonVersion : string option
+      Tags : Map<string, string>
       Metadata : List<string * string>
       ZipDeployPath : (string * ZipDeploy.ZipDeployTarget) option }
     interface IParameters with
@@ -168,6 +169,7 @@ type Site =
                  | Some Enabled -> box {| ``type`` = "SystemAssigned" |}
                  | Some Disabled -> box {| ``type`` = "None" |}
                  | None -> null
+               tags = this.Tags
                properties =
                     {| serverFarmId = this.ServicePlan.Value
                        httpsOnly = this.HTTPSOnly

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -10,7 +10,8 @@ let instrumentationKey (ResourceName accountName) =
     |> ArmExpression.create
 
 type AppInsightsConfig =
-    { Name : ResourceName }
+    { Name : ResourceName 
+      Tags : Map<string,string> }
     /// Gets the ARM expression path to the instrumentation key of this App Insights instance.
     member this.InstrumentationKey = instrumentationKey this.Name
     interface IBuilder with
@@ -18,12 +19,14 @@ type AppInsightsConfig =
         member this.BuildResources location = [
             { Name = this.Name
               Location = location
-              LinkedWebsite = None }
+              LinkedWebsite = None
+              Tags = this.Tags }
         ]
 
 type AppInsightsBuilder() =
     member __.Yield _ =
-        { Name = ResourceName.Empty }
+        { Name = ResourceName.Empty
+          Tags = Map.empty }
     [<CustomOperation "name">]
     /// Sets the name of the App Insights instance.
     member __.Name(state:AppInsightsConfig, name) = { state with Name = ResourceName name }

--- a/src/Farmer/Builders/Builders.CognitiveServices.fs
+++ b/src/Farmer/Builders/Builders.CognitiveServices.fs
@@ -8,26 +8,35 @@ open Farmer.CognitiveServices
 type CognitiveServicesConfig =
     { Name : ResourceName
       Sku : Sku
-      Api : Kind }
+      Api : Kind
+      Tags: Map<string,string>  }
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
             { Name = this.Name
               Location = location
               Sku = this.Sku
-              Kind = this.Api }
+              Kind = this.Api
+              Tags = this.Tags }
         ]
 
 type CognitiveServicesBuilder() =
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = F0
-          Api = AllInOne }
+          Api = AllInOne
+          Tags = Map.empty }
     [<CustomOperation "name">]
     member _.Name (state:CognitiveServicesConfig, name) = { state with Name = ResourceName name }
     [<CustomOperation "sku">]
     member _.Sku (state:CognitiveServicesConfig, sku) = { state with Sku = sku }
     [<CustomOperation "api">]
     member _.Api (state:CognitiveServicesConfig, api) = { state with Api = api }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:CognitiveServicesConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:CognitiveServicesConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let cognitiveServices = CognitiveServicesBuilder()

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -9,7 +9,8 @@ open Farmer.Arm.ContainerRegistry
 type ContainerRegistryConfig =
     { Name : ResourceName
       Sku : Sku
-      AdminUserEnabled : bool }
+      AdminUserEnabled : bool
+      Tags: Map<string,string>  }
     member this.LoginServer =
         (sprintf "reference(resourceId('Microsoft.ContainerRegistry/registries', '%s'),'2019-05-01').loginServer" this.Name.Value)
         |> ArmExpression.create
@@ -19,13 +20,15 @@ type ContainerRegistryConfig =
             { Name = this.Name
               Location = location
               Sku = this.Sku
-              AdminUserEnabled = this.AdminUserEnabled }
+              AdminUserEnabled = this.AdminUserEnabled
+              Tags = this.Tags }
         ]
 type ContainerRegistryBuilder() =
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic
-          AdminUserEnabled = false }
+          AdminUserEnabled = false
+          Tags = Map.empty }
 
     [<CustomOperation "name">]
     /// Sets the name of the Azure Container Registry instance.
@@ -38,5 +41,11 @@ type ContainerRegistryBuilder() =
     [<CustomOperation "enable_admin_user">]
     /// Enables the admin user on the Azure Container Registry.
     member _.EnableAdminUser (state:ContainerRegistryConfig) = { state with AdminUserEnabled = true }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:ContainerRegistryConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:ContainerRegistryConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let containerRegistry = ContainerRegistryBuilder()

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -40,7 +40,8 @@ type CosmosDbConfig =
       DbThroughput : int<RU>
       Containers : CosmosDbContainerConfig list
       PublicNetworkAccess : FeatureFlag
-      FreeTier : bool }
+      FreeTier : bool
+      Tags: Map<string,string>  }
     member private this.AccountResourceName = this.AccountName.CreateResourceName this
     member this.PrimaryKey = buildKey this.AccountResourceName "primaryMasterKey"
     member this.SecondaryKey = buildKey this.AccountResourceName "secondaryMasterKey"
@@ -62,7 +63,8 @@ type CosmosDbConfig =
                   ConsistencyPolicy = this.AccountConsistencyPolicy
                   PublicNetworkAccess = this.PublicNetworkAccess
                   FailoverPolicy = this.AccountFailoverPolicy
-                  FreeTier = this.FreeTier }
+                  FreeTier = this.FreeTier
+                  Tags = this.Tags }
             | _ ->
                 ()
 
@@ -154,7 +156,8 @@ type CosmosDbBuilder() =
           DbThroughput = 400<RU>
           Containers = []
           PublicNetworkAccess = Enabled
-          FreeTier = false }
+          FreeTier = false
+          Tags = Map.empty }
 
     /// Sets the name of the CosmosDB server.
     [<CustomOperation "account_name">]
@@ -188,6 +191,12 @@ type CosmosDbBuilder() =
     /// Enables the use of CosmosDB free tier (one per subscription).
     [<CustomOperation "free_tier">]
     member __.FreeTier(state:CosmosDbConfig) = { state with FreeTier = true }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:CosmosDbConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:CosmosDbConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let cosmosDb = CosmosDbBuilder()
 let cosmosContainer = CosmosDbContainerBuilder()

--- a/src/Farmer/Builders/Builders.DataLake.fs
+++ b/src/Farmer/Builders/Builders.DataLake.fs
@@ -9,21 +9,24 @@ open Farmer.Arm.DataLakeStore
 type DataLakeConfig =
     { Name : ResourceName
       EncryptionState : FeatureFlag
-      Sku : Sku }
+      Sku : Sku
+      Tags: Map<string,string>  }
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
             { Name = this.Name
               Location = location
               EncryptionState = this.EncryptionState
-              Sku = this.Sku }
+              Sku = this.Sku
+              Tags = this.Tags  }
         ]
 
 type DataLakeBuilder() =
     member __.Yield _ =
         { Name = ResourceName ""
           EncryptionState = Disabled
-          Sku = Sku.Consumption }
+          Sku = Sku.Consumption
+          Tags = Map.empty}
 
     /// Sets the name of the data lake.
     [<CustomOperation "name">]
@@ -35,5 +38,11 @@ type DataLakeBuilder() =
     [<CustomOperation "sku">]
     member _.Sku (state:DataLakeConfig, sku) =
         { state with Sku = sku }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:DataLakeConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:DataLakeConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let dataLake = DataLakeBuilder()

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -77,7 +77,8 @@ type ExpressRouteConfig =
     /// Indicates if global reach is enabled on this circuit
     GlobalReachEnabled : bool
     /// Peerings on this circuit
-    Peerings : ExpressRouteCircuitPeeringConfig list }
+    Peerings : ExpressRouteCircuitPeeringConfig list
+    Tags: Map<string,string>  }
 
     interface IBuilder with
         member this.DependencyName = this.Name
@@ -100,6 +101,7 @@ type ExpressRouteConfig =
                          SharedKey = peering.SharedKey
                          VlanId = peering.VlanId |}
               ]
+              Tags = this.Tags
             }
         ]
 
@@ -112,7 +114,8 @@ type ExpressRouteBuilder() =
         PeeringLocation = ""
         Bandwidth = 50<Mbps>
         GlobalReachEnabled = false
-        Peerings = [] }
+        Peerings = [] 
+        Tags = Map.empty}
     /// Sets the name of the circuit
     [<CustomOperation "name">]
     member __.Name(state:ExpressRouteConfig, name) = { state with Name = ResourceName name }
@@ -137,4 +140,10 @@ type ExpressRouteBuilder() =
     /// Enables Global Reach on the circuit
     [<CustomOperation "enable_global_reach">]
     member __.EnableGlobalReach(state:ExpressRouteConfig) = { state with GlobalReachEnabled = true }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:ExpressRouteConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:ExpressRouteConfig, key, value) = this.Tags(state, [ (key,value) ])
 let expressRoute = ExpressRouteBuilder()

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -19,6 +19,7 @@ type FunctionsConfig =
       AppInsights : ResourceRef<FunctionsConfig> option
       OperatingSystem : OS
       Settings : Map<string, Setting>
+      Tags : Map<string, string>
       Dependencies : ResourceName list
       Cors : Cors option
       StorageAccount : ResourceRef<FunctionsConfig>
@@ -59,6 +60,7 @@ type FunctionsConfig =
               ServicePlan = this.ServicePlanName
               Location = location
               Cors = this.Cors
+              Tags = this.Tags
               AppSettings = [
                 "FUNCTIONS_WORKER_RUNTIME", (string this.Runtime).ToLower()
                 "WEBSITE_NODE_DEFAULT_VERSION", "10.14.1"
@@ -158,6 +160,7 @@ type FunctionsBuilder() =
           Settings = Map.empty
           Dependencies = []
           Identity = None
+          Tags = Map.empty
           ZipDeployPath = None }
     /// Sets the name of the functions instance.
     [<CustomOperation "name">]
@@ -223,6 +226,12 @@ type FunctionsBuilder() =
     [<CustomOperation "disable_managed_identity">]
     member _.DisableManagedIdentity(state:FunctionsConfig) =
         { state with Identity = Some Disabled }
+    [<CustomOperation "tags">]
+    member _.Tags(state:FunctionsConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "tag">]
+    member this.Tag(state:FunctionsConfig, key, value) = this.Tags(state, [ (key,value) ])
     [<CustomOperation "zip_deploy">]
     /// Specifies a folder path or a zip file containing the function app to install as a post-deployment task.
     member __.ZipDeploy(state:FunctionsConfig, path) = { state with ZipDeployPath = Some path }

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -118,7 +118,8 @@ type FunctionsConfig =
                   Sku = Sku.Y1
                   WorkerSize = Serverless
                   WorkerCount = 0
-                  OperatingSystem = this.OperatingSystem }
+                  OperatingSystem = this.OperatingSystem
+                  Tags = this.Tags }
             | _ ->
                 ()
             match this.StorageAccount with
@@ -127,7 +128,8 @@ type FunctionsConfig =
                   Location = location
                   Sku = Storage.Standard_LRS
                   StaticWebsite = None
-                  EnableHierarchicalNamespace = false}
+                  EnableHierarchicalNamespace = false
+                  Tags = this.Tags }
             | _ ->
                 ()
             match this.AppInsights with
@@ -137,7 +139,8 @@ type FunctionsConfig =
                   LinkedWebsite =
                     match this.OperatingSystem with
                     | Windows -> Some this.Name
-                    | Linux -> None }
+                    | Linux -> None 
+                  Tags = this.Tags }
             | Some _
             | None ->
                 ()
@@ -226,11 +229,11 @@ type FunctionsBuilder() =
     [<CustomOperation "disable_managed_identity">]
     member _.DisableManagedIdentity(state:FunctionsConfig) =
         { state with Identity = Some Disabled }
-    [<CustomOperation "tags">]
+    [<CustomOperation "add_tags">]
     member _.Tags(state:FunctionsConfig, pairs) = 
         { state with 
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "tag">]
+    [<CustomOperation "add_tag">]
     member this.Tag(state:FunctionsConfig, key, value) = this.Tags(state, [ (key,value) ])
     [<CustomOperation "zip_deploy">]
     /// Specifies a folder path or a zip file containing the function app to install as a post-deployment task.

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -87,7 +87,8 @@ type KeyVaultConfig =
       Policies : CreateMode
       NetworkAcl : NetworkAcl
       Uri : Uri option
-      Secrets : SecretConfig list }
+      Secrets : SecretConfig list
+      Tags: Map<string,string>  }
       interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
@@ -125,7 +126,8 @@ type KeyVaultConfig =
                   DefaultAction = this.NetworkAcl.DefaultAction
                   Bypass = this.NetworkAcl.Bypass
                   IpRules = this.NetworkAcl.IpRules
-                  VnetRules = this.NetworkAcl.VnetRules }
+                  VnetRules = this.NetworkAcl.VnetRules 
+                  Tags = this.Tags }
 
             keyVault
             for secret in this.Secrets do
@@ -199,7 +201,8 @@ type KeyVaultBuilderState =
       CreateMode : SimpleCreateMode option
       Policies : AccessPolicyConfig list
       Uri : Uri option
-      Secrets : SecretConfig list }
+      Secrets : SecretConfig list 
+      Tags: Map<string,string> }
 
 type KeyVaultBuilder() =
     member __.Yield (_:unit) =
@@ -211,7 +214,8 @@ type KeyVaultBuilder() =
           Policies = []
           CreateMode = None
           Uri = None
-          Secrets = [] }
+          Secrets = []
+          Tags = Map.empty  }
 
     member __.Run(state:KeyVaultBuilderState) : KeyVaultConfig =
         { Name = state.Name
@@ -226,7 +230,8 @@ type KeyVaultBuilder() =
             | Some SimpleCreateMode.Recover, primary :: secondary -> Recover(primary, secondary)
             | Some SimpleCreateMode.Recover, [] -> failwith "Setting the creation mode to Recover requires at least one access policy. Use the accessPolicy builder to create a policy, and add it to the vault configuration using add_access_policy."
           Secrets = state.Secrets
-          Uri = state.Uri }
+          Uri = state.Uri
+          Tags = state.Tags  }
     /// Sets the name of the vault.
     [<CustomOperation "name">]
     member __.Name(state:KeyVaultBuilderState, name) = { state with Name = name }
@@ -311,6 +316,12 @@ type KeyVaultBuilder() =
     member this.AddSecrets(state:KeyVaultBuilderState, keys) = this.AddSecrets(state, keys |> Seq.map SecretConfig.create)
     member this.AddSecrets(state:KeyVaultBuilderState, items) = this.AddSecrets(state, items |> Seq.map(fun (key, builder:#IBuilder, value) -> SecretConfig.create (key, value, builder.DependencyName)))
     member this.AddSecrets(state:KeyVaultBuilderState, items) = this.AddSecrets(state, items |> Seq.map(fun (key, resourceName:ResourceName, value) -> SecretConfig.create (key, value, resourceName)))
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:KeyVaultBuilderState, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:KeyVaultBuilderState, key, value) = this.Tags(state, [ (key,value) ])
 
 type SecretBuilder() =
     member __.Run(state:SecretConfig) =

--- a/src/Farmer/Builders/Builders.Maps.fs
+++ b/src/Farmer/Builders/Builders.Maps.fs
@@ -8,19 +8,22 @@ open Farmer.Arm.Maps
 
 type MapsConfig =
     { Name : ResourceName
-      Sku : Sku }
+      Sku : Sku 
+      Tags: Map<string,string> }
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources _ = [
             { Name = this.Name
               Location = Location "global"
-              Sku = this.Sku }
+              Sku = this.Sku
+              Tags = this.Tags  }
         ]
 
 type MapsBuilder() =
     member _.Yield _ =
         { Name = ResourceName.Empty
-          Sku = S0 }
+          Sku = S0
+          Tags = Map.empty  }
     member _.Run(state:MapsConfig) =
         { state with Name = state.Name |> sanitiseMaps |> ResourceName }
     /// Sets the name of the Azure Maps instance.
@@ -29,6 +32,11 @@ type MapsBuilder() =
     member this.Name(state:MapsConfig, name) = this.Name(state, ResourceName name)
     /// Sets the SKU of the Azure Maps instance.
     [<CustomOperation("sku")>]
-    member _.Sku(state:MapsConfig, sku) = { state with Sku = sku }
-
+    member _.Sku(state:MapsConfig, sku) = { state with Sku = sku }    
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:MapsConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:MapsConfig, key, value) = this.Tags(state, [ (key,value) ])
 let maps = MapsBuilder()

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -1,0 +1,151 @@
+[<AutoOpen>]
+
+module Farmer.Builders.NetworkSecurityGroup
+
+open Farmer
+open Farmer.NetworkSecurity
+open Farmer.Arm.NetworkSecurityGroup
+
+/// Network access policy
+type SecurityRule =
+    { Name: ResourceName
+      Description : string option
+      Service: Service
+      Source: (NetworkProtocol * Endpoint * Port) list
+      Destination : Endpoint list
+      Operation : Operation }
+
+type SecurityRuleBuilder () =
+    member __.Yield _ =
+        { Name = ResourceName.Empty
+          Description = None
+          Service = Service("any", AnyPort)
+          Source = [ ]
+          Destination = [ ]
+          Operation = Allow
+        }
+    /// Sets the name of the security rule
+    [<CustomOperation "name">]
+    member _.Name(state:SecurityRule, name) = { state with Name = ResourceName name }
+    /// Sets the description of the security rule
+    [<CustomOperation "description">]
+    member _.Description(state:SecurityRule, description) = { state with Description = Some description }
+    /// Sets the service or services protected by this rule.
+    [<CustomOperation("service")>]
+    member _.Service(state:SecurityRule, service) = { state with Service = service }
+    member _.Service(state:SecurityRule, nameAndPort) = { state with Service = Service (nameAndPort |> fst, nameAndPort |> snd |> uint16 |> Port) }
+    /// Sets the source endpoint that is matched in this rule
+    [<CustomOperation("add_source")>]
+    member _.AddSource(state:SecurityRule, source) = { state with Source = source :: state.Source }
+    /// Sets the rule to match on any source endpoint.
+    [<CustomOperation("add_source_any")>]
+    member _.AddSourceAny(state:SecurityRule, protocol) = { state with Source = (protocol, AnyEndpoint, AnyPort) :: state.Source }
+    /// Sets the rule to match on a tagged source endpoint, such as 'Internet'.
+    [<CustomOperation("add_source_tag")>]
+    member _.AddSourceTag(state:SecurityRule, protocol, tag) = { state with Source = (protocol, Tag tag, AnyPort) :: state.Source }
+    /// Sets the rule to match on a source address.
+    [<CustomOperation("add_source_address")>]
+    member _.AddSourceAddress(state:SecurityRule, protocol, sourceAddress) = { state with Source = (protocol, Host (System.Net.IPAddress.Parse sourceAddress), AnyPort) :: state.Source }
+    /// Sets the rule to match on a source network.
+    [<CustomOperation("add_source_network")>]
+    member _.AddSourceNetwork(state:SecurityRule, protocol, sourceNetwork) = { state with Source = (protocol, Network (IPAddressCidr.parse sourceNetwork), AnyPort) :: state.Source }
+    /// Sets the destination endpoint that is matched in this rule
+    [<CustomOperation("add_destination")>]
+    member _.AddDestination(state:SecurityRule, dest) = { state with Destination = dest :: state.Destination }
+    /// Sets the rule to match on any destination endpoint.
+    [<CustomOperation("add_destination_any")>]
+    member _.AddDestinationAny(state:SecurityRule) = { state with Destination = AnyEndpoint :: state.Destination }
+    /// Sets the rule to match on a tagged destination endpoint, such as 'Internet'.
+    [<CustomOperation("add_destination_tag")>]
+    member _.AddDestinationTag(state:SecurityRule, tag) = { state with Destination = Tag tag :: state.Destination }
+    /// Sets the rule to match on a destination address.
+    [<CustomOperation("add_destination_address")>]
+    member _.AddDestinationAddress(state:SecurityRule, destAddress) = { state with Destination = Host (System.Net.IPAddress.Parse destAddress) :: state.Destination }
+    /// Sets the rule to match on a destination network.
+    [<CustomOperation("add_destination_network")>]
+    member _.AddDestinationNetwork(state:SecurityRule, destNetwork) = { state with Destination = Network (IPAddressCidr.parse destNetwork):: state.Destination }
+    /// Sets the rule to allow this traffic (default value).
+    [<CustomOperation("allow")>]
+    member _.Allow(state:SecurityRule) = { state with Operation = Allow }
+    /// Sets the rule to deny this traffic.
+    [<CustomOperation("deny")>]
+    member _.Deny(state:SecurityRule) = { state with Operation = Deny }
+
+let securityRule = SecurityRuleBuilder()
+
+module SecurityRule =
+    let internal buildNsgRule (nsg:NetworkSecurityGroup) (rule:SecurityRule) (priority:int) : IArmResource =
+        let sourcePorts = System.Collections.Generic.HashSet<Port> ()
+        let sourceAddresses = System.Collections.Generic.HashSet<Endpoint> ()
+        let protocols = System.Collections.Generic.HashSet<NetworkProtocol> ()
+        let destPorts = System.Collections.Generic.HashSet<Port> ()
+        let destAddresses = rule.Destination
+        let wildcardOrTag (addresses:Endpoint seq) =
+            // Use a wildcard if there is one
+            if addresses |> Seq.contains AnyEndpoint then Some AnyEndpoint, []
+            else // Use the first tag that is set (only one supported), otherwise use addresses
+                addresses
+                |> Seq.tryFind (function | Tag _ -> true | _ -> false) |> function
+                | Some (Tag tag) -> Some (Tag tag), []
+                | _ -> None, addresses |> List.ofSeq
+
+        let rec collateRules (service:Service) =
+            match service with
+            | Service (_, servicePort) ->
+                destPorts.Add servicePort |> ignore
+                for (protocol, sourceEndpoint, sourcePort) in rule.Source do
+                    protocols.Add protocol |> ignore
+                    sourcePorts.Add sourcePort |> ignore
+                    sourceAddresses.Add sourceEndpoint |> ignore
+            | Services (_, services) ->
+                for service in services do
+                    collateRules service
+        collateRules rule.Service
+        let sourceAddress, sourceAddresses = wildcardOrTag sourceAddresses
+        let destAddress, destAddresses = wildcardOrTag destAddresses
+        { Name = rule.Name
+          Description = None
+          SecurityGroup = nsg
+          Protocol = if protocols.Count > 1 then AnyProtocol else protocols |> Seq.head
+          SourcePort = if sourcePorts.Contains AnyPort then Some AnyPort else None
+          SourcePorts = if sourcePorts.Contains AnyPort then [] else sourcePorts |> List.ofSeq
+          SourceAddress = sourceAddress
+          SourceAddresses = sourceAddresses
+          DestinationPort = if destPorts.Contains AnyPort then Some AnyPort else None
+          DestinationPorts = if destPorts.Contains AnyPort then [] else destPorts |> List.ofSeq
+          DestinationAddress = destAddress
+          DestinationAddresses = destAddresses
+          Access = rule.Operation
+          Direction = Inbound
+          Priority = priority
+        } :> IArmResource
+
+type NsgConfig =
+    { Name : ResourceName
+      SecurityRules : SecurityRule list }
+    interface IBuilder with
+        member this.DependencyName = this.Name
+        member this.BuildResources location =
+            let nsg = 
+                { Name = this.Name
+                  Location = location
+                }
+            let policyRules =
+                seq {
+                    for rule in this.SecurityRules do
+                        yield SecurityRule.buildNsgRule nsg rule
+                }
+                |> Seq.mapi (fun priority rule -> rule ((priority + 1) * 100))
+                |> List.ofSeq
+            (nsg :> IArmResource) :: policyRules
+type NsgBuilder() =
+    member __.Yield _ =
+        { Name = ResourceName.Empty; SecurityRules = [] }
+    /// Sets the name of the network security group
+    [<CustomOperation "name">]
+    member _.Name(state:NsgConfig, name) = { state with Name = ResourceName name }
+    /// Adds rules to this NSG.
+    [<CustomOperation "add_rules">]
+    member _.AddSecurityRules (state:NsgConfig, rules) = { state with SecurityRules = state.SecurityRules @ rules }
+
+let nsg = NsgBuilder()

--- a/src/Farmer/Builders/Builders.Redis.fs
+++ b/src/Farmer/Builders/Builders.Redis.fs
@@ -20,7 +20,8 @@ type RedisConfig =
       RedisConfiguration : Map<string, string>
       NonSslEnabled : bool option
       ShardCount : int option
-      MinimumTlsVersion : TlsVersion option }
+      MinimumTlsVersion : TlsVersion option
+      Tags: Map<string,string> }
     member this.Key = buildRedisKey this.Name
     interface IBuilder with
         member this.DependencyName = this.Name
@@ -33,7 +34,8 @@ type RedisConfig =
               RedisConfiguration = this.RedisConfiguration
               NonSslEnabled = this.NonSslEnabled
               ShardCount = this.ShardCount
-              MinimumTlsVersion = this.MinimumTlsVersion }
+              MinimumTlsVersion = this.MinimumTlsVersion
+              Tags = this.Tags }
         ]
 
 type RedisBuilder() =
@@ -44,7 +46,8 @@ type RedisBuilder() =
           RedisConfiguration = Map.empty
           NonSslEnabled = None
           ShardCount = None
-          MinimumTlsVersion = None }
+          MinimumTlsVersion = None
+          Tags = Map.empty }
     member __.Run (state:RedisConfig) =
         { state with
             Capacity =
@@ -87,5 +90,11 @@ type RedisBuilder() =
     member __.ShardCount(state:RedisConfig, shardCount) = { state with ShardCount = Some shardCount }
     [<CustomOperation "minimum_tls_version">]
     member __.MinimumTlsVersion(state:RedisConfig, tlsVersion) = { state with MinimumTlsVersion = Some tlsVersion }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:RedisConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:RedisConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let redis = RedisBuilder()

--- a/src/Farmer/Builders/Builders.Search.fs
+++ b/src/Farmer/Builders/Builders.Search.fs
@@ -11,7 +11,8 @@ type SearchConfig =
     { Name : ResourceName
       Sku : Sku
       Replicas : int
-      Partitions : int }
+      Partitions : int
+      Tags: Map<string,string>  }
     /// Gets an ARM expression for the admin key of the search instance.
     member this.AdminKey =
         sprintf "listAdminKeys('Microsoft.Search/searchServices/%s', '2015-08-19').primaryKey" this.Name.Value
@@ -27,7 +28,8 @@ type SearchConfig =
               Location = location
               Sku = this.Sku
               ReplicaCount = this.Replicas
-              PartitionCount = this.Partitions }
+              PartitionCount = this.Partitions
+              Tags = this.Tags  }
         ]
 
 type SearchBuilder() =
@@ -35,7 +37,8 @@ type SearchBuilder() =
         { Name = ResourceName.Empty
           Sku = Standard
           Replicas = 1
-          Partitions = 1 }
+          Partitions = 1
+          Tags = Map.empty  }
     member __.Run(state:SearchConfig) =
         { state with Name = state.Name |> sanitiseSearch |> ResourceName }
     /// Sets the name of the Azure Search instance.
@@ -51,5 +54,11 @@ type SearchBuilder() =
     /// Sets the number of partitions of the Azure Search instance.
     [<CustomOperation "partitions">]
     member __.PartitionCount(state:SearchConfig, partitions:int) = { state with Partitions = partitions }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:SearchConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:SearchConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let search = SearchBuilder()

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -123,7 +123,8 @@ type ServiceBusConfig =
       Sku : Sku
       DependsOn : ResourceName list
       Queues : Map<ResourceName, ServiceBusQueueConfig>
-      Topics : Map<ResourceName, ServiceBusTopicConfig> }
+      Topics : Map<ResourceName, ServiceBusTopicConfig>
+      Tags: Map<string,string>  }
     member private _.GetKeyPath sbNsName property =
         sprintf
             "listkeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '%s', 'RootManageSharedAccessKey'), '2017-04-01').%s"
@@ -138,7 +139,8 @@ type ServiceBusConfig =
             { Name = this.Name
               Location = location
               Sku = this.Sku
-              DependsOn = this.DependsOn }
+              DependsOn = this.DependsOn
+              Tags = this.Tags  }
 
             for queue in this.Queues do
               let queue = queue.Value
@@ -186,7 +188,8 @@ type ServiceBusBuilder() =
           Sku = Basic
           Queues = Map.empty
           Topics = Map.empty
-          DependsOn = List.empty }
+          DependsOn = List.empty
+          Tags = Map.empty  }
     member _.Run (state:ServiceBusConfig) =
         let isBetween min max v = v >= min && v <= max
         for queue in state.Queues do
@@ -224,6 +227,12 @@ type ServiceBusBuilder() =
                 (state.Topics, topics)
                 ||> List.fold(fun state (topic:ServiceBusTopicConfig) -> state.Add(topic.Name, topic))
         }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:ServiceBusConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:ServiceBusConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let serviceBus = ServiceBusBuilder()
 let topic = ServiceBusTopicBuilder()

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -55,7 +55,8 @@ type ServiceBusSubscriptionConfig =
       DefaultMessageTimeToLive : TimeSpan option
       MaxDeliveryCount : int option
       Session : bool option
-      DeadLetteringOnMessageExpiration : bool option }
+      DeadLetteringOnMessageExpiration : bool option
+      Rules : Rule list }
 
 type ServiceBusSubscriptionBuilder() =
     member _.Yield _ =
@@ -66,7 +67,8 @@ type ServiceBusSubscriptionBuilder() =
           DefaultMessageTimeToLive = None
           MaxDeliveryCount = None
           Session = None
-          DeadLetteringOnMessageExpiration = None }
+          DeadLetteringOnMessageExpiration = None
+          Rules = List.empty }
 
     /// The name of the queue.
     [<CustomOperation "name">] member _.Name(state:ServiceBusSubscriptionConfig, name) = { state with Name = ResourceName name }
@@ -77,11 +79,13 @@ type ServiceBusSubscriptionBuilder() =
     /// The default time-to-live for messages. If not specified, the maximum TTL will be set for the SKU.
     [<CustomOperation "message_ttl_days">] member _.MessageTtl(state:ServiceBusSubscriptionConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
     /// Enables session support.
-    [<CustomOperation "max_delivery_count">] member _.MaxDeliveryCount(state:ServiceBusQueueConfig, count) = { state with MaxDeliveryCount = Some count }
+    [<CustomOperation "max_delivery_count">] member _.MaxDeliveryCount(state:ServiceBusSubscriptionConfig, count) = { state with MaxDeliveryCount = Some count }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
-    [<CustomOperation "enable_session">] member _.Session(state:ServiceBusQueueConfig) = { state with Session = Some true }
+    [<CustomOperation "enable_session">] member _.Session(state:ServiceBusSubscriptionConfig) = { state with Session = Some true }
     /// Enables dead lettering of messages that expire.
-    [<CustomOperation "enable_dead_letter_on_message_expiration">] member _.DeadLetteringOnMessageExpiration(state:ServiceBusQueueConfig) = { state with DeadLetteringOnMessageExpiration = Some true }
+    [<CustomOperation "enable_dead_letter_on_message_expiration">] member _.DeadLetteringOnMessageExpiration(state:ServiceBusSubscriptionConfig) = { state with DeadLetteringOnMessageExpiration = Some true }
+    /// Adds filtering rules for a subscription
+    [<CustomOperation "add_rules">] member _.AddRules(state:ServiceBusSubscriptionConfig, rules) = { state with Rules = state.Rules @ rules }
 
 type ServiceBusTopicConfig =
     { Name : ResourceName
@@ -171,7 +175,8 @@ type ServiceBusConfig =
                       DefaultMessageTimeToLive = subscription.DefaultMessageTimeToLive |> Option.map IsoDateTime.OfTimeSpan
                       MaxDeliveryCount = subscription.MaxDeliveryCount
                       Session = subscription.Session
-                      DeadLetteringOnMessageExpiration = subscription.DeadLetteringOnMessageExpiration }
+                      DeadLetteringOnMessageExpiration = subscription.DeadLetteringOnMessageExpiration
+                      Rules = subscription.Rules }
 
         ]
 

--- a/src/Farmer/Builders/Builders.ServicePlan.fs
+++ b/src/Farmer/Builders/Builders.ServicePlan.fs
@@ -11,7 +11,8 @@ type ServicePlanConfig =
       Sku : Sku
       WorkerSize : WorkerSize
       WorkerCount : int
-      OperatingSystem : OS }
+      OperatingSystem : OS
+      Tags : Map<string,string> }
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
@@ -20,7 +21,8 @@ type ServicePlanConfig =
             Sku = this.Sku
             WorkerSize = this.WorkerSize
             OperatingSystem = this.OperatingSystem
-            WorkerCount = this.WorkerCount }
+            WorkerCount = this.WorkerCount
+            Tags = this.Tags }
         ]
 
 type ServicePlanBuilder() =
@@ -29,7 +31,8 @@ type ServicePlanBuilder() =
           Sku = Free
           WorkerSize = Small
           WorkerCount = 1
-          OperatingSystem = Windows }
+          OperatingSystem = Windows 
+          Tags = Map.empty }
     [<CustomOperation "name">]
     /// Sets the name of the Server Farm.
     member __.Name(state:ServicePlanConfig, name) = { state with Name = ResourceName name }

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -31,7 +31,9 @@ type StorageAccountConfig =
       /// Queues
       Queues : ResourceName Set
       /// Static Website Settings
-      StaticWebsite : {| IndexPage : string; ContentPath : string; ErrorPage : string option |} option }
+      StaticWebsite : {| IndexPage : string; ContentPath : string; ErrorPage : string option |} option
+      /// Tags to apply to the storage account
+      Tags: Map<string,string> }
     /// Gets the ARM expression path to the key of this storage account.
     member this.Key = buildKey this.Name
     /// Gets the Primary endpoint for static website (if enabled)
@@ -44,7 +46,8 @@ type StorageAccountConfig =
               Location = location
               Sku = this.Sku
               EnableHierarchicalNamespace = this.EnableDataLake
-              StaticWebsite = this.StaticWebsite }
+              StaticWebsite = this.StaticWebsite
+              Tags = this.Tags }
             for name, access in this.Containers do
                 { Name = name
                   StorageAccount = this.Name
@@ -67,6 +70,7 @@ type StorageAccountBuilder() =
         FileShares = []
         Queues = Set.empty
         StaticWebsite = None
+        Tags = Map.empty
     }
     member _.Run(state:StorageAccountConfig) =
         { state with
@@ -113,6 +117,14 @@ type StorageAccountBuilder() =
     /// Enables support for hierarchical namespace, also known as Data Lake Storage Gen2.
     [<CustomOperation "enable_data_lake">]
     member _.UseHns(state:StorageAccountConfig) = { state with EnableDataLake = true }
+    /// Adds tags to the storage account
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:StorageAccountConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    /// Adds a tag to the storage account
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:StorageAccountConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 /// Allow adding storage accounts directly to CDNs
 type EndpointBuilder with

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -32,7 +32,8 @@ type VmConfig =
       SubnetPrefix : string
       Subnet : AutoCreationKind<VmConfig>
 
-      DependsOn : ResourceName list }
+      DependsOn : ResourceName list
+      Tags: Map<string,string> }
 
     member internal this.deriveResourceName = makeName this.Name >> ResourceName
     member this.NicName = this.deriveResourceName "nic"
@@ -59,7 +60,8 @@ type VmConfig =
                     failwithf "You must specify a username for virtual machine %s" this.Name.Value
               Image = this.Image
               OsDisk = this.OsDisk
-              DataDisks = this.DataDisks }
+              DataDisks = this.DataDisks
+              Tags = this.Tags }
 
             // Custom Script
             match this.CustomScript with
@@ -69,7 +71,8 @@ type VmConfig =
                   VirtualMachine = this.Name
                   OS = this.Image.OS
                   ScriptContents = script
-                  FileUris = this.CustomScriptFiles }
+                  FileUris = this.CustomScriptFiles
+                  Tags = this.Tags }
             | None ->
                 ()
 
@@ -82,7 +85,8 @@ type VmConfig =
               IpConfigs = [
                 {| SubnetName = subnetName
                    PublicIpName = this.IpName |} ]
-              VirtualNetwork = vnetName }
+              VirtualNetwork = vnetName
+              Tags = this.Tags }
 
             // VNET
             match this.VNet with
@@ -95,6 +99,7 @@ type VmConfig =
                          Prefix = this.SubnetPrefix
                          Delegations = [] |}
                   ]
+                  Tags = this.Tags
                 }
             | _ ->
                 ()
@@ -102,7 +107,8 @@ type VmConfig =
             // IP Address
             { Name = this.IpName
               Location = location
-              DomainNameLabel = this.DomainNamePrefix }
+              DomainNameLabel = this.DomainNamePrefix
+              Tags = this.Tags }
 
             // Storage account - optional
             match this.DiagnosticsStorageAccount with
@@ -111,7 +117,8 @@ type VmConfig =
                   Location = location
                   Sku = Storage.Standard_LRS
                   StaticWebsite = None
-                  EnableHierarchicalNamespace = false }
+                  EnableHierarchicalNamespace = false
+                  Tags = this.Tags }
             | Some _
             | None ->
                 ()
@@ -133,7 +140,8 @@ type VirtualMachineBuilder() =
           SubnetPrefix = "10.0.0.0/24"
           VNet = derived (fun config -> config.deriveResourceName "vnet")
           Subnet = Derived(fun config -> config.deriveResourceName "subnet")
-          DependsOn = [] }
+          DependsOn = []
+          Tags = Map.empty }
 
     member __.Run (state:VmConfig) =
         { state with
@@ -210,5 +218,11 @@ type VirtualMachineBuilder() =
     member _.CustomScript(state:VmConfig, script:string) = { state with CustomScript = Some script }
     [<CustomOperation "custom_script_files">]
     member _.CustomScriptFiles(state:VmConfig, uris:string list) = { state with CustomScriptFiles = uris |> List.map Uri }
+    [<CustomOperation "add_tags">]
+    member _.Tags(state:VmConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "add_tag">]
+    member this.Tag(state:VmConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let vm = VirtualMachineBuilder()

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -75,6 +75,7 @@ type WebAppConfig =
       OperatingSystem : OS
       Settings : Map<string, Setting>
       Dependencies : ResourceName list
+      Tags : Map<string,string>
 
       Cors : Cors option
       Sku : Sku
@@ -119,6 +120,7 @@ type WebAppConfig =
               WebSocketsEnabled = this.WebSocketsEnabled
               Identity = this.Identity
               Cors = this.Cors
+              Tags = this.Tags
               AppSettings =
                 let literalSettings = [
                     if this.RunFromPackage then AppSettings.RunFromPackage
@@ -282,6 +284,7 @@ type WebAppBuilder() =
           ClientAffinityEnabled = None
           WebSocketsEnabled = None
           Settings = Map.empty
+          Tags = Map.empty
           Dependencies = []
           Identity = None
           Runtime = Runtime.DotNetCoreLts
@@ -440,6 +443,12 @@ type WebAppBuilder() =
     member this.EnableCi(state:WebAppConfig) = this.SourceControlCi(state, Enabled)
     [<CustomOperation "disable_source_control_ci">]
     member this.DisableCi(state:WebAppConfig) = this.SourceControlCi(state, Disabled)
+    [<CustomOperation "tags">]
+    member _.Tags(state:WebAppConfig, pairs) = 
+        { state with 
+            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
+    [<CustomOperation "tag">]
+    member this.Tag(state:WebAppConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let webApp = WebAppBuilder()
 

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -251,7 +251,8 @@ type WebAppConfig =
                   LinkedWebsite =
                     match this.OperatingSystem with
                     | Windows -> Some this.Name
-                    | Linux -> None }
+                    | Linux -> None
+                  Tags = this.Tags }
             | Some _
             | None ->
                 ()
@@ -263,7 +264,8 @@ type WebAppConfig =
                   Sku = this.Sku
                   WorkerSize = this.WorkerSize
                   WorkerCount = this.WorkerCount
-                  OperatingSystem = this.OperatingSystem }
+                  OperatingSystem = this.OperatingSystem 
+                  Tags = this.Tags}
             | _ ->
                 ()
         ]
@@ -443,11 +445,11 @@ type WebAppBuilder() =
     member this.EnableCi(state:WebAppConfig) = this.SourceControlCi(state, Enabled)
     [<CustomOperation "disable_source_control_ci">]
     member this.DisableCi(state:WebAppConfig) = this.SourceControlCi(state, Disabled)
-    [<CustomOperation "tags">]
+    [<CustomOperation "add_tags">]
     member _.Tags(state:WebAppConfig, pairs) = 
         { state with 
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "tag">]
+    [<CustomOperation "add_tag">]
     member this.Tag(state:WebAppConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let webApp = WebAppBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -780,7 +780,7 @@ module NetworkSecurity =
     type Service =
     | Service of Name:string * Port
     | Services of Name:string * Service list
-    
+
     type TrafficDirection = Inbound | Outbound
     module TrafficDirection =
         let ArmValue = function | Inbound -> "Inbound" | Outbound -> "Outbound"

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -641,17 +641,19 @@ module DataLake =
     | Commitment_1PB
     | Commitment_5PB
 
+/// A network represented by an IP address and CIDR prefix.
 type public IPAddressCidr =
     { Address : System.Net.IPAddress
       Prefix : int }
 
+/// Functions for IP networks and CIDR notation.
 module IPAddressCidr =
     let parse (s:string) : IPAddressCidr =
         match s.Split([|'/'|], System.StringSplitOptions.RemoveEmptyEntries) with
         [| ip; prefix |] ->
             { Address = System.Net.IPAddress.Parse (ip.Trim ())
               Prefix = int prefix }
-        | _ -> raise (System.ArgumentOutOfRangeException "Malformed CIDR, expecting and IP and prefix separated by '/'")
+        | _ -> raise (System.ArgumentOutOfRangeException "Malformed CIDR, expecting an IP and prefix separated by '/'")
     let safeParse (s:string) : Result<IPAddressCidr, System.Exception> =
         try parse s |> Ok
         with ex -> Error ex
@@ -714,6 +716,76 @@ module IPAddressCidr =
             cidr |> addresses |> Seq.skip 2
         else
             Seq.empty
+
+module NetworkSecurity =
+    type Operation =
+    | Allow
+    | Deny
+    module Operation =
+        let ArmValue = function
+        | Allow -> "Allow"
+        | Deny -> "Deny"
+    type Operation with
+        member this.ArmValue = this |> Operation.ArmValue
+
+    /// Network protocol supported in network security group rules.
+    type NetworkProtocol =
+    /// Any protocol
+    | AnyProtocol
+    /// Transmission Control Protocol
+    | TCP
+    /// User Datagram Protocol
+    | UDP
+    /// Internet Control Message Protocol
+    | ICMP
+    /// Authentication Header (IPSec)
+    | AH
+    /// Encapsulating Security Payload (IPSec)
+    | ESP
+    module NetworkProtocol =
+        let ArmValue = function
+            | AnyProtocol -> "*"
+            | TCP -> "Tcp"
+            | UDP -> "Udp"
+            | ICMP -> "Icmp"
+            | AH -> "Ah"
+            | ESP -> "Esp"
+    type NetworkProtocol with
+        member this.ArmValue = this |> NetworkProtocol.ArmValue
+
+    type Port =
+    | Port of uint16
+    | Range of First:uint16 * Last:uint16
+    | AnyPort
+    module Port =
+        let ArmValue = function
+        | Port num -> num |> string
+        | Range (first,last) -> sprintf "%d-%d" first last
+        | AnyPort -> "*"
+    type Port with
+        member this.ArmValue = this |> Port.ArmValue
+
+    type Endpoint =
+    | Host of System.Net.IPAddress
+    | Network of IPAddressCidr
+    | Tag of string
+    | AnyEndpoint
+    module Endpoint =
+        let ArmValue = function
+        | Host ip -> string ip
+        | Network cidr -> cidr |> IPAddressCidr.format
+        | Tag tag -> tag
+        | AnyEndpoint -> "*"
+
+    type Service =
+    | Service of Name:string * Port
+    | Services of Name:string * Service list
+    
+    type TrafficDirection = Inbound | Outbound
+    module TrafficDirection =
+        let ArmValue = function | Inbound -> "Inbound" | Outbound -> "Outbound"
+    type TrafficDirection with
+        member this.ArmValue = this |> TrafficDirection.ArmValue
 
 module Cdn =
     type Sku =

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -72,6 +72,7 @@
     <Compile Include="Arm/Maps.fs" />
     <Compile Include="Arm/SignalR.fs" />
     <Compile Include="Arm/EventGrid.fs" />
+    <Compile Include="Arm\NetworkSecurityGroup.fs" />
 
     <Compile Include="Builders/Builders.Helpers.fs" />
     <Compile Include="Builders/Builders.PostgreSQL.fs" />
@@ -100,5 +101,6 @@
     <Compile Include="Builders/Builders.VirtualNetworkGateway.fs" />
     <Compile Include="Builders/Builders.VirtualNetwork.fs" />
     <Compile Include="Builders/Builders.EventGrid.fs" />
+    <Compile Include="Builders\Builders.NetworkSecurityGroup.fs" />
   </ItemGroup>
 </Project>

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -16,6 +16,7 @@ let allTests =
                 ContainerRegistry.tests
                 ExpressRoute.tests
                 KeyVault.tests
+                NetworkSecurityGroup.tests
                 ServiceBus.tests
                 VirtualMachine.tests
                 PostgreSQL.tests

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -1,0 +1,199 @@
+module NetworkSecurityGroup
+
+open Expecto
+open Farmer
+open Farmer.NetworkSecurity
+open Farmer.Arm.NetworkSecurityGroup
+open Farmer.Builders
+open Microsoft.Azure.Management.Network
+open Microsoft.Azure.Management.Network.Models
+open Microsoft.Rest
+open System
+
+let client = new NetworkManagementClient(Uri "http://management.azure.com", TokenCredentials "NotNullOrWhiteSpace")
+let tests = testList "NetworkSecurityGroup" [
+    test "Can create a network security group in an ARM template" {
+        let resource =
+            let nsg =
+                { Name = ResourceName "my-nsg"
+                  Location = Location.WestEurope
+                }
+            arm { add_resource nsg }
+            |> findAzureResources<NetworkSecurityGroup> client.SerializationSettings
+            |> List.head
+        Expect.equal resource.Name "my-nsg" ""
+    }
+    test "Can create a network security group with rules in an ARM template" {
+        let rules =
+            let nsg =
+                { Name = ResourceName "my-nsg"
+                  Location = Location.WestEurope
+                }
+            let acceptRule =
+                { Name = ResourceName "accept-web"
+                  Description = Some (sprintf "Rule created on %s" (DateTimeOffset.Now.Date.ToShortDateString()))
+                  SecurityGroup = nsg
+                  Protocol = TCP
+                  SourcePort = Some AnyPort
+                  SourcePorts = [ ]
+                  DestinationPort = None
+                  DestinationPorts = [ Port 80us; Port 443us ]
+                  SourceAddress = Some AnyEndpoint
+                  SourceAddresses = [ ]
+                  DestinationAddress = None
+                  DestinationAddresses = [ Network (IPAddressCidr.parse "10.100.30.0/24") ]
+                  Access = Allow
+                  Direction = Inbound
+                  Priority = 100
+                } :> IArmResource
+            arm {
+                add_resource nsg
+                add_resource acceptRule
+            }
+            |> findAzureResources<SecurityRule> client.SerializationSettings
+        
+        match rules with
+        | [ _; rule1 ] ->
+            rule1.Validate()
+            Expect.equal rule1.Name "my-nsg/accept-web" ""
+            Expect.equal rule1.Access "Allow" ""
+            Expect.equal rule1.DestinationAddressPrefixes.[0] "10.100.30.0/24" ""
+            Expect.equal rule1.DestinationPortRanges.[0] "80" ""
+            Expect.equal rule1.DestinationPortRanges.[1] "443" ""
+            Expect.equal rule1.Direction "Inbound" ""
+            Expect.equal rule1.Protocol "Tcp" ""
+            Expect.equal rule1.Priority (Nullable 100) ""
+            Expect.equal rule1.SourceAddressPrefix "*" ""
+            Expect.equal rule1.SourcePortRange "*" ""
+            Expect.equal rule1.SourcePortRanges.Count 0 ""
+            rule1.Validate()
+        | _ -> failwithf "Unexpected number of resources in template."
+    }
+    test "Policy converted to security rules" {
+        let web = Services ("web", [
+            Service ("http", Port 80us)
+            Service ("https", Port 443us)
+        ])
+        let webPolicy = securityRule {
+            name "web-servers"
+            description "Public web server access"
+            service web
+            add_source_tag TCP "Internet"
+            add_destination_network "10.100.30.0/24"
+            allow
+        }
+        let myNsg = nsg {
+            name "my-nsg"
+            add_rules [
+                webPolicy
+            ]
+        }
+        let rules =
+            arm {
+                add_resource myNsg
+            }
+            |> findAzureResources<SecurityRule> client.SerializationSettings
+        match rules with
+        | [ _; rule1 ] ->
+            rule1.Validate()
+            Expect.equal rule1.Name "my-nsg/web-servers" ""
+            Expect.equal rule1.Access "Allow" ""
+            Expect.equal rule1.DestinationAddressPrefixes.[0] "10.100.30.0/24" ""
+            Expect.equal rule1.DestinationPortRanges.[0] "80" ""
+            Expect.equal rule1.DestinationPortRanges.[1] "443" ""
+            Expect.equal rule1.Direction "Inbound" ""
+            Expect.equal rule1.Protocol "Tcp" ""
+            Expect.equal rule1.Priority (Nullable 100) ""
+            Expect.equal rule1.SourceAddressPrefix "Internet" ""
+            Expect.equal rule1.SourcePortRange "*" ""
+            Expect.equal rule1.SourcePortRanges.Count 0 ""
+        | _ -> failwithf "Unexpected number of resources in template."
+    }
+    test "Multitier Policy converted to security rules" {
+        let web = Services ("web", [
+            Service ("http", Port 80us)
+            Service ("https", Port 443us)
+        ])
+        let webNet = "10.100.30.0/24"
+        let app = Service ("http", Port 8080us)
+        let appNet = "10.100.31.0/24"
+        let database = Service ("postgres", Port 5432us)
+        let dbNet = "10.100.32.0/24"
+        let webPolicy = securityRule { // Web servers - accessible from anything
+            name "web-servers"
+            description "Public web server access"
+            service web
+            add_source_tag TCP "Internet"
+            add_destination_network "10.100.30.0/24"
+            allow
+        }
+        let appPolicy = securityRule { // Only accessible by web servers
+            name "app-servers"
+            description "Internal app server access"
+            service app
+            add_source_network TCP webNet
+            add_destination_network appNet
+            allow
+        }
+        let dbPolicy = securityRule { // DB servers - not accessible by web, only by app servers
+            name "db-servers"
+            description "Internal database server access"
+            service ("postgres", 5432)
+            add_source_network TCP appNet
+            add_destination_network dbNet
+            allow
+        }
+        let myNsg = nsg {
+            name "my-nsg"
+            add_rules [
+                webPolicy
+                appPolicy
+                dbPolicy
+            ]
+        }
+        let rules =
+            arm {
+                add_resource myNsg
+            }
+            |> findAzureResources<SecurityRule> client.SerializationSettings
+        match rules with
+        | [ _; rule1; rule2; rule3 ] ->
+            // Web server access
+            rule1.Validate()
+            Expect.equal rule1.Name "my-nsg/web-servers" ""
+            Expect.equal rule1.Access "Allow" ""
+            Expect.equal rule1.DestinationAddressPrefixes.[0] "10.100.30.0/24" ""
+            Expect.equal rule1.DestinationPortRanges.[0] "80" ""
+            Expect.equal rule1.DestinationPortRanges.[1] "443" ""
+            Expect.equal rule1.Direction "Inbound" ""
+            Expect.equal rule1.Protocol "Tcp" ""
+            Expect.equal rule1.Priority (Nullable 100) ""
+            Expect.equal rule1.SourceAddressPrefix "Internet" ""
+            Expect.equal rule1.SourceAddressPrefixes.Count 0 ""
+            Expect.equal rule1.SourcePortRange "*" ""
+            Expect.equal rule1.SourcePortRanges.Count 0 ""
+            // App server access
+            rule2.Validate()
+            Expect.equal rule2.Name "my-nsg/app-servers" ""
+            Expect.equal rule2.Access "Allow" ""
+            Expect.equal rule2.DestinationAddressPrefixes.[0] "10.100.31.0/24" ""
+            Expect.equal rule2.DestinationPortRanges.[0] "8080" ""
+            Expect.equal rule2.Direction "Inbound" ""
+            Expect.equal rule2.Protocol "Tcp" ""
+            Expect.equal rule2.Priority (Nullable 200) ""
+            Expect.equal rule2.SourceAddressPrefixes.[0] "10.100.30.0/24" ""
+            Expect.equal rule1.SourcePortRanges.Count 0 ""
+            // DB server access
+            rule3.Validate()
+            Expect.equal rule3.Name "my-nsg/db-servers" ""
+            Expect.equal rule3.Access "Allow" ""
+            Expect.equal rule3.DestinationAddressPrefixes.[0] "10.100.32.0/24" ""
+            Expect.equal rule3.DestinationPortRanges.[0] "5432" ""
+            Expect.equal rule3.Direction "Inbound" ""
+            Expect.equal rule3.Protocol "Tcp" ""
+            Expect.equal rule3.Priority (Nullable 300) ""
+            Expect.equal rule3.SourceAddressPrefixes.[0] "10.100.31.0/24" ""
+            Expect.equal rule1.SourcePortRanges.Count 0 ""
+        | _ -> failwithf "Unexpected number of resources in template."
+    }
+]

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -17,7 +17,7 @@ let tests = testList "NetworkSecurityGroup" [
             let nsg =
                 { Name = ResourceName "my-nsg"
                   Location = Location.WestEurope
-                }
+                  Tags = Map.empty }
             arm { add_resource nsg }
             |> findAzureResources<NetworkSecurityGroup> client.SerializationSettings
             |> List.head
@@ -28,7 +28,7 @@ let tests = testList "NetworkSecurityGroup" [
             let nsg =
                 { Name = ResourceName "my-nsg"
                   Location = Location.WestEurope
-                }
+                  Tags = Map.empty }
             let acceptRule =
                 { Name = ResourceName "accept-web"
                   Description = Some (sprintf "Rule created on %s" (DateTimeOffset.Now.Date.ToShortDateString()))

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -51,7 +51,7 @@ let tests = testList "NetworkSecurityGroup" [
                 add_resource acceptRule
             }
             |> findAzureResources<SecurityRule> client.SerializationSettings
-        
+
         match rules with
         | [ _; rule1 ] ->
             rule1.Validate()
@@ -84,15 +84,9 @@ let tests = testList "NetworkSecurityGroup" [
         }
         let myNsg = nsg {
             name "my-nsg"
-            add_rules [
-                webPolicy
-            ]
+            add_rules [ webPolicy ]
         }
-        let rules =
-            arm {
-                add_resource myNsg
-            }
-            |> findAzureResources<SecurityRule> client.SerializationSettings
+        let rules = arm { add_resource myNsg } |> findAzureResources<SecurityRule> client.SerializationSettings
         match rules with
         | [ _; rule1 ] ->
             rule1.Validate()
@@ -138,7 +132,7 @@ let tests = testList "NetworkSecurityGroup" [
         let dbPolicy = securityRule { // DB servers - not accessible by web, only by app servers
             name "db-servers"
             description "Internal database server access"
-            service ("postgres", 5432)
+            service database
             add_source_network TCP appNet
             add_destination_network dbNet
             allow
@@ -151,11 +145,7 @@ let tests = testList "NetworkSecurityGroup" [
                 dbPolicy
             ]
         }
-        let rules =
-            arm {
-                add_resource myNsg
-            }
-            |> findAzureResources<SecurityRule> client.SerializationSettings
+        let rules = arm { add_resource myNsg } |> findAzureResources<SecurityRule> client.SerializationSettings
         match rules with
         | [ _; rule1; rule2; rule3 ] ->
             // Web server access

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Cdn.fs" />
     <Compile Include="ContainerGroup.fs" />
     <Compile Include="ExpressRoute.fs" />
+    <Compile Include="NetworkSecurityGroup.fs" />
     <Compile Include="Storage.fs" />
     <Compile Include="ServiceBus.fs" />
     <Compile Include="IotHub.fs" />

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -42,4 +42,14 @@ let tests = testList "Web App Tests" [
         Expect.isEmpty (resources |> getResource<Insights.Components>) "Should be no AI component"
         Expect.isEmpty (resources |> getResource<Web.ServerFarm>) "Should be no server farm"
     }
+    test "Web app supports adding tags to resource" {
+        let resources = webApp { name "test"; tag "key" "value"; tags ["alpha","a"; "beta","b"]} |> getResources
+        let wa = resources |> getResource<Web.Site> |> List.head
+        Expect.containsAll (wa.Tags|> Map.toSeq) 
+            [ "key","value"
+              "alpha","a"
+              "beta","b"]
+            "Should contain the given tags"
+        Expect.equal 3 (wa.Tags|> Map.count) "Should not contain additional tags"
+    }
 ]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -43,7 +43,7 @@ let tests = testList "Web App Tests" [
         Expect.isEmpty (resources |> getResource<Web.ServerFarm>) "Should be no server farm"
     }
     test "Web app supports adding tags to resource" {
-        let resources = webApp { name "test"; tag "key" "value"; tags ["alpha","a"; "beta","b"]} |> getResources
+        let resources = webApp { name "test"; add_tag "key" "value"; add_tags ["alpha","a"; "beta","b"]} |> getResources
         let wa = resources |> getResource<Web.Site> |> List.head
         Expect.containsAll (wa.Tags|> Map.toSeq) 
             [ "key","value"


### PR DESCRIPTION
This is an initial step in implementing tag support for resources (#298). At the moment, this only affects the `webApp` and `function` builders. If this implementation is acceptable, I will follow the same pattern for the other builders. and then update docs

**Usage:**

```fsharp
webApp{
  name "my-web-app"
  tag "key" "value"
  tags [ "alpha","a"; "beta","b" ]
}
```