### PR TITLE
Sql vcore

### DIFF
--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -33,6 +33,8 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 |-|-|
 | name | Sets the name of the database. |
 | sku | Sets the sku of the database. If not set, the database is assumed to be part of an elastic pool which will be automatically created. |
+| hybrid_benefit | If a VCore-style SKU is selected, this allows you to use Azure Hybrid Benefit licensing. |
+| db_size | Sets the maximum database size. |
 | collation | Sets the collation of the database. |
 | use_encryption | Enables transparent data encryption of the database. |
 
@@ -53,7 +55,17 @@ let myDatabases = sqlServer {
     add_databases [
         sqlDb { name "poolDb1" }
         sqlDb { name "poolDb2" }
-        sqlDb { name "standaloneDb1"; sku DbSku.Basic }
+        sqlDb { name "dtuDb"; sku SqlDtu.Basic }
+        sqlDb { name "memoryDb"; sku MSeries.M_8 }
+        sqlDb { name "cpuDb"; sku FSeries.Fsv2_8 }
+        sqlDb { name "businessCriticalDb"; sku (SqlVCore.BusinessCritical Gen5Series.Gen5_2) }
+        sqlDb { name "hyperscaleDb"; sku (SqlVCore.Hyperscale Gen5Series.Gen5_2) }
+        sqlDb {
+            name "generalPurposeDb"
+            sku (SqlVCore.GeneralPurpose Gen5Series.Gen5_8)
+            db_size 8192<Mb>
+            hybrid_benefit
+        }
     ]
 }
 

--- a/samples/scripts/sqlserver.fsx
+++ b/samples/scripts/sqlserver.fsx
@@ -10,13 +10,11 @@ let myDatabases = sqlServer {
     admin_username "admin_username"
     enable_azure_firewall
 
-    elastic_pool_name "mypool"
-    elastic_pool_sku PoolSku.Basic100
-
     add_databases [
-        sqlDb { name "poolDb1" }
-        sqlDb { name "poolDb2" }
-        sqlDb { name "standaloneDb1"; sku DbSku.Basic }
+        sqlDb { name "standaloneDb1"; sku MSeries_12 }
+        sqlDb { name "standaloneDb1"; sku Fsv2_12 }
+        sqlDb { name "standaloneDb1"; sku (GeneralPurpose.Provisioned (Gen5 Gen5_10)) }
+        sqlDb { name "standaloneDb1"; sku (BusinessCritical.Gen5 Gen5_10) }
     ]
 }
 
@@ -25,5 +23,7 @@ let template = arm {
     add_resource myDatabases
 }
 
-template
-|> Writer.quickWrite "sql-example"
+template |> Writer.quickWrite "sql-example"
+
+// template |> Deploy.execute "delete-me-too" [ "password-for-isaac_super_server", "qweasdQWEASD123***" ]
+

--- a/samples/scripts/sqlserver.fsx
+++ b/samples/scripts/sqlserver.fsx
@@ -11,10 +11,11 @@ let myDatabases = sqlServer {
     enable_azure_firewall
 
     add_databases [
-        sqlDb { name "standaloneDb1"; sku MSeries_12 }
-        sqlDb { name "standaloneDb1"; sku Fsv2_12 }
-        sqlDb { name "standaloneDb1"; sku (GeneralPurpose.Provisioned (Gen5 Gen5_10)) }
-        sqlDb { name "standaloneDb1"; sku (BusinessCritical.Gen5 Gen5_10) }
+        // sqlDb { name "memoryDb"; sku M_8 }
+        // sqlDb { name "cpuDb"; sku Fsv2_8 }
+        sqlDb { name "generalPurposeDb"; sku (GeneralPurpose Gen5_2) }
+        // sqlDb { name "businessCriticalDb"; sku (BusinessCritical Gen5_2) }
+        // sqlDb { name "hyperscaleDb"; sku (Hyperscale.Create Gen5_2) }
     ]
 }
 
