### PR TITLE
ACI dropped support for assigning static private IP

### DIFF
--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -25,7 +25,6 @@ The Container Group builder is used to create Azure Container Group instances.
 | containerGroup | restart_policy | Sets the restart policy (default Always) |
 | containerGroup | public_dns | Sets the DNS host label when using a public IP. |
 | containerGroup | private_ip | Indicates the container should use a system-assigned private IP address for use in a virtual network. |
-| containerGroup | private_static_ip | Sets a static assigned IP address for use in a virtual network |
 | containerGroup | network_profile | Name of a network profile resource for the subnet in a virtual network where the container group will attach. |
 | containerGroup | add_tcp_port | Adds a TCP port to be externally accessible. |
 | containerGroup | add_udp_port | Adds a UDP port to be externally accessible. |
@@ -110,6 +109,6 @@ let group = containerGroup {
     restart_policy AlwaysRestart
     add_instances [ myContainer ]
     network_profile "vnet-aci-profile"
-    private_static_ip "10.30.19.4" [TCP, 80us]
+    private_ip [TCP, 80us]
 }
 ```

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -90,16 +90,12 @@ type ContainerGroup =
                         {| ``type`` =
                             match this.IpAddress.Type with
                             | PublicAddress | PublicAddressWithDns _ -> "Public"
-                            | PrivateAddress _ | PrivateAddressWithIp _ -> "Private"
+                            | PrivateAddress _ -> "Private"
                            ports = [
                                for port in this.IpAddress.Ports do
                                 {| protocol = string port.Protocol
                                    port = port.Port |}
                            ]
-                           ip =
-                            match this.IpAddress.Type with
-                            | PrivateAddressWithIp ip -> string ip
-                            | _ -> null
                            dnsNameLabel =
                             match this.IpAddress.Type with
                             | PublicAddressWithDns dnsLabel -> dnsLabel

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -121,9 +121,6 @@ type ContainerGroupBuilder() =
     /// Sets the IP addresss to a public address with a DNS label
     [<CustomOperation "public_dns">]
     member this.PublicDns(state, dnsLabel, ports) = this.SetIpAddress(state, PublicAddressWithDns dnsLabel, ports)
-    /// Sets the IP addresss to a private address that is statically assigned
-    [<CustomOperation "private_static_ip">]
-    member this.PrivateStaticIp(state, ip, ports) = this.SetIpAddress(state, PrivateAddressWithIp (System.Net.IPAddress.Parse ip), ports)
     /// Sets the IP addresss to a private address assigned by the vnet
     [<CustomOperation "private_ip">]
     member this.PrivateIp(state:ContainerGroupConfig, ports) = this.SetIpAddress(state, PrivateAddress, ports)

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -510,7 +510,6 @@ module ContainerGroup =
         | PublicAddress
         | PublicAddressWithDns of DnsName:string
         | PrivateAddress
-        | PrivateAddressWithIp of System.Net.IPAddress
     /// A secret file which will be encoded as base64 and attached to a container group.
     type SecretFile = SecretFile of Name:string * Secret:byte array
     /// A container group volume.


### PR DESCRIPTION
The Azure container instances team changed the service behavior so if you pass a static IP for a private container group, it now returns an error, so deprecation of this capability follows that change.