### PR TITLE
Add support for NuGet Continous Deployment - Fixes #306

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ jobs:
       testResultsFormat: VSTest
   - task: DotNetCoreCLI@2
     displayName: 'Package'
+    condition: and(succeeded(), eq(variables.vmImage, 'ubuntu-latest'))
     inputs:
       command: 'pack'
       packagesToPack: 'src/Farmer'
@@ -52,7 +53,7 @@ jobs:
 - deployment: "NugetPublish"
   dependsOn: ["Build"]
   condition:  and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master')) #optional, only trigger for master
-  displayName: "Publish to Nuget"
+  displayName: "Publish to NuGet"
   environment: "NuGet" #needs to be configured in ADoS - put a manual gate here
   pool:
     vmImage: 'windows-latest' #task doesn't run on other OS's

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,7 @@ jobs:
       verbosityPack: 'Minimal'
   - task: PublishBuildArtifacts@1
     displayName: Store NuGet Package
+    condition: and(succeeded(), eq(variables.vmImage, 'ubuntu-latest'))    
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'
       ArtifactName: 'FarmerPackage-$(imageName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,48 +2,68 @@ trigger:
   paths:
     exclude:
     - 'docs/'
-strategy:
-  matrix:
-    Linux:
-      imageName: 'ubuntu-latest'
-    Windows:
-      imageName: 'windows-latest'
-pool:
-  vmImage: $(imageName)
-steps:
-- task: DotNetCoreCLI@2
-  displayName: 'Restore'
-  inputs:
-    command: 'restore'
-    verbosityRestore: 'Minimal'
-- task: DotNetCoreCLI@2
-  displayName: 'Build'
-  inputs:
-    command: 'build'
-    arguments: '-c release'
-- task: AzureCLI@2
-  displayName: 'Test'
-  inputs:
-    azureSubscription: 'Microsoft Azure Sponsorship(6c9e2629-3964-4b24-bc32-97dafc8c90f3)'
-    scriptType: 'bash'
-    scriptLocation: 'inlineScript'
-    inlineScript: 'dotnet test -v n -c release -l trx'
-- task: PublishTestResults@2
-  displayName: 'Publish Test Results'
-  inputs:
-    testResultsFiles: '**/*.trx'
-    testResultsFormat: VSTest
-- task: DotNetCoreCLI@2
-  displayName: 'Package'
-  inputs:
-    command: 'pack'
-    packagesToPack: 'src/Farmer'
-    configuration: Release
-    versioningScheme: 'off'
-    verbosityPack: 'Minimal'
-- task: PublishBuildArtifacts@1
-  displayName: Store NuGet Package
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'FarmerPackage-$(imageName)'
-    publishLocation: 'Container'
+jobs:    
+- job: "Build"
+  strategy:
+    matrix:
+      Linux:
+        imageName: 'ubuntu-latest'
+      Windows:
+        imageName: 'windows-latest'
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore'
+    inputs:
+      command: 'restore'
+      verbosityRestore: 'Minimal'
+  - task: DotNetCoreCLI@2
+    displayName: 'Build'
+    inputs:
+      command: 'build'
+      arguments: '-c release'
+  - task: AzureCLI@2
+    displayName: 'Test'
+    inputs:
+      azureSubscription: 'Microsoft Azure Sponsorship(6c9e2629-3964-4b24-bc32-97dafc8c90f3)'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: 'dotnet test -v n -c release -l trx'
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      testResultsFiles: '**/*.trx'
+      testResultsFormat: VSTest
+  - task: DotNetCoreCLI@2
+    displayName: 'Package'
+    inputs:
+      command: 'pack'
+      packagesToPack: 'src/Farmer'
+      configuration: Release
+      versioningScheme: 'off'
+      verbosityPack: 'Minimal'
+  - task: PublishBuildArtifacts@1
+    displayName: Store NuGet Package
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: 'FarmerPackage-$(imageName)'
+      publishLocation: 'Container'
+- deployment: "NugetPublish"
+  dependsOn: ["Build"]
+  condition:  and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master')) #optional, only trigger for master
+  displayName: "Publish to Nuget"
+  environment: "NuGet" #needs to be configured in ADoS - put a manual gate here
+  pool:
+    vmImage: 'windows-latest' #task doesn't run on other OS's
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - task: NuGetCommand@2
+          displayName: "Push to NuGet"
+          inputs:
+            command: 'push'
+            packagesToPush: '$(Pipeline.Workspace)/**/*.nupkg;' #Path here must match
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'NuGet' #this needs to be established in ADos Servie Connections       


### PR DESCRIPTION
ADoS admins will need to add:

- [x] Service Connection called 'Nuget' which has the appriorpaite credentials stored
- [x] Pipeline environment, also called 'NuGet'. Put a manual approval gate on this. It will then require an authorised user to click 'Approve' to progress.

Caveats - with every yaml build process there has been a lot of wack-a-mole to get these to work. I'd expect the same.

Fixes #306 