@@ -25,5 +26,5 @@ let template = arm {
 
 template |> Writer.quickWrite "sql-example"
 
-// template |> Deploy.execute "delete-me-too" [ "password-for-isaac_super_server", "qweasdQWEASD123***" ]
+template |> Deploy.execute "delete-me-too" [ "password-for-isaac_super_server", "qweasdQWEASD123***" ]
 

--- a/samples/scripts/sqlserver.fsx
+++ b/samples/scripts/sqlserver.fsx
@@ -11,11 +11,19 @@ let myDatabases = sqlServer {
     enable_azure_firewall
 
     add_databases [
-        // sqlDb { name "memoryDb"; sku M_8 }
-        // sqlDb { name "cpuDb"; sku Fsv2_8 }
-        sqlDb { name "generalPurposeDb"; sku (GeneralPurpose Gen5_2) }
-        // sqlDb { name "businessCriticalDb"; sku (BusinessCritical Gen5_2) }
-        // sqlDb { name "hyperscaleDb"; sku (Hyperscale.Create Gen5_2) }
+        sqlDb { name "poolDb1" }
+        sqlDb { name "poolDb2" }
+        sqlDb { name "dtuDb"; sku SqlDtu.Basic }
+        sqlDb { name "memoryDb"; sku MSeries.M_8 }
+        sqlDb { name "cpuDb"; sku FSeries.Fsv2_8 }
+        sqlDb { name "businessCriticalDb"; sku (SqlVCore.BusinessCritical Gen5Series.Gen5_2) }
+        sqlDb { name "hyperscaleDb"; sku (SqlVCore.Hyperscale Gen5Series.Gen5_2) }
+        sqlDb {
+            name "generalPurposeDb"
+            sku (SqlVCore.GeneralPurpose Gen5Series.Gen5_8)
+            db_size (1024<Mb> * 128)
+            hybrid_benefit
+        }
     ]
 }
 
@@ -25,6 +33,3 @@ let template = arm {
 }
 
 template |> Writer.quickWrite "sql-example"
-
-template |> Deploy.execute "delete-me-too" [ "password-for-isaac_super_server", "qweasdQWEASD123***" ]
-

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -12,7 +12,7 @@ let firewallRules = ResourceType "Microsoft.Sql/servers/firewallrules"
 let databases = ResourceType "Microsoft.Sql/servers/databases"
 let transparentDataEncryption = ResourceType "Microsoft.Sql/servers/databases/transparentDataEncryption"
 
-type DbKind = Standalone of DbSku | Pool of ResourceName
+type DbKind = Standalone of DbPurchaseModel | Pool of ResourceName
 
 type Server =
     { ServerName : ResourceName

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -18,8 +18,7 @@ type Server =
     { ServerName : ResourceName
       Location : Location
       Credentials : {| Username : string; Password : SecureParameter |}
-      Tags: Map<string,string>
-    }
+      Tags: Map<string,string> }
     interface IParameters with
         member this.SecureParameters = [ this.Credentials.Password ]
     interface IArmResource with
@@ -29,12 +28,13 @@ type Server =
                name = this.ServerName.Value
                apiVersion = "2019-06-01-preview"
                location = this.Location.ArmValue
-               tags = this.Tags
-                   |> Map.add "displayName" this.ServerName.Value
+               tags =
+                this.Tags
+                |> Map.add "displayName" this.ServerName.Value
                properties =
-                   {| administratorLogin = this.Credentials.Username
-                      administratorLoginPassword = this.Credentials.Password.AsArmRef.Eval()
-                      version = "12.0" |}
+                {| administratorLogin = this.Credentials.Username
+                   administratorLoginPassword = this.Credentials.Password.AsArmRef.Eval()
+                   version = "12.0" |}
             |} :> _
 
 module Servers =
@@ -76,8 +76,8 @@ module Servers =
                    apiVersion = "2014-04-01"
                    location = this.Location.ArmValue
                    properties =
-                     {| endIpAddress = string this.Start
-                        startIpAddress = string this.End |}
+                    {| endIpAddress = string this.Start
+                       startIpAddress = string this.End |}
                    dependsOn = [ this.Server.Value ]
                 |} :> _
 
