### PR TITLE
[docs] add custom script to the vm docs example

### DIFF
--- a/docs/content/api-overview/resources/virtual-machine.md
+++ b/docs/content/api-overview/resources/virtual-machine.md
@@ -60,5 +60,7 @@ let myVm = vm {
     os_disk 128 Vm.StandardSSD_LRS
     add_ssd_disk 128
     add_slow_disk 512
+    custom_script "powershell setup-vm.ps1" // you have to actually *call* the script
+    custom_script_files [ "https://foo.bar/foo/setup-vm.ps1" ] 
 }
 ```


### PR DESCRIPTION
As per #319, here's a small addition to the docs.  
(tbh I have not tried if it works with `powershell scriptname.ps1` on Windows, as I used the feature only on Linux vms, but I didn't want to add a Linux example just for that)  
Perhaps for this kind of non-trivial features it's worth linking to the upstream docs as well (?)

Btw, README.md says to check `docs` branch for the docs, but I found that it's not the most up-to-date version.