### PR TITLE
Better storage validation

### DIFF
--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -15,23 +15,6 @@ let namespaces = ResourceType "Microsoft.ServiceBus/namespaces"
 
 module Namespaces =
     module Topics =
-        type CorrelationFilter =
-            { CorrelationId : string option
-              Properties : Map<string, obj> option }
-        type Rule =
-            | SqlFilter of Name:ResourceName * SqlExpression:string
-            | CorrelationFilter of Name:ResourceName * CorrelationFilter
-            member this.Name =
-                match this with
-                | SqlFilter (name, _) -> name
-                | CorrelationFilter (name, _) -> name
-        let correlation_property_filter (name:string) (properties:(string * string) seq) =
-            let downcastProperties =
-                properties
-                |> Seq.map (fun (k,v) -> k, v :> obj)
-                |> Map.ofSeq
-                |> Some
-            Rule.CorrelationFilter (ResourceName name, { CorrelationId = None; Properties = downcastProperties })
         type Subscription =
             { Name : ResourceName
               Namespace : ResourceName
@@ -62,28 +45,26 @@ module Namespaces =
                            requiresSession = this.Session |> Option.toNullable
                            lockDuration = tryGetIso this.LockDuration
                         |}
-                       resources = this.Rules |> List.map ( fun rule ->
+                       resources = [
+                        for rule in this.Rules do
                            {| apiVersion = "2017-04-01"
                               name = rule.Name.Value
-                              ``type`` = "rules"
+                              ``type`` = "Rules"
                               dependsOn = [ this.Name.Value ]
                               properties =
                                match rule with
-                               | SqlFilter (_, sqlExpression) -> 
+                               | SqlFilter filter ->
                                    {| filterType = "SqlFilter"
-                                      sqlFilter = {| sqlExpression = sqlExpression |}
-                                      correlationFilter = Unchecked.defaultof<_>
-                                    |}
-                               | CorrelationFilter (_, correlationFilter) -> 
+                                      sqlFilter = box {| sqlExpression = filter.SqlExpression |}
+                                      correlationFilter = null |}
+                               | CorrelationFilter filter ->
                                    {| filterType = "CorrelationFilter"
                                       correlationFilter =
-                                          {| correlationId = correlationFilter.CorrelationId |> Option.toObj
-                                             properties =
-                                                 correlationFilter.Properties
-                                                 |> Option.map (fun m -> m |> Map.toSeq |> dict)
-                                                 |> Option.toObj |}
-                                      sqlFilter = Unchecked.defaultof<_> |}
-                           |})
+                                          box {| correlationId = filter.CorrelationId |> Option.toObj
+                                                 properties = filter.Properties |}
+                                      sqlFilter = null |}
+                           |}
+                       ]
                     |} :> _
 
     type Queue =

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -4,25 +4,37 @@ module Farmer.Arm.Storage
 open Farmer
 open Farmer.Storage
 open Farmer.CoreTypes
+open System
 
 let storageAccounts = ResourceType "Microsoft.Storage/storageAccounts"
 let containers = ResourceType "Microsoft.Storage/storageAccounts/blobServices/containers"
 let fileShares = ResourceType "Microsoft.Storage/storageAccounts/fileServices/shares"
 let queues = ResourceType "Microsoft.Storage/storageAccounts/queueServices/queues"
 
+type StorageAccountName =
+    private | StorageAccountName of ResourceName
+    static member Create name =
+        if String.IsNullOrWhiteSpace name then Error "Min length is 1"
+        elif name.Length > 24 then Error "Max length is 24"
+        elif name |> Seq.exists Char.IsUpper then Error "Upper case letters are not allowed"
+        elif name |> Seq.exists (Char.IsLetterOrDigit >> not) then Error "Only alphanumeric characters are allowed"
+        else Ok (StorageAccountName (ResourceName name))
+    static member Create (ResourceName name) = StorageAccountName.Create name
+    member this.ResourceName = match this with StorageAccountName name -> name
+
 type StorageAccount =