@@ -85,6 +85,7 @@ module Servers =
         { Name : ResourceName
           Server : ResourceName
           Location : Location
+          MaxSizeBytes : int64 option
           Sku : DbKind
           Collation : string }
         interface IArmResource with
@@ -96,11 +97,19 @@ module Servers =
                    location = this.Location.ArmValue
                    tags = {| displayName = this.Name.Value |}
                    sku =
-                        match this.Sku with
-                        | Standalone sku -> box {| name = sku.Name; tier = sku.Edition |}
-                        | Pool _ -> null
+                    match this.Sku with
+                    | Standalone sku -> box {| name = sku.Name; tier = sku.Edition |}
+                    | Pool _ -> null
                    properties =
                         {| collation = this.Collation
+                           maxSizeBytes = this.MaxSizeBytes |> Option.toNullable
+                           licenseType =
+                            match this.Sku with
+                            | Standalone (VCore (_, license)) ->
+                                license.ArmValue
+                            | Standalone (DTU _)
+                            | Pool _ ->
+                                null
                            elasticPoolId =
                                 match this.Sku with
                                 | Standalone _ ->
@@ -109,11 +118,11 @@ module Servers =
                                     ArmExpression.resourceId(elasticPools, this.Server, pool).Eval()
                         |}
                    dependsOn =
-                     [ this.Server.Value
-                       match this.Sku with
-                       | Standalone _ -> ()
-                       | Pool poolName -> poolName.Value
-                     ]
+                    [ this.Server.Value
+                      match this.Sku with
+                      | Standalone _ -> ()
+                      | Pool poolName -> poolName.Value
+                    ]
                 |} :> _
 
     module Databases =

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -12,6 +12,7 @@ open Databases
 type SqlAzureDbConfig =
     { Name : ResourceName
       Sku : DbPurchaseModel option
+      MaxSize : int<Mb> option
       Collation : string
       Encryption : FeatureFlag }
 
@@ -63,6 +64,10 @@ type SqlAzureConfig =
                 { Name = database.Name
                   Server = this.Name
                   Location = location
+                  MaxSizeBytes =
+                    match database.Sku, database.MaxSize with
+                    | Some _, Some maxSize -> Some (Mb.toBytes maxSize)
+                    | _ -> None
                   Sku =
                    match database.Sku with
                    | Some dbSku -> Standalone dbSku
@@ -88,7 +93,7 @@ type SqlAzureConfig =
                   Server = this.Name
                   Location = location
                   Sku = this.ElasticPoolSettings.Sku
-                  MaxSizeBytes = this.ElasticPoolSettings.Capacity |> Option.map(fun mb -> int64 mb * 1024L * 1024L)
+                  MaxSizeBytes = this.ElasticPoolSettings.Capacity |> Option.map Mb.toBytes
                   MinMax = this.ElasticPoolSettings.PerDbLimits |> Option.map(fun l -> l.Min, l.Max) }
         ]
 
@@ -97,24 +102,40 @@ type SqlDbBuilder() =
         { Name = ResourceName ""
           Collation = "SQL_Latin1_General_CP1_CI_AS"
           Sku = None
+          MaxSize = None
           Encryption = Disabled }
     /// Sets the name of the database.
     [<CustomOperation "name">]
     member _.DbName(state:SqlAzureDbConfig, name) = { state with Name = name }
     member this.DbName(state:SqlAzureDbConfig, name:string) = this.DbName(state, ResourceName name)
-    // Sets the sku of the database
+    /// Sets the sku of the database
     [<CustomOperation "sku">]
     member _.DbSku(state:SqlAzureDbConfig, sku:SqlDtu) = { state with Sku = Some (DTU sku) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:M) = { state with Sku = Some (VCore(MemoryIntensive sku)) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:Fsv2) = { state with Sku = Some (VCore(CpuIntensive sku)) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:SqlVCore) = { state with Sku = Some (VCore sku) }
