### PR TITLE
Fail fast on Storage name validation errors

### DIFF
--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -4,25 +4,37 @@ module Farmer.Arm.Storage
 open Farmer
 open Farmer.Storage
 open Farmer.CoreTypes
+open System
 
 let storageAccounts = ResourceType "Microsoft.Storage/storageAccounts"
 let containers = ResourceType "Microsoft.Storage/storageAccounts/blobServices/containers"
 let fileShares = ResourceType "Microsoft.Storage/storageAccounts/fileServices/shares"
 let queues = ResourceType "Microsoft.Storage/storageAccounts/queueServices/queues"
 
+type StorageAccountName =
+    private | StorageAccountName of ResourceName
+    static member Create name =
+        if String.IsNullOrWhiteSpace name then Error "Storage account name cannot be empty"
+        elif name.Length > 24 then Error (sprintf "Storage account name max length is 24, but here is %d ('%s')" name.Length name)
+        elif name |> Seq.exists Char.IsUpper then Error (sprintf "Storage account name does not allow upper case letters ('%s')" name)
+        elif name |> Seq.exists (Char.IsLetterOrDigit >> not) then Error (sprintf "Only alphanumeric characters are allowed ('%s')" name)
+        else Ok (StorageAccountName (ResourceName name))
+    static member Create (ResourceName name) = StorageAccountName.Create name
+    member this.ResourceName = match this with StorageAccountName name -> name
+
 type StorageAccount =
-    { Name : ResourceName
+    { Name : StorageAccountName
       Location : Location
       Sku : Sku
       EnableHierarchicalNamespace : bool
       StaticWebsite : {| IndexPage : string; ErrorPage : string option; ContentPath : string |} option }
     interface IArmResource with
-        member this.ResourceName = this.Name
+        member this.ResourceName = this.Name.ResourceName
         member this.JsonModel =
             {| ``type`` = storageAccounts.ArmValue
                sku = {| name = this.Sku.ArmValue |}
                kind = "StorageV2"
-               name = this.Name.Value
+               name = this.Name.ResourceName.Value
                apiVersion = "2018-07-01"
                location = this.Location.ArmValue
                properties = {| isHnsEnabled = this.EnableHierarchicalNamespace |}
@@ -31,9 +43,9 @@ type StorageAccount =
         member this.Run _ =
             this.StaticWebsite
             |> Option.map(fun staticWebsite -> result {
-                let! enableStaticResponse = Deploy.Az.enableStaticWebsite this.Name.Value staticWebsite.IndexPage staticWebsite.ErrorPage
-                printfn "Deploying content of %s folder to $web container for storage account %s" staticWebsite.ContentPath this.Name.Value
-                let! uploadResponse = Deploy.Az.batchUploadStaticWebsite this.Name.Value staticWebsite.ContentPath
+                let! enableStaticResponse = Deploy.Az.enableStaticWebsite this.Name.ResourceName.Value staticWebsite.IndexPage staticWebsite.ErrorPage
+                printfn "Deploying content of %s folder to $web container for storage account %s" staticWebsite.ContentPath this.Name.ResourceName.Value
+                let! uploadResponse = Deploy.Az.batchUploadStaticWebsite this.Name.ResourceName.Value staticWebsite.ContentPath
                 return enableStaticResponse + ", " + uploadResponse
             })
 

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -121,7 +121,7 @@ type FunctionsConfig =
                 ()
             match this.StorageAccount with
             | DeployableResource this resourceName ->
-                { StorageAccount.Name = resourceName
+                { Name = StorageAccountName.Create resourceName |> Result.get
                   Location = location
                   Sku = Storage.Standard_LRS
                   StaticWebsite = None

--- a/src/Farmer/Builders/Builders.Helpers.fs
+++ b/src/Farmer/Builders/Builders.Helpers.fs
@@ -1,6 +1,5 @@
 module Farmer.Helpers
 
-open Farmer.CoreTypes
 open System
 
 let sanitise filters maxLength (resourceName:ResourceName) =

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -40,7 +40,7 @@ type StorageAccountConfig =
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
-            { Name = this.Name
+            { Name = StorageAccountName.Create this.Name |> Result.get
               Location = location
               Sku = this.Sku
               EnableHierarchicalNamespace = this.EnableDataLake
@@ -68,9 +68,6 @@ type StorageAccountBuilder() =
         Queues = Set.empty
         StaticWebsite = None
     }
-    member _.Run(state:StorageAccountConfig) =
-        { state with
-            Name = state.Name |> Helpers.sanitiseStorage |> ResourceName }
     /// Sets the name of the storage account.
     [<CustomOperation "name">]
     member _.Name(state:StorageAccountConfig, name) = { state with Name = name }

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -107,7 +107,7 @@ type VmConfig =
             // Storage account - optional
             match this.DiagnosticsStorageAccount with
             | Some (DeployableResource this resourceName) ->
-                { Name = resourceName
+                { Name = StorageAccountName.Create resourceName |> Result.get
                   Location = location
                   Sku = Storage.Standard_LRS
                   StaticWebsite = None

--- a/src/Farmer/Result.fs
+++ b/src/Farmer/Result.fs
@@ -19,6 +19,8 @@ module Result =
     let ofExn thunk arg =
         try Ok(thunk arg)
         with ex -> Error (string ex)
+    // Unsafely unwraps a Result. If the Result is an Error, the Error is cascaded as an exception.
+    let get = function Ok value -> value | Error err -> failwith (err.ToString())
     let bindError onError = function Error s -> onError s | s -> s
 
     type ResultBuilder() =

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -15,7 +15,7 @@ let tests = testList "Storage Tests" [
     test "Can create a basic storage account" {
         let resource =
             let account = storageAccount {
-                name "myStorage123~@"
+                name "mystorage123"
                 sku Premium_LRS
                 enable_data_lake
             }
@@ -57,5 +57,12 @@ let tests = testList "Storage Tests" [
         Expect.equal resources.[0].Name "storage/default/share1" "file share name for 'share1' is wrong"
         Expect.equal resources.[1].Name "storage/default/share2" "file share name for 'share2' is wrong"
         Expect.equal resources.[1].ShareQuota (Nullable 1024) "file share quota for 'share2' is wrong"
+    }
+    test "Rejects invalid storage accounts" {
+        Expect.equal (Arm.Storage.StorageAccountName.Create "") (Error "Storage account name cannot be empty") "Name too short"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "abcdefghij1234567890abcde") (Error "Storage account name max length is 24, but here is 25 ('abcdefghij1234567890abcde')") "Name too long"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "U") (Error "Storage account name does not allow upper case letters ('U')") "Upper case character allowed"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "!") (Error "Only alphanumeric characters are allowed ('!')") "Non alpha numeric character allowed"
+        Expect.equal (Arm.Storage.StorageAccountName.Create "abcdefghij1234567890abcd" |> Result.get |> fun name -> name.ResourceName) (ResourceName "abcdefghij1234567890abcd") "Should have created a valid storage account name"
     }
 ]


### PR DESCRIPTION
This stops storage accounts silently trimming characters from the name, which should never have been done in the first place. Instead there is now a StorageAccountName which guarantees valid creation of the name and is embedded at the lowest level (the Storage ARM resource). Any resources using a storage account must create a valid name using the builder methods on type.

Fixes #295