-    { Name : ResourceName
+    { Name : StorageAccountName
       Location : Location
       Sku : Sku
       EnableHierarchicalNamespace : bool
       StaticWebsite : {| IndexPage : string; ErrorPage : string option; ContentPath : string |} option }
     interface IArmResource with
-        member this.ResourceName = this.Name
+        member this.ResourceName = this.Name.ResourceName
         member this.JsonModel =
             {| ``type`` = storageAccounts.ArmValue
                sku = {| name = this.Sku.ArmValue |}
                kind = "StorageV2"
-               name = this.Name.Value
+               name = this.Name.ResourceName.Value
                apiVersion = "2018-07-01"
                location = this.Location.ArmValue
                properties = {| isHnsEnabled = this.EnableHierarchicalNamespace |}
@@ -31,9 +43,9 @@ type StorageAccount =
         member this.Run _ =
             this.StaticWebsite
             |> Option.map(fun staticWebsite -> result {
-                let! enableStaticResponse = Deploy.Az.enableStaticWebsite this.Name.Value staticWebsite.IndexPage staticWebsite.ErrorPage
-                printfn "Deploying content of %s folder to $web container for storage account %s" staticWebsite.ContentPath this.Name.Value
-                let! uploadResponse = Deploy.Az.batchUploadStaticWebsite this.Name.Value staticWebsite.ContentPath
+                let! enableStaticResponse = Deploy.Az.enableStaticWebsite this.Name.ResourceName.Value staticWebsite.IndexPage staticWebsite.ErrorPage
+                printfn "Deploying content of %s folder to $web container for storage account %s" staticWebsite.ContentPath this.Name.ResourceName.Value
+                let! uploadResponse = Deploy.Az.batchUploadStaticWebsite this.Name.ResourceName.Value staticWebsite.ContentPath
                 return enableStaticResponse + ", " + uploadResponse
             })
 

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -14,10 +14,10 @@ let queues = ResourceType "Microsoft.Storage/storageAccounts/queueServices/queue
 type StorageAccountName =
     private | StorageAccountName of ResourceName
     static member Create name =
-        if String.IsNullOrWhiteSpace name then Error "Min length is 1"
-        elif name.Length > 24 then Error "Max length is 24"
-        elif name |> Seq.exists Char.IsUpper then Error "Upper case letters are not allowed"
-        elif name |> Seq.exists (Char.IsLetterOrDigit >> not) then Error "Only alphanumeric characters are allowed"
+        if String.IsNullOrWhiteSpace name then Error "Storage account name cannot be empty"
+        elif name.Length > 24 then Error (sprintf "Storage account name max length is 24, but here is %d ('%s')" name.Length name)
+        elif name |> Seq.exists Char.IsUpper then Error (sprintf "Storage account name does not allow upper case letters ('%s')" name)
+        elif name |> Seq.exists (Char.IsLetterOrDigit >> not) then Error (sprintf "Only alphanumeric characters are allowed ('%s')" name)
         else Ok (StorageAccountName (ResourceName name))
     static member Create (ResourceName name) = StorageAccountName.Create name
     member this.ResourceName = match this with StorageAccountName name -> name

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -121,7 +121,7 @@ type FunctionsConfig =
                 ()
             match this.StorageAccount with
             | DeployableResource this resourceName ->
-                { StorageAccount.Name = resourceName
+                { Name = StorageAccountName.Create resourceName |> Result.get
                   Location = location
                   Sku = Storage.Standard_LRS
                   StaticWebsite = None

--- a/src/Farmer/Builders/Builders.Helpers.fs
+++ b/src/Farmer/Builders/Builders.Helpers.fs
@@ -1,6 +1,5 @@
 module Farmer.Helpers
 
-open Farmer.CoreTypes
 open System
 
 let sanitise filters maxLength (resourceName:ResourceName) =

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -71,21 +71,36 @@ type ServiceBusSubscriptionBuilder() =
           Rules = List.empty }
 
     /// The name of the queue.
-    [<CustomOperation "name">] member _.Name(state:ServiceBusSubscriptionConfig, name) = { state with Name = ResourceName name }
+    [<CustomOperation "name">]
+     member _.Name(state:ServiceBusSubscriptionConfig, name) = { state with Name = ResourceName name }
     /// The length of time that a lock can be held on a message.
-    [<CustomOperation "lock_duration_minutes">] member _.LockDurationMinutes(state:ServiceBusSubscriptionConfig, duration) = { state with LockDuration = Some (TimeSpan.FromMinutes (float duration)) }
+    [<CustomOperation "lock_duration_minutes">]
+     member _.LockDurationMinutes(state:ServiceBusSubscriptionConfig, duration) = { state with LockDuration = Some (TimeSpan.FromMinutes (float duration)) }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
-    [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusSubscriptionConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
+    [<CustomOperation "duplicate_detection_minutes">]
+     member _.DuplicateDetection(state:ServiceBusSubscriptionConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
     /// The default time-to-live for messages. If not specified, the maximum TTL will be set for the SKU.
-    [<CustomOperation "message_ttl_days">] member _.MessageTtl(state:ServiceBusSubscriptionConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
+    [<CustomOperation "message_ttl_days">]
+     member _.MessageTtl(state:ServiceBusSubscriptionConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
     /// Enables session support.
-    [<CustomOperation "max_delivery_count">] member _.MaxDeliveryCount(state:ServiceBusSubscriptionConfig, count) = { state with MaxDeliveryCount = Some count }
+    [<CustomOperation "max_delivery_count">]
+     member _.MaxDeliveryCount(state:ServiceBusSubscriptionConfig, count) = { state with MaxDeliveryCount = Some count }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
-    [<CustomOperation "enable_session">] member _.Session(state:ServiceBusSubscriptionConfig) = { state with Session = Some true }
+    [<CustomOperation "enable_session">]
+     member _.Session(state:ServiceBusSubscriptionConfig) = { state with Session = Some true }
     /// Enables dead lettering of messages that expire.
-    [<CustomOperation "enable_dead_letter_on_message_expiration">] member _.DeadLetteringOnMessageExpiration(state:ServiceBusSubscriptionConfig) = { state with DeadLetteringOnMessageExpiration = Some true }
+    [<CustomOperation "enable_dead_letter_on_message_expiration">]
+    member _.DeadLetteringOnMessageExpiration(state:ServiceBusSubscriptionConfig) = { state with DeadLetteringOnMessageExpiration = Some true }
     /// Adds filtering rules for a subscription
-    [<CustomOperation "add_rules">] member _.AddRules(state:ServiceBusSubscriptionConfig, rules) = { state with Rules = state.Rules @ rules }
+    [<CustomOperation "add_filters">]
+    member _.AddFilters(state:ServiceBusSubscriptionConfig, filters) = { state with Rules = state.Rules @ filters }
+    /// Adds a sql filtering rule for a subscription
+    [<CustomOperation "add_sql_filter">]
+    member this.AddFilter(state:ServiceBusSubscriptionConfig, name, expression) = this.AddFilters(state, [ Rule.CreateSqlFilter(name, expression) ])
+    /// Adds a correlation filtering rule for a subscription
+    [<CustomOperation "add_correlation_filter">]
+    member this.AddCorrelationFilter(state:ServiceBusSubscriptionConfig, name, properties) = this.AddFilters(state, [ Rule.CreateCorrelationFilter(name, properties) ])
+
 
 type ServiceBusTopicConfig =
     { Name : ResourceName

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -40,7 +40,7 @@ type StorageAccountConfig =
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
-            { Name = this.Name
+            { Name = StorageAccountName.Create this.Name |> Result.get
               Location = location
               Sku = this.Sku
               EnableHierarchicalNamespace = this.EnableDataLake
@@ -68,9 +68,6 @@ type StorageAccountBuilder() =
         Queues = Set.empty
         StaticWebsite = None
     }
-    member _.Run(state:StorageAccountConfig) =
-        { state with
-            Name = state.Name |> Helpers.sanitiseStorage |> ResourceName }
     /// Sets the name of the storage account.
     [<CustomOperation "name">]
     member _.Name(state:StorageAccountConfig, name) = { state with Name = name }

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -107,7 +107,7 @@ type VmConfig =
             // Storage account - optional
             match this.DiagnosticsStorageAccount with
             | Some (DeployableResource this resourceName) ->
-                { Name = resourceName
+                { Name = StorageAccountName.Create resourceName |> Result.get
                   Location = location
                   Sku = Storage.Standard_LRS
                   StaticWebsite = None

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1,51 +1,50 @@
 ﻿namespace Farmer
 
 open System
-open System.Runtime.CompilerServices
 
-type Location =
-    | Location of string
-    static member EastAsia = Location "EastAsia"
-    static member SoutheastAsia = Location "SoutheastAsia"
-    static member CentralUS = Location "CentralUS"
-    static member EastUS = Location "EastUS"
-    static member EastUS2 = Location "EastUS2"
-    static member WestUS = Location "WestUS"
-    static member NorthCentralUS = Location "NorthCentralUS"
-    static member SouthCentralUS = Location "SouthCentralUS"
-    static member NorthEurope = Location "NorthEurope"
-    static member WestEurope = Location "WestEurope"
-    static member JapanWest = Location "JapanWest"
-    static member JapanEast = Location "JapanEast"
-    static member BrazilSouth = Location "BrazilSouth"
-    static member AustraliaEast = Location "AustraliaEast"
-    static member AustraliaSoutheast = Location "AustraliaSoutheast"
-    static member SouthIndia = Location "SouthIndia"
-    static member CentralIndia = Location "CentralIndia"
-    static member WestIndia = Location "WestIndia"
-    static member CanadaCentral = Location "CanadaCentral"
-    static member CanadaEast = Location "CanadaEast"
-    static member UKSouth = Location "UKSouth"
-    static member UKWest = Location "UKWest"
-    static member WestCentralUS = Location "WestCentralUS"
-    static member WestUS2 = Location "WestUS2"
-    static member KoreaCentral = Location "KoreaCentral"
-    static member KoreaSouth = Location "KoreaSouth"
-    static member FranceCentral = Location "FranceCentral"
-    static member FranceSouth = Location "FranceSouth"
-    static member AustraliaCentral = Location "AustraliaCentral"
-    static member AustraliaCentral2 = Location "AustraliaCentral2"
-    static member UAECentral = Location "UAECentral"
-    static member UAENorth = Location "UAENorth"
-    static member SouthAfricaNorth = Location "SouthAfricaNorth"
-    static member SouthAfricaWest = Location "SouthAfricaWest"
-    static member SwitzerlandNorth = Location "SwitzerlandNorth"
-    static member SwitzerlandWest = Location "SwitzerlandWest"
-    static member GermanyNorth = Location "GermanyNorth"
-    static member GermanyWestCentral = Location "GermanyWestCentral"
-    static member NorwayWest = Location "NorwayWest"
-    static member NorwayEast = Location "NorwayEast"
-    member this.ArmValue = match this with Location location -> location.ToLower()
+[<AutoOpen>]
+module LocationExtensions =
+    type Location with
+        static member EastAsia = Location "EastAsia"
+        static member SoutheastAsia = Location "SoutheastAsia"
+        static member CentralUS = Location "CentralUS"
+        static member EastUS = Location "EastUS"
+        static member EastUS2 = Location "EastUS2"
+        static member WestUS = Location "WestUS"
+        static member NorthCentralUS = Location "NorthCentralUS"
+        static member SouthCentralUS = Location "SouthCentralUS"
+        static member NorthEurope = Location "NorthEurope"
+        static member WestEurope = Location "WestEurope"
+        static member JapanWest = Location "JapanWest"
+        static member JapanEast = Location "JapanEast"
+        static member BrazilSouth = Location "BrazilSouth"
+        static member AustraliaEast = Location "AustraliaEast"
+        static member AustraliaSoutheast = Location "AustraliaSoutheast"
+        static member SouthIndia = Location "SouthIndia"
+        static member CentralIndia = Location "CentralIndia"
+        static member WestIndia = Location "WestIndia"
+        static member CanadaCentral = Location "CanadaCentral"
+        static member CanadaEast = Location "CanadaEast"
+        static member UKSouth = Location "UKSouth"
+        static member UKWest = Location "UKWest"
+        static member WestCentralUS = Location "WestCentralUS"
+        static member WestUS2 = Location "WestUS2"
+        static member KoreaCentral = Location "KoreaCentral"
+        static member KoreaSouth = Location "KoreaSouth"
+        static member FranceCentral = Location "FranceCentral"
+        static member FranceSouth = Location "FranceSouth"
+        static member AustraliaCentral = Location "AustraliaCentral"
+        static member AustraliaCentral2 = Location "AustraliaCentral2"
+        static member UAECentral = Location "UAECentral"
+        static member UAENorth = Location "UAENorth"
+        static member SouthAfricaNorth = Location "SouthAfricaNorth"
+        static member SouthAfricaWest = Location "SouthAfricaWest"
+        static member SwitzerlandNorth = Location "SwitzerlandNorth"
+        static member SwitzerlandWest = Location "SwitzerlandWest"
+        static member GermanyNorth = Location "GermanyNorth"
+        static member GermanyWestCentral = Location "GermanyWestCentral"
+        static member NorwayWest = Location "NorwayWest"
+        static member NorwayEast = Location "NorwayEast"
 
 type OS = Windows | Linux
 
@@ -587,6 +586,17 @@ module ServiceBus =
         | Basic
         | Standard
         | Premium of MessagingUnits
+    type Rule =
+        | SqlFilter of {| Name : ResourceName; SqlExpression : string |}
+        | CorrelationFilter of {| Name : ResourceName; CorrelationId : string option; Properties : Map<string, string> |}
+        member this.Name =
+            match this with
+            | SqlFilter f -> f.Name
+            | CorrelationFilter f -> f.Name
+        static member CreateCorrelationFilter (name, properties, ?correlationId) =
+            CorrelationFilter {| Name = ResourceName name; CorrelationId = correlationId; Properties = Map properties |}
+        static member CreateSqlFilter (name, expression) =
+            SqlFilter {| Name = ResourceName name; SqlExpression = expression |}
 
 module CosmosDb =
     /// The consistency policy of a CosmosDB account.

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -43,9 +43,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="Common.fs" />
     <Compile Include="Result.fs" />
     <Compile Include="Types.fs" />
+    <Compile Include="Common.fs" />
     <Compile Include="ArmBuilder.fs" />
     <Compile Include="Writer.fs" />
     <Compile Include="Deploy.fs" />

--- a/src/Farmer/Result.fs
+++ b/src/Farmer/Result.fs
@@ -19,6 +19,8 @@ module Result =
     let ofExn thunk arg =
         try Ok(thunk arg)
         with ex -> Error (string ex)
+    // Unsafely unwraps a Result. If the Result is an Error, the Error is cascaded as an exception.
+    let get = function Ok value -> value | Error err -> failwith (err.ToString())
     let bindError onError = function Error s -> onError s | s -> s
 
     type ResultBuilder() =

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -13,6 +13,10 @@ type ResourceName =
         | r -> r
     member this.Map mapper = match this with ResourceName r -> ResourceName (mapper r)
 
+type Location =
+    | Location of string
+    member this.ArmValue = match this with Location location -> location.ToLower()
+
 /// An Azure ARM resource value which can be mapped into an ARM template.
 type IArmResource =
     /// The name of the resource, to uniquely identify against other resources in the template.

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -4,9 +4,9 @@ open Expecto
 open Farmer
 open Farmer.Arm.ServiceBus
 open Farmer.Arm.ServiceBus.Namespaces.Topics
-open Namespaces
 open Farmer.Builders
 open Farmer.ServiceBus
+open Namespaces
 open Microsoft.Azure.Management.ServiceBus
 open Microsoft.Azure.Management.ServiceBus.Models
 open Microsoft.Rest
@@ -169,20 +169,17 @@ let tests = testList "Service Bus Tests" [
         }
         test "Creates a correlation filter rule" {
             let correlationRule =
-                Namespaces.Topics.Rule.CorrelationFilter
-                    (ResourceName
-                        "CompletedStatus",
-                        { CorrelationId = None
-                          Properties = [
-                              "Status", "Completed" :> obj
-                              "Operation", "DoStuff" :> obj
-                          ] |> Map.ofList |> Some
-                        }
-                    )
-            let builtCorrelationRule = Namespaces.Topics.correlation_property_filter "CompletedStatus" [ "Status", "Completed"; "Operation", "DoStuff" ]
+                ServiceBus.CorrelationFilter
+                    {| Name = ResourceName "CompletedStatus"
+                       CorrelationId = Some "xyz"
+                       Properties = [
+                           "Status", "Completed"
+                           "Operation", "DoStuff"
+                       ] |> Map |}
+            let builtCorrelationRule = Rule.CreateCorrelationFilter("CompletedStatus", [ "Status", "Completed"; "Operation", "DoStuff" ], "xyz")
             Expect.equal correlationRule builtCorrelationRule "Built incorrect correlation filter"
         }
-        test "Can create a subscription with correlation filter" {
+        test "Can create a subscription with different filters" {
             let sb =
                 serviceBus {
                     name "my-bus"
@@ -193,24 +190,29 @@ let tests = testList "Service Bus Tests" [
                             add_subscriptions [
                                 subscription {
                                     name "my-sub"
-                                    add_rules [
-                                        Namespaces.Topics.correlation_property_filter "SuccessfulStatus" ["Status", "Success"]
-                                        Namespaces.Topics.correlation_property_filter "FailedStatus" ["Status", "Fail"]
+                                    add_filters [
+                                        Rule.CreateCorrelationFilter("SuccessfulStatus", ["Status", "Success"])
+                                        Rule.CreateSqlFilter("Thing", "Status = Success")
                                     ]
+                                    add_correlation_filter "FailedStatus" [ "Status", "Fail" ]
+                                    add_sql_filter "OtherSqlThing" "Status = Failed"
                                 }
                             ]
                         }
                     ]
                 }
-            let template = 
+            let template =
                 arm {
                     location Location.EastUS
                     add_resource sb
                 }
             let generatedTemplate = template.Template
             let genSubscription = generatedTemplate.Resources.Item 2 :?> Subscription
-            Expect.hasLength genSubscription.Rules 2 "Expected subscription should have 2 rules"
-            Expect.equal genSubscription.Rules.Head.Name.Value "SuccessfulStatus" "Rule doesn't have the expected name 'SuccessfulStatus'."
+            Expect.hasLength genSubscription.Rules 4 "Expected subscription should have 4 rules"
+            Expect.equal genSubscription.Rules.[0] (Rule.CreateCorrelationFilter("SuccessfulStatus", ["Status", "Success"])) "Rule 0 is incorrect"
+            Expect.equal genSubscription.Rules.[1] (Rule.CreateSqlFilter("Thing", "Status = Success")) "Rule 1 is incorrect"
+            Expect.equal genSubscription.Rules.[2] (Rule.CreateCorrelationFilter("FailedStatus", ["Status", "Fail"])) "Rule 2 is incorrect"
+            Expect.equal genSubscription.Rules.[3] (Rule.CreateSqlFilter("OtherSqlThing", "Status = Failed")) "Rule 3 is incorrect"
         }
     ]
 ]

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -59,9 +59,10 @@ let tests = testList "Storage Tests" [
         Expect.equal resources.[1].ShareQuota (Nullable 1024) "file share quota for 'share2' is wrong"
     }
     test "Rejects invalid storage accounts" {
-        Expect.equal (Arm.Storage.StorageAccountName.Create "1234567890123456789012345") (Error "Max length is 24") "Name too long"
-        Expect.equal (Arm.Storage.StorageAccountName.Create "") (Error "Min length is 1") "Name too short"
-        Expect.equal (Arm.Storage.StorageAccountName.Create "U") (Error "Upper case letters are not allowed") "Upper case character allowed"
-        Expect.equal (Arm.Storage.StorageAccountName.Create "!") (Error "Only alphanumeric characters are allowed") "Non alpha numeric character allowed"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "") (Error "Storage account name cannot be empty") "Name too short"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "abcdefghij1234567890abcde") (Error "Storage account name max length is 24, but here is 25 ('abcdefghij1234567890abcde')") "Name too long"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "U") (Error "Storage account name does not allow upper case letters ('U')") "Upper case character allowed"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "!") (Error "Only alphanumeric characters are allowed ('!')") "Non alpha numeric character allowed"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "abcdefghij1234567890abcd" |> Result.get |> fun name -> name.ResourceName) (ResourceName "abcdefghij1234567890abcd") "Should have created a valid storage account name"
     }
 ]

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -15,7 +15,7 @@ let tests = testList "Storage Tests" [
     test "Can create a basic storage account" {
         let resource =
             let account = storageAccount {
-                name "myStorage123~@"
+                name "mystorage123"
                 sku Premium_LRS
                 enable_data_lake
             }
@@ -57,5 +57,11 @@ let tests = testList "Storage Tests" [
         Expect.equal resources.[0].Name "storage/default/share1" "file share name for 'share1' is wrong"
         Expect.equal resources.[1].Name "storage/default/share2" "file share name for 'share2' is wrong"
         Expect.equal resources.[1].ShareQuota (Nullable 1024) "file share quota for 'share2' is wrong"
+    }
+    test "Rejects invalid storage accounts" {
+        Expect.equal (Arm.Storage.StorageAccountName.Create "1234567890123456789012345") (Error "Max length is 24") "Name too long"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "") (Error "Min length is 1") "Name too short"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "U") (Error "Upper case letters are not allowed") "Upper case character allowed"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "!") (Error "Only alphanumeric characters are allowed") "Non alpha numeric character allowed"
     }
 ]


### PR DESCRIPTION
This stops storage accounts silently trimming characters from the name, which should never have been done in the first place. Instead there is now a `StorageAccountName` which guarantees valid creation of the name and is embedded at the lowest level (the Storage ARM resource).

Fixes #295 