-    // Sets the collation of the database.
+    member _.DbSku(state:SqlAzureDbConfig, sku:MSeries) = { state with Sku = Some (VCore(MemoryIntensive sku, LicenseRequired)) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:FSeries) = { state with Sku = Some (VCore(CpuIntensive sku, LicenseRequired)) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:SqlVCore) = { state with Sku = Some (VCore (sku, LicenseRequired)) }
+    /// Sets the collation of the database.
     [<CustomOperation "collation">]
     member _.DbCollation(state:SqlAzureDbConfig, collation:string) = { state with Collation = collation }
-    // Enables encryption of the database.
+    /// States that you already have a SQL license and qualify for Azure Hybrid Benefit discount.
+    [<CustomOperation "hybrid_benefit">]
+    member _.ZoneRedundant(state:SqlAzureDbConfig) =
+        { state with
+            Sku =
+                match state.Sku with
+                | Some (VCore (v, _)) ->
+                    Some (VCore (v, AzureHybridBenefit))
+                | Some (DTU _)
+                | None ->
+                    failwith "You can only set licensing on VCore databases. Ensure that you have already set the SKU to a VCore model."
+        }
+    /// Sets the maximum size of the database, if this database is not part of an elastic pool.
+    [<CustomOperation "db_size">]
+    member _.MaxSize(state:SqlAzureDbConfig, size:int<Mb>) = { state with MaxSize = Some size }
+    /// Enables encryption of the database.
     [<CustomOperation "use_encryption">]
     member _.UseEncryption(state:SqlAzureDbConfig) = { state with Encryption = Enabled }
-    // Adds a custom firewall rule given a name, start and end IP address range.
+    /// Adds a custom firewall rule given a name, start and end IP address range.
     member _.Run (state:SqlAzureDbConfig) =
         if state.Name = ResourceName.Empty then failwith "You must set a database name."
         state

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -11,7 +11,7 @@ open Databases
 
 type SqlAzureDbConfig =
     { Name : ResourceName
-      Sku : DbSku option
+      Sku : DbPurchaseModel option
       Collation : string
       Encryption : FeatureFlag }
 
@@ -104,7 +104,11 @@ type SqlDbBuilder() =
     member this.DbName(state:SqlAzureDbConfig, name:string) = this.DbName(state, ResourceName name)
     // Sets the sku of the database
     [<CustomOperation "sku">]
-    member _.DbSku(state:SqlAzureDbConfig, sku:DbSku) = { state with Sku = Some sku }
+    member _.DbSku(state:SqlAzureDbConfig, sku:SqlDtu) = { state with Sku = Some (DTU sku) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:MSeries) = { state with Sku = Some (VCore(BusinessCritical (MSeries sku))) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:Fsv2) = { state with Sku = Some (VCore(GeneralPurpose (GeneralPurpose.Provisioned(Fsv2 sku)))) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:BusinessCritical) = { state with Sku = Some (VCore(BusinessCritical sku)) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:GeneralPurpose) = { state with Sku = Some (VCore(GeneralPurpose sku)) }
     // Sets the collation of the database.
     [<CustomOperation "collation">]
     member _.DbCollation(state:SqlAzureDbConfig, collation:string) = { state with Collation = collation }

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -105,10 +105,9 @@ type SqlDbBuilder() =
     // Sets the sku of the database
     [<CustomOperation "sku">]
     member _.DbSku(state:SqlAzureDbConfig, sku:SqlDtu) = { state with Sku = Some (DTU sku) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:MSeries) = { state with Sku = Some (VCore(BusinessCritical (MSeries sku))) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:Fsv2) = { state with Sku = Some (VCore(GeneralPurpose (GeneralPurpose.Provisioned(Fsv2 sku)))) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:BusinessCritical) = { state with Sku = Some (VCore(BusinessCritical sku)) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:GeneralPurpose) = { state with Sku = Some (VCore(GeneralPurpose sku)) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:M) = { state with Sku = Some (VCore(MemoryIntensive sku)) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:Fsv2) = { state with Sku = Some (VCore(CpuIntensive sku)) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:SqlVCore) = { state with Sku = Some (VCore sku) }
     // Sets the collation of the database.
     [<CustomOperation "collation">]
     member _.DbCollation(state:SqlAzureDbConfig, collation:string) = { state with Collation = collation }

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -111,8 +111,8 @@ type SqlDbBuilder() =
     /// Sets the sku of the database
     [<CustomOperation "sku">]
     member _.DbSku(state:SqlAzureDbConfig, sku:SqlDtu) = { state with Sku = Some (DTU sku) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:MSeries) = { state with Sku = Some (VCore(MemoryIntensive sku, LicenseRequired)) }
