### PR TITLE
Expose storage key expression.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 Release Notes
 =============
 ## 1.1.0-beta2
+* Create Storage Account connection string expressions.
 * Small updates to SQL naming
 
 ## 1.1.0-beta1

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -39,6 +39,9 @@ The Storage Account builder creates storage accounts and their associated contai
 | Key | Returns an ARM expression to retrieve the storage account's primary connection string. Useful for e.g. supplying the connection string to another resource e.g. KeyVault or an app setting in the App Service. |
 | WebsitePrimaryEndpoint | Returns the Primary endpoint for static website (if enabled). |
 
+#### Helpers
+The `StorageAccount` type contains helper methods to quickly create ARM expressions for Storage Account connection strings.
+
 #### Example
 
 ```fsharp

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -36,7 +36,7 @@ type FunctionsConfig =
     /// Gets the ARM expression path to the publishing password of this functions app.
     member this.PublishingPassword = publishingPassword this.Name
     /// Gets the ARM expression path to the storage account key of this functions app.
-    member this.StorageAccountKey = Storage.buildKey this.StorageAccountName
+    member this.StorageAccountKey = StorageAccount.GetConnectionString this.StorageAccountName
     /// Gets the ARM expression path to the app insights key of this functions app, if it exists.
     member this.AppInsightsKey = this.AppInsightsName |> Option.map instrumentationKey
     /// Gets the default key for the functions site
@@ -52,7 +52,7 @@ type FunctionsConfig =
     /// Gets the App Insights name for this functions app, if it exists.
     member this.AppInsightsName = this.AppInsights |> Option.map (fun ai -> ai.CreateResourceName this)
     /// Gets the Storage Account name for this functions app.
-    member this.StorageAccountName = this.StorageAccount.CreateResourceName this
+    member this.StorageAccountName : Storage.StorageAccountName = this.StorageAccount.CreateResourceName this |> Storage.StorageAccountName.Create |> Result.get
     interface IBuilder with
         member this.DependencyName = this.ServicePlanName
         member this.BuildResources location = [
@@ -66,15 +66,15 @@ type FunctionsConfig =
                 "FUNCTIONS_WORKER_RUNTIME", (string this.Runtime).ToLower()
                 "WEBSITE_NODE_DEFAULT_VERSION", "10.14.1"
                 "FUNCTIONS_EXTENSION_VERSION", match this.ExtensionVersion with V1 -> "~1" | V2 -> "~2" | V3 -> "~3"
-                "AzureWebJobsStorage", Storage.buildKey this.StorageAccountName |> ArmExpression.Eval
-                "AzureWebJobsDashboard", Storage.buildKey this.StorageAccountName |> ArmExpression.Eval
+                "AzureWebJobsStorage", StorageAccount.GetConnectionString this.StorageAccountName |> ArmExpression.Eval
+                "AzureWebJobsDashboard", StorageAccount.GetConnectionString this.StorageAccountName |> ArmExpression.Eval
 
                 match this.AppInsightsKey with
                 | Some key -> "APPINSIGHTS_INSTRUMENTATIONKEY", key |> ArmExpression.Eval
                 | None -> ()
 
                 if this.OperatingSystem = Windows then
-                    "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", Storage.buildKey this.StorageAccountName |> ArmExpression.Eval
+                    "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", StorageAccount.GetConnectionString this.StorageAccountName |> ArmExpression.Eval
                     "WEBSITE_CONTENTSHARE", this.Name.Value.ToLower()
               ]
               |> List.map Setting.AsLiteral
@@ -95,7 +95,7 @@ type FunctionsConfig =
                 | DependableResource this resourceName -> resourceName
                 | _ -> ()
 
-                this.StorageAccountName
+                this.StorageAccountName.ResourceName
               ]
               AlwaysOn = false
               HTTPSOnly = this.HTTPSOnly
@@ -126,7 +126,7 @@ type FunctionsConfig =
                 ()
             match this.StorageAccount with
             | DeployableResource this resourceName ->
-                { Name = Storage.StorageAccountName.Create resourceName |> Result.get
+                { Name = Storage.StorageAccountName.Create(resourceName).OkValue
                   Location = location
                   Sku = Storage.Standard_LRS
                   StaticWebsite = None

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -100,7 +100,7 @@ type VmConfig =
             // Storage account - optional
             match this.DiagnosticsStorageAccount with
             | Some (DeployableResource this resourceName) ->
-                { Name = Storage.StorageAccountName.Create resourceName |> Result.get
+                { Name = Storage.StorageAccountName.Create(resourceName).OkValue
                   Location = location
                   Sku = Storage.Standard_LRS
                   StaticWebsite = None

--- a/src/Farmer/Result.fs
+++ b/src/Farmer/Result.fs
@@ -61,3 +61,6 @@ module Result =
 [<AutoOpen>]
 module Builders =
     let result = Result.ResultBuilder()
+    type Result<'TS, 'TE> with
+        /// Unsafely unwraps the Success value out of the Result.
+        member this.OkValue = Result.get this

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -93,7 +93,7 @@ let tests = testList "Storage Tests" [
         check "abcdefghij1234567890abcde" "max length is 24, but here is 25 ('abcdefghij1234567890abcde')" "Name too long"
         check "zzzT" "can only contain lowercase letters ('zzzT')" "Upper case character allowed"
         check "zzz!" "can only contain alphanumeric characters ('zzz!')" "Non alpha numeric character allowed"
-        Expect.equal (StorageResourceName.Create "abcdefghij1234567890abcd" |> Result.get |> fun name -> name.ResourceName) (ResourceName "abcdefghij1234567890abcd") "Should have created a valid storage account name"
+        Expect.equal (StorageResourceName.Create("abcdefghij1234567890abcd").OkValue.ResourceName) (ResourceName "abcdefghij1234567890abcd") "Should have created a valid storage account name"
     }
     test "Rejects invalid storage resource names" {
         let check (v:string) m = Expect.equal (StorageResourceName.Create v) (Error ("Storage resource names " + m))
@@ -108,7 +108,7 @@ let tests = testList "Storage Tests" [
         check "-zz" "must start with an alphanumeric character ('-zz')" "Start with dash"
         check "zz-" "must end with an alphanumeric character ('zz-')" "End with dash"
 
-        Expect.equal (StorageResourceName.Create "abcdefghij1234567890abcd" |> Result.get |> fun name -> name.ResourceName) (ResourceName "abcdefghij1234567890abcd") "Should have created a valid storage resource name"
+        Expect.equal (StorageResourceName.Create("abcdefghij1234567890abcd").OkValue.ResourceName) (ResourceName "abcdefghij1234567890abcd") "Should have created a valid storage resource name"
     }
     test "Adds lifecycle policies correctly" {
         let resource : ManagementPolicy =

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -131,5 +131,15 @@ let tests = testList "Storage Tests" [
         Expect.equal rule.Definition.Actions.BaseBlob.Delete.DaysAfterModificationGreaterThan 1. "should ignore duplicate actions"
         Expect.equal rule.Definition.Actions.BaseBlob.TierToArchive.DaysAfterModificationGreaterThan 2. "should add multiple actions to a rule"
         Expect.equal (rule.Definition.Filters.PrefixMatch |> Seq.toList) [ "foo/bar" ] "incorrect filter"
-   }
+    }
+    test "Creates connection strings correctly" {
+        let simpleConn = StorageAccount.GetConnectionString "account"
+        let rgConn = StorageAccount.GetConnectionString("account", "rg")
+
+        Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys('account', '2017-10-01').keys[0].value)" simpleConn.Value "Simple connection string"
+        Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('rg', 'Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" rgConn.Value "Complex connection string"
+    }
+    test "Ensures Storage Account Names are valid" {
+        Expect.throws (fun _ -> StorageAccount.GetConnectionString "IFDJI$*(£" |> ignore) "Did not validate"
+    }
 ]


### PR DESCRIPTION
This PR closes issue #365

The changes in this PR are as follows:

* Make it possible for consumers to easily create a Storage Account Key ARM Expression
* Add a Result extension member to easily (but unsafely!) get the OK branch of a result.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the contributions guide and ensured my code adheres to them.
