### PR TITLE
NSG simplification

### DIFF
--- a/src/Farmer/Arm/NetworkSecurityGroup.fs
+++ b/src/Farmer/Arm/NetworkSecurityGroup.fs
@@ -34,8 +34,7 @@ type SecurityRule =
       DestinationAddresses : Endpoint list
       Access : Operation
       Direction : TrafficDirection
-      Priority : int
-    }
+      Priority : int }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =

--- a/src/Farmer/Builders/Builders.EventGrid.fs
+++ b/src/Farmer/Builders/Builders.EventGrid.fs
@@ -88,7 +88,7 @@ type EventGridConfig<'T> =
            Destination : ResourceName
            Endpoint : EndpointType
            SystemEvents : EventGridEvent list |} list
-      Tags: Map<string,string> 
+      Tags: Map<string,string>
     }
     interface IBuilder with
         member this.DependencyName = this.TopicName
@@ -152,8 +152,8 @@ type EventGridBuilder() =
     member _.AddEventHubSubscription(state:EventGridConfig<'T> when 'T :> IEventGridEvent, eventHub:EventHubConfig, events:'T list) =
         EventGridBuilder.AddSub(state, eventHub.Name.Value + "-eventhub", eventHub.EventHubNamespaceName, EventHub eventHub.Name, events |> List.map (fun x -> x.ToEvent))
     [<CustomOperation "add_tags">]
-    member _.Tags(state:EventGridConfig<'T>, pairs) = 
-        { state with 
+    member _.Tags(state:EventGridConfig<'T>, pairs) =
+        { state with
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
     [<CustomOperation "add_tag">]
     member this.Tag(state:EventGridConfig<'T>, key, value) = this.Tags(state, [ (key,value) ])

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -109,6 +109,8 @@ let internal buildNsgRule (nsg:NetworkSecurityGroup) (rule:SecurityRuleConfig) (
       Description = None
       SecurityGroup = nsg
       Protocol = if protocols.Count > 1 then AnyProtocol else protocols |> Seq.head
+
+      // TODO: What is the semantic meaning here? Is there a relationship between source port and ports?
       SourcePort = if sourcePorts.Contains AnyPort then Some AnyPort else None
       SourcePorts = if sourcePorts.Contains AnyPort then [] else sourcePorts |> List.ofSeq
       SourceAddress = sourceAddress

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -12,18 +12,18 @@ open System.Net
 type SecurityRuleConfig =
     { Name: ResourceName
       Description : string option
-      Service: Service
-      Source: (NetworkProtocol * Endpoint * Port) list
-      Destination : Endpoint list
+      Services: {| Name : string; Services : Service list |}
+      Sources: (NetworkProtocol * Endpoint * Port) list
+      Destinations : Endpoint list
       Operation : Operation }
 
 type SecurityRuleBuilder () =
     member __.Yield _ =
         { Name = ResourceName.Empty
           Description = None
-          Service = Service("any", AnyPort)
-          Source = [ ]
-          Destination = [ ]
+          Services = {| Name = ""; Services = [] |}
+          Sources = [ ]
+          Destinations = [ ]
           Operation = Allow }
     /// Sets the name of the security rule
     [<CustomOperation "name">]
@@ -33,100 +33,93 @@ type SecurityRuleBuilder () =
     member _.Description(state:SecurityRuleConfig, description) = { state with Description = Some description }
     /// Sets the service or services protected by this rule.
     [<CustomOperation("service")>]
-    member _.Service(state:SecurityRuleConfig, service) = { state with Service = service }
-    member this.Service(state:SecurityRuleConfig, (name, port)) = this.Service(state, Service (name, Port(uint16 port)))
+    member _.Service(state:SecurityRuleConfig, name, services) =
+        { state with
+            Services =
+                {| Name = name
+                   Services = [
+                    for (name, port) in services do
+                        Service (name, Port(uint16 port))
+                   ]
+                |}
+        }
+    member this.Service(state:SecurityRuleConfig, name, port) = this.Service(state, "", [ name, port ])
     /// Sets the source endpoint that is matched in this rule
     [<CustomOperation("add_source")>]
-    member _.AddSource(state:SecurityRuleConfig, source) = { state with Source = source :: state.Source }
+    member _.AddSource(state:SecurityRuleConfig, source) = { state with Sources = source :: state.Sources }
     /// Sets the rule to match on any source endpoint.
     [<CustomOperation("add_source_any")>]
-    member _.AddSourceAny(state:SecurityRuleConfig, protocol) = { state with Source = (protocol, AnyEndpoint, AnyPort) :: state.Source }
+    member _.AddSourceAny(state:SecurityRuleConfig, protocol) = { state with Sources = (protocol, AnyEndpoint, AnyPort) :: state.Sources }
     /// Sets the rule to match on a tagged source endpoint, such as 'Internet'.
     [<CustomOperation("add_source_tag")>]
-    member _.AddSourceTag(state:SecurityRuleConfig, protocol, tag) = { state with Source = (protocol, Tag tag, AnyPort) :: state.Source }
+    member _.AddSourceTag(state:SecurityRuleConfig, protocol, tag) = { state with Sources = (protocol, Tag tag, AnyPort) :: state.Sources }
     /// Sets the rule to match on a source address.
     [<CustomOperation("add_source_address")>]
-    member _.AddSourceAddress(state:SecurityRuleConfig, protocol, sourceAddress) = { state with Source = (protocol, Host (IPAddress.Parse sourceAddress), AnyPort) :: state.Source }
+    member _.AddSourceAddress(state:SecurityRuleConfig, protocol, sourceAddress) = { state with Sources = (protocol, Host (IPAddress.Parse sourceAddress), AnyPort) :: state.Sources }
     /// Sets the rule to match on a source network.
     [<CustomOperation("add_source_network")>]
-    member _.AddSourceNetwork(state:SecurityRuleConfig, protocol, sourceNetwork) = { state with Source = (protocol, Network (IPAddressCidr.parse sourceNetwork), AnyPort) :: state.Source }
+    member _.AddSourceNetwork(state:SecurityRuleConfig, protocol, sourceNetwork) = { state with Sources = (protocol, Network (IPAddressCidr.parse sourceNetwork), AnyPort) :: state.Sources }
     /// Sets the destination endpoint that is matched in this rule
     [<CustomOperation("add_destination")>]
-    member _.AddDestination(state:SecurityRuleConfig, dest) = { state with Destination = dest :: state.Destination }
+    member _.AddDestination(state:SecurityRuleConfig, dest) = { state with Destinations = dest :: state.Destinations }
     /// Sets the rule to match on any destination endpoint.
     [<CustomOperation("add_destination_any")>]
-    member _.AddDestinationAny(state:SecurityRuleConfig) = { state with Destination = AnyEndpoint :: state.Destination }
+    member _.AddDestinationAny(state:SecurityRuleConfig) = { state with Destinations = AnyEndpoint :: state.Destinations }
     /// Sets the rule to match on a tagged destination endpoint, such as 'Internet'.
     [<CustomOperation("add_destination_tag")>]
-    member _.AddDestinationTag(state:SecurityRuleConfig, tag) = { state with Destination = Tag tag :: state.Destination }
+    member _.AddDestinationTag(state:SecurityRuleConfig, tag) = { state with Destinations = Tag tag :: state.Destinations }
     /// Sets the rule to match on a destination address.
     [<CustomOperation("add_destination_address")>]
-    member _.AddDestinationAddress(state:SecurityRuleConfig, destAddress) = { state with Destination = Host (IPAddress.Parse destAddress) :: state.Destination }
+    member _.AddDestinationAddress(state:SecurityRuleConfig, destAddress) = { state with Destinations = Host (IPAddress.Parse destAddress) :: state.Destinations }
     /// Sets the rule to match on a destination network.
     [<CustomOperation("add_destination_network")>]
-    member _.AddDestinationNetwork(state:SecurityRuleConfig, destNetwork) = { state with Destination = Network (IPAddressCidr.parse destNetwork):: state.Destination }
+    member _.AddDestinationNetwork(state:SecurityRuleConfig, destNetwork) = { state with Destinations = Network (IPAddressCidr.parse destNetwork):: state.Destinations }
     /// Sets the rule to allow this traffic (default value).
-    [<CustomOperation("allow")>]
+    [<CustomOperation("allow_traffic")>]
     member _.Allow(state:SecurityRuleConfig) = { state with Operation = Allow }
     /// Sets the rule to deny this traffic.
-    [<CustomOperation("deny")>]
+    [<CustomOperation("deny_traffic")>]
     member _.Deny(state:SecurityRuleConfig) = { state with Operation = Deny }
 
 let securityRule = SecurityRuleBuilder()
 
-module SecurityRule =
-    let internal buildNsgRule (nsg:NetworkSecurityGroup) (rule:SecurityRuleConfig) (priority:int) =
-        let sourcePorts = HashSet()
-        let sourceAddresses = HashSet()
-        let protocols = HashSet()
-        let destPorts = HashSet()
-        let destAddresses = rule.Destination
+let internal buildNsgRule (nsg:NetworkSecurityGroup) (rule:SecurityRuleConfig) (priority:int) =
+    let wildcardOrTag (addresses:Endpoint seq) =
+        // Use a wildcard if there is one
+        if addresses |> Seq.contains AnyEndpoint then Some AnyEndpoint, []
+        // Use the first tag that is set (only one supported), otherwise use addresses
+        else
+            addresses
+            |> Seq.tryFind (function Tag _ -> true | _ -> false)
+            |> function
+            | Some (Tag tag) ->
+                Some (Tag tag), []
+            | None | Some (AnyEndpoint | Network _ | Host _) ->
+                None, List.ofSeq addresses
 
-        let wildcardOrTag (addresses:Endpoint seq) =
-            // Use a wildcard if there is one
-            if addresses |> Seq.contains AnyEndpoint then Some AnyEndpoint, []
-            // Use the first tag that is set (only one supported), otherwise use addresses
-            else
-                addresses
-                |> Seq.tryFind (function Tag _ -> true | _ -> false)
-                |> function
-                | Some (Tag tag) ->
-                    Some (Tag tag), []
-                | None | Some (AnyEndpoint | Network _ | Host _) ->
-                    None, List.ofSeq addresses
+    let destPorts = rule.Services.Services |> List.map(fun (Service(_, port)) -> port) |> Set
+    let protocols = rule.Sources |> List.map(fun (protocol, _, _) -> protocol) |> Set
+    let sourceAddresses = rule.Sources |> List.map(fun (_, sourceAddress, _) -> sourceAddress) |> List.distinct
+    let sourcePorts = rule.Sources |> List.map(fun (_, _, sourcePort) -> sourcePort) |> Set
 
-        let rec collateRules (service:Service) =
-            match service with
-            | Service (_, servicePort) ->
-                destPorts.Add servicePort |> ignore
-                for (protocol, sourceEndpoint, sourcePort) in rule.Source do
-                    protocols.Add protocol |> ignore
-                    sourcePorts.Add sourcePort |> ignore
-                    sourceAddresses.Add sourceEndpoint |> ignore
-            | Services (_, services) ->
-                for service in services do
-                    collateRules service
+    let sourceAddress, sourceAddresses = wildcardOrTag sourceAddresses
+    let destAddress, destAddresses = wildcardOrTag rule.Destinations
 
-        collateRules rule.Service
-
-        let sourceAddress, sourceAddresses = wildcardOrTag sourceAddresses
-        let destAddress, destAddresses = wildcardOrTag destAddresses
-
-        { Name = rule.Name
-          Description = None
-          SecurityGroup = nsg
-          Protocol = if protocols.Count > 1 then AnyProtocol else protocols |> Seq.head
-          SourcePort = if sourcePorts.Contains AnyPort then Some AnyPort else None
-          SourcePorts = if sourcePorts.Contains AnyPort then [] else sourcePorts |> List.ofSeq
-          SourceAddress = sourceAddress
-          SourceAddresses = sourceAddresses
-          DestinationPort = if destPorts.Contains AnyPort then Some AnyPort else None
-          DestinationPorts = if destPorts.Contains AnyPort then [] else destPorts |> List.ofSeq
-          DestinationAddress = destAddress
-          DestinationAddresses = destAddresses
-          Access = rule.Operation
-          Direction = Inbound
-          Priority = priority }
+    { Name = rule.Name
+      Description = None
+      SecurityGroup = nsg
+      Protocol = if protocols.Count > 1 then AnyProtocol else protocols |> Seq.head
+      SourcePort = if sourcePorts.Contains AnyPort then Some AnyPort else None
+      SourcePorts = if sourcePorts.Contains AnyPort then [] else sourcePorts |> List.ofSeq
+      SourceAddress = sourceAddress
+      SourceAddresses = sourceAddresses
+      DestinationPort = if destPorts.Contains AnyPort then Some AnyPort else None
+      DestinationPorts = if destPorts.Contains AnyPort then [] else destPorts |> List.ofSeq
+      DestinationAddress = destAddress
+      DestinationAddresses = destAddresses
+      Access = rule.Operation
+      Direction = Inbound
+      Priority = priority }
 
 type NsgConfig =
     { Name : ResourceName
@@ -142,7 +135,7 @@ type NsgConfig =
             securityGroup
             // Policy Rules
             for priority, rule in List.indexed this.SecurityRules do
-                SecurityRule.buildNsgRule securityGroup rule ((priority + 1) * 100)
+                buildNsgRule securityGroup rule ((priority + 1) * 100)
         ]
 type NsgBuilder() =
     member __.Yield _ =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -764,28 +764,30 @@ module NetworkSecurity =
         member this.ArmValue = this |> NetworkProtocol.ArmValue
 
     type Port =
-    | Port of uint16
-    | Range of First:uint16 * Last:uint16
-    | AnyPort
+        | Port of uint16
+        | Range of First:uint16 * Last:uint16
+        | AnyPort
+        member this.ArmValue =
+            match this with
+            | Port num -> num |> string
+            | Range (first,last) -> sprintf "%d-%d" first last
+            | AnyPort -> "*"
     module Port =
-        let ArmValue = function
-        | Port num -> num |> string
-        | Range (first,last) -> sprintf "%d-%d" first last
-        | AnyPort -> "*"
-    type Port with
-        member this.ArmValue = this |> Port.ArmValue
+        let ArmValue (port:Port) = port.ArmValue
 
     type Endpoint =
-    | Host of System.Net.IPAddress
-    | Network of IPAddressCidr
-    | Tag of string
-    | AnyEndpoint
+        | Host of Net.IPAddress
+        | Network of IPAddressCidr
+        | Tag of string
+        | AnyEndpoint
+        member this.ArmValue =
+            match this with
+            | Host ip -> string ip
+            | Network cidr -> cidr |> IPAddressCidr.format
+            | Tag tag -> tag
+            | AnyEndpoint -> "*"
     module Endpoint =
-        let ArmValue = function
-        | Host ip -> string ip
-        | Network cidr -> cidr |> IPAddressCidr.format
-        | Tag tag -> tag
-        | AnyEndpoint -> "*"
+        let ArmValue (endpoint:Endpoint) = endpoint.ArmValue
 
     type NetworkService = NetworkService of name:string * Port
 

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -777,9 +777,7 @@ module NetworkSecurity =
         | Tag tag -> tag
         | AnyEndpoint -> "*"
 
-    type Service =
-    | Service of Name:string * Port
-    | Services of Name:string * Service list
+    type Service = Service of Name:string * Port
 
     type TrafficDirection = Inbound | Outbound
     module TrafficDirection =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -787,7 +787,7 @@ module NetworkSecurity =
         | Tag tag -> tag
         | AnyEndpoint -> "*"
 
-    type Service = Service of Name:string * Port
+    type NetworkService = NetworkService of name:string * Port
 
     type TrafficDirection = Inbound | Outbound
     module TrafficDirection =

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -34,13 +34,9 @@ let tests = testList "NetworkSecurityGroup" [
                   Description = Some (sprintf "Rule created on %s" (DateTimeOffset.Now.Date.ToShortDateString()))
                   SecurityGroup = nsg
                   Protocol = TCP
-                  SourcePort = Some AnyPort
-                  SourcePorts = [ ]
-                  DestinationPort = None
-                  DestinationPorts = [ Port 80us; Port 443us ]
-                  SourceAddress = Some AnyEndpoint
-                  SourceAddresses = [ ]
-                  DestinationAddress = None
+                  SourcePorts = Set [ AnyPort ]
+                  DestinationPorts = Set [ Port 80us; Port 443us ]
+                  SourceAddresses = [ AnyEndpoint ]
                   DestinationAddresses = [ Network (IPAddressCidr.parse "10.100.30.0/24") ]
                   Access = Allow
                   Direction = Inbound
@@ -54,6 +50,7 @@ let tests = testList "NetworkSecurityGroup" [
         match rules with
         | [ _; rule1 ] ->
             rule1.Validate()
+
             Expect.equal rule1.Name "my-nsg/accept-web" ""
             Expect.equal rule1.Access "Allow" ""
             Expect.equal rule1.DestinationAddressPrefixes.[0] "10.100.30.0/24" ""

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -16,8 +16,8 @@ let tests = testList "NetworkSecurityGroup" [
         let resource =
             let nsg =
                 { Name = ResourceName "my-nsg"
-                  Location = Location.WestEurope }
-                  Tags = Map.empty
+                  Location = Location.WestEurope
+                  Tags = Map.empty }
             arm { add_resource nsg }
             |> findAzureResources<NetworkSecurityGroup> client.SerializationSettings
             |> List.head
@@ -27,8 +27,8 @@ let tests = testList "NetworkSecurityGroup" [
         let rules =
             let nsg =
                 { Name = ResourceName "my-nsg"
-                  Location = Location.WestEurope }
-                  Tags = Map.empty
+                  Location = Location.WestEurope
+                  Tags = Map.empty }
             let acceptRule =
                 { Name = ResourceName "accept-web"
                   Description = Some (sprintf "Rule created on %s" (DateTimeOffset.Now.Date.ToShortDateString()))

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -72,8 +72,8 @@ let tests = testList "NetworkSecurityGroup" [
         let webPolicy = securityRule {
             name "web-servers"
             description "Public web server access"
-            service "web" [ "http", 80
-                            "https", 443 ]
+            services [ "http", 80
+                       "https", 443 ]
             add_source_tag TCP "Internet"
             add_destination_network "10.100.30.0/24"
         }
@@ -103,22 +103,22 @@ let tests = testList "NetworkSecurityGroup" [
         let webPolicy = securityRule { // Web servers - accessible from anything
             name "web-servers"
             description "Public web server access"
-            service "web" [ "http", 80
-                            "https", 443 ]
+            services [ "http", 80
+                       "https", 443 ]
             add_source_tag TCP "Internet"
             add_destination_network "10.100.30.0/24"
         }
         let appPolicy = securityRule { // Only accessible by web servers
             name "app-servers"
             description "Internal app server access"
-            service "http" 8080
+            services [ "http", 8080 ]
             add_source_network TCP "10.100.30.0/24"
             add_destination_network appNet
         }
         let dbPolicy = securityRule { // DB servers - not accessible by web, only by app servers
             name "db-servers"
             description "Internal database server access"
-            service "postgres" 5432
+            services [ "postgres", 5432 ]
             add_source_network TCP appNet
             add_destination_network "10.100.32.0/24"
         }


### PR DESCRIPTION
@ninjarobot Here's some simplifications I've made.

1. I'm not sure about the name on the Service "group" or indeed individual services (within the context of security rules) - they don't appear to be used anywhere? What are they for?
2. I think the Source / Destination Port / Ports could be modelled and brought into the ARM Resource, but we should talk it through so I understand.
3. I've removed the mutable HashSets with the simple Set / List.distincts.