-    member _.DbSku(state:SqlAzureDbConfig, sku:FSeries) = { state with Sku = Some (VCore(CpuIntensive sku, LicenseRequired)) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:MSeries) = { state with Sku = Some (VCore(SqlVCore.MemoryIntensive sku, LicenseRequired)) }
+    member _.DbSku(state:SqlAzureDbConfig, sku:FSeries) = { state with Sku = Some (VCore(SqlVCore.CpuIntensive sku, LicenseRequired)) }
     member _.DbSku(state:SqlAzureDbConfig, sku:SqlVCore) = { state with Sku = Some (VCore (sku, LicenseRequired)) }
     /// Sets the collation of the database.
     [<CustomOperation "collation">]

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -454,7 +454,6 @@ module Sql =
         | Gen5_32
         | Gen5_40
         | Gen5_80
-        member this.Name = this.ToString().[5..]
     type Fsv2 =
         | Fsv2_8
         | Fsv2_10
@@ -467,54 +466,46 @@ module Sql =
         | Fsv2_32
         | Fsv2_36
         | Fsv2_72
-        member this.Name = this.ToString().[5..]
 
-    type MSeries =
-        | MSeries_8
-        | MSeries_10
-        | MSeries_12
-        | MSeries_14
-        | MSeries_16
-        | MSeries_18
-        | MSeries_20
-        | MSeries_24
-        | MSeries_32
-        | MSeries_64
-        | MSeries_128
-        member this.Name = this.ToString().[8..]
+    type M =
+        | M_8
+        | M_10
+        | M_12
+        | M_14
+        | M_16
+        | M_18
+        | M_20
+        | M_24
+        | M_32
+        | M_64
+        | M_128
 
-    type BusinessCritical =
-        | Gen5 of Gen5
-        | MSeries of MSeries
-        member this.Name =
-            match this with
-            | Gen5 g -> "Gen5_" + g.Name
-            | MSeries m -> "M_" + m.Name
-    type Provisioned =
-        | Gen5 of Gen5
-        | Fsv2 of Fsv2
-        member this.Name =
-            match this with
-            | Gen5 g -> "Gen5_" + g.Name
-            | Fsv2 f -> "Fsv2_" + f.Name
-    [<RequireQualifiedAccess>]
-    type GeneralPurpose =
-        | Provisioned of Provisioned
-        //| Serverless
     type SqlVCore =
-        | GeneralPurpose of GeneralPurpose
-        | BusinessCritical of BusinessCritical
+        | MemoryIntensive of M
+        | CpuIntensive of Fsv2
+        | GeneralPurpose of Gen5
+        | BusinessCritical of Gen5
         | Hyperscale of Gen5 * Replicas:int * ZoneRedundant:bool * ReadScaleOut:CoreTypes.FeatureFlag
         member this.Edition =
             match this with
-            | GeneralPurpose _ -> "GeneralPurpose"
-            | BusinessCritical _ -> "BusinessCritical"
+            | GeneralPurpose _ | CpuIntensive _ -> "GeneralPurpose"
+            | BusinessCritical _ | MemoryIntensive _ -> "BusinessCritical"
             | Hyperscale _ -> "Hyperscale"
          member this.Name =
             match this with
