### PR TITLE
Add tostring override to postgre family name DU

### DIFF
--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -10,7 +10,16 @@ let databases = ResourceType "Microsoft.DBforPostgreSQL/servers/databases"
 let firewallRules = ResourceType "Microsoft.DBforPostgreSQL/servers/firewallrules"
 let servers = ResourceType "Microsoft.DBforPostgreSQL/servers"
 
-type [<RequireQualifiedAccess>] PostgreSQLFamily = Gen5
+type [<RequireQualifiedAccess>] PostgreSQLFamily = 
+| Gen5
+
+    override this.ToString() =
+        match this with
+        | Gen5 -> "Gen5"
+
+    member this.AsArmValue =
+        match this with
+        | Gen5 -> "Gen5"
 
 module Servers =
     type Database =
@@ -60,7 +69,7 @@ type Server =
       BackupRetention : int<Days> }
 
     member this.Sku =
-        {| name = sprintf "%s_%O_%d" this.Tier.Name this.Family this.Capacity
+        {| name = sprintf "%s_%s_%d" this.Tier.Name this.Family.AsArmValue this.Capacity
            tier = string this.Tier
            capacity = this.Capacity
            family = string this.Family

--- a/src/Tests/PostgreSQL.fs
+++ b/src/Tests/PostgreSQL.fs
@@ -7,6 +7,7 @@ open Farmer
 open Farmer.PostgreSQL
 open Farmer.Builders
 open Newtonsoft.Json.Linq
+open Farmer.Arm
 
 type PostgresSku =
     { name : string
@@ -265,5 +266,10 @@ let tests = testList "PostgreSQL Database Service" [
         Expect.throws (fun () -> Validate.capacity 128<VCores>) "Capacity too large"
         Expect.throws (fun () -> Validate.capacity 13<VCores>) "Capacity not a power of two"
         Expect.throwsNot (fun () -> Validate.capacity 16<VCores>) "Capacity just right"
+    }
+
+    test "Family name should not include type name" {
+        Expect.equal PostgreSQLFamily.Gen5.AsArmValue "Gen5" "Wrong value for Gen5 family"
+        Expect.equal (PostgreSQLFamily.Gen5.ToString()) "Gen5" "Wrong value for Gen5 family"
     }
 ]


### PR DESCRIPTION
This PR fixes the issue introduced by the change in ToString() behavior on the latest fsharp version.

Issue: https://github.com/CompositionalIT/farmer/issues/314