-            | GeneralPurpose (GeneralPurpose.Provisioned p) -> "GP_" + p.Name
-            | BusinessCritical b -> "BC_" + b.Name
-            | Hyperscale (h, _, _, _) -> "HS_" + h.Name
+            | GeneralPurpose g -> "GP_" + (string g)
+            | BusinessCritical b -> "BC_" + (string b)
+            | Hyperscale (h, _, _, _) -> "HS_" + (string h)
+            | MemoryIntensive m -> "BC_" + (string m)
+            | CpuIntensive c -> "GP_" + (string c)
+
+    type Hyperscale =
+        static member Create(gen5, ?replicas, ?zoneRedundant, ?readScaleOut) =
+            SqlVCore.Hyperscale(
+                gen5,
+                replicas |> Option.defaultValue 1,
+                zoneRedundant |> Option.defaultValue false,
+                readScaleOut |> Option.defaultValue false |> CoreTypes.FeatureFlag.ofBool)
 
     type SqlDtu =
         | Free

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -488,6 +488,7 @@ module Sql =
         | M_128
         member this.Name = Reflection.FSharpValue.GetUnionFields(this, typeof<MSeries>) |> fun (v,_) -> v.Name
 
+    [<RequireQualifiedAccess>]
     type SqlVCore =
         | MemoryIntensive of MSeries
         | CpuIntensive of FSeries
@@ -507,6 +508,7 @@ module Sql =
             | MemoryIntensive m -> "BC_" + m.Name
             | CpuIntensive c -> "GP_" + c.Name
 
+    [<RequireQualifiedAccess>]
     type SqlDtu =
         | Free
         | Basic

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -65,4 +65,45 @@ let tests = testList "SQL Server" [
         Expect.equal model.Sku.Name "BasicPool" "Incorrect Elastic Pool SKU"
         Expect.equal model.Sku.Size "200" "Incorrect Elastic Pool SKU size"
     }
+
+    test "Works with VCore databases" {
+        let sql = sqlServer {
+            name "server"
+            admin_username "isaac"
+            add_databases [ sqlDb { name "db"; sku MSeries.M_18 } ]
+        }
+
+        let model : Models.Database = sql |> getResourceAtIndex client.SerializationSettings 1
+        Expect.equal model.Sku.Name "BC_M_18" "Incorrect SKU"
+        Expect.equal model.LicenseType "LicenseIncluded" "Incorrect License"
+    }
+
+    test "Cannot set hybrid if not VCore" {
+        Expect.throws(fun () ->
+            sqlServer {
+                name "server"
+                admin_username "isaac"
+                add_databases [ sqlDb { name "db"; hybrid_benefit } ]
+            } |> ignore) "Shouldn't set hybrid on non-VCore"
+    }
+
+    test "Sets license and size correctly" {
+        let sql =
+            sqlServer {
+                name "server"
+                admin_username "isaac"
+                add_databases [
+                    sqlDb {
+                        name "db"
+                        sku (SqlVCore.GeneralPurpose Gen5Series.Gen5_12)
+                        hybrid_benefit
+                        db_size 2048<Mb>
+                     } ]
+            }
+
+        let model : Models.Database = sql |> getResourceAtIndex client.SerializationSettings 1
+        Expect.equal model.Sku.Name "GP_Gen5_12" "Incorrect SKU"
+        Expect.equal model.MaxSizeBytes (Nullable 2147483648L) "Incorrect Size"
+        Expect.equal model.LicenseType "BasePrice" "Incorrect SKU"
+    }
 ]

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -20,7 +20,7 @@ let tests = testList "SQL Server" [
             add_databases [
                 sqlDb {
                     name "db"
-                    sku DbSku.S0
+                    sku SqlDtu.S0
                 }
             ]
         }
@@ -41,7 +41,7 @@ let tests = testList "SQL Server" [
                 sqlDb {
                     name "db"
                     use_encryption
-                    sku DbSku.S0
+                    sku SqlDtu.S0
                 }
             ]
         }


### PR DESCRIPTION
Adds support for VCore models. This PR has two commits, both with alternate modelling approaches:

The first commit is more true to the "real" structure of how the SKUs are organised. However, it is slightly more verbose and does not lend itself especially well to the builder DSL.

The second commit flattens the SKUs so they are in a single flat list - this doesn't match how they are organised in terms of relationships but it is still "correct" and is easier to consume.

I'm inclined to go with the second approach.

Still need to clean up Hyperscale a bit as well as look at the extra (optional) fields - I think I'll add them as keywords.

Closes #359 