### PR TITLE
Experimental work on Resource Types

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 ## 1.1.0-beta2
 * Small updates to SQL naming
+* Internal updates to ARM resource construction
 
 ## 1.1.0-beta1
 * AppInsights: Support for IP Masking and Sampling

--- a/src/Farmer/Arm/Cache.fs
+++ b/src/Farmer/Arm/Cache.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.Redis
 
-let redis = ResourceType "Microsoft.Cache/Redis"
+let redis = ResourceType ("Microsoft.Cache/Redis", "2018-03-01")
 
 type Redis =
     { Name : ResourceName
@@ -26,8 +26,8 @@ type Redis =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = redis.ArmValue
-               apiVersion = "2018-03-01"
+            {| ``type`` = redis.Path
+               apiVersion = redis.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                properties =

--- a/src/Farmer/Arm/Cache.fs
+++ b/src/Farmer/Arm/Cache.fs
@@ -26,26 +26,22 @@ type Redis =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = redis.Path
-               apiVersion = redis.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               properties =
-                    {| sku =
-                        {| name = string this.Sku.Sku
-                           family = this.Family
-                           capacity = this.Sku.Capacity
-                        |}
-                       enableNonSslPort = this.NonSslEnabled |> Option.toNullable
-                       shardCount = this.ShardCount |> Option.toNullable
-                       minimumTlsVersion =
-                         this.MinimumTlsVersion
-                         |> Option.map(function
-                             | Tls10 -> "1.0"
-                             | Tls11 -> "1.1"
-                             | Tls12 -> "1.2")
-                         |> Option.toObj
-                       redisConfiguration = this.RedisConfiguration
-                   |}
-               tags = this.Tags
+            {| redis.Create(this.Name, this.Location, tags = this.Tags) with
+                 properties =
+                      {| sku =
+                          {| name = string this.Sku.Sku
+                             family = this.Family
+                             capacity = this.Sku.Capacity
+                          |}
+                         enableNonSslPort = this.NonSslEnabled |> Option.toNullable
+                         shardCount = this.ShardCount |> Option.toNullable
+                         minimumTlsVersion =
+                           this.MinimumTlsVersion
+                           |> Option.map(function
+                               | Tls10 -> "1.0"
+                               | Tls11 -> "1.1"
+                               | Tls12 -> "1.2")
+                           |> Option.toObj
+                         redisConfiguration = this.RedisConfiguration
+                     |}
             |} :> _

--- a/src/Farmer/Arm/Cdn.fs
+++ b/src/Farmer/Arm/Cdn.fs
@@ -6,9 +6,9 @@ open Farmer.CoreTypes
 open Farmer.Cdn
 open System
 
-let profiles = ResourceType "Microsoft.Cdn/profiles"
-let endpoints = ResourceType "Microsoft.Cdn/profiles/endpoints"
-let customDomains = ResourceType "Microsoft.Cdn/profiles/endpoints/customDomains"
+let profiles = ResourceType ("Microsoft.Cdn/profiles", "2019-04-15")
+let endpoints = ResourceType ("Microsoft.Cdn/profiles/endpoints", "2019-04-15")
+let customDomains = ResourceType ("Microsoft.Cdn/profiles/endpoints/customDomains", "2019-04-15")
 
 type Profile =
     { Name : ResourceName
@@ -17,9 +17,9 @@ type Profile =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = profiles.ArmValue
+            {| ``type`` = profiles.Path
+               apiVersion = profiles.Version
                name = this.Name.Value
-               apiVersion = "2019-04-15"
                location = "global"
                sku = {| name = string this.Sku |}
                properties = {||}
@@ -42,9 +42,9 @@ module Profiles =
         interface IArmResource with
             member this.ResourceName: ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = endpoints.ArmValue
+                {| ``type`` = endpoints.Path
+                   apiVersion = endpoints.Version
                    name = this.Profile.Value + "/" + this.Name.Value
-                   apiVersion = "2019-04-15"
                    location = "global"
                    dependsOn = [
                        this.Profile.Value
@@ -77,8 +77,8 @@ module Profiles =
                 member this.ResourceName = this.Name
                 member this.JsonModel =
                     {| Name = this.Endpoint.Value + "/" + this.Name.Value
-                       ``type`` = customDomains.ArmValue
-                       apiVersion = "2019-04-15"
+                       ``type`` = customDomains.Path
+                       apiVersion = customDomains.Version
                        dependsOn = [ this.Endpoint.Value ]
                        properties = {| hostName = string this.Hostname |}
                     |} :> _

--- a/src/Farmer/Arm/CognitiveServices.fs
+++ b/src/Farmer/Arm/CognitiveServices.fs
@@ -15,12 +15,8 @@ type Accounts =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| name = this.Name.Value
-               ``type`` = accounts.Path
-               apiVersion = accounts.Version
-               sku = {| name = string this.Sku |}
-               kind = this.Kind.ToString().Replace("_", ".")
-               location = this.Location.ArmValue
-               tags = {||}
-               properties = {||}
-               tags = this.Tags |} :> _
+            {| accounts.Create(this.Name, this.Location, tags = this.Tags) with
+                sku = {| name = string this.Sku |}
+                kind = this.Kind.ToString().Replace("_", ".")
+                properties = {||}
+            |} :> _

--- a/src/Farmer/Arm/CognitiveServices.fs
+++ b/src/Farmer/Arm/CognitiveServices.fs
@@ -4,7 +4,7 @@ module Farmer.Arm.CognitiveServices
 open Farmer
 open Farmer.CoreTypes
 
-let accounts = ResourceType "Microsoft.CognitiveServices/accounts"
+let accounts = ResourceType ("Microsoft.CognitiveServices/accounts", "2017-04-18")
 
 type Accounts =
     { Name : ResourceName
@@ -16,8 +16,8 @@ type Accounts =
         member this.ResourceName = this.Name
         member this.JsonModel =
             {| name = this.Name.Value
-               ``type`` = accounts.ArmValue
-               apiVersion = "2017-04-18"
+               ``type`` = accounts.Path
+               apiVersion = accounts.Version
                sku = {| name = string this.Sku |}
                kind = this.Kind.ToString().Replace("_", ".")
                location = this.Location.ArmValue

--- a/src/Farmer/Arm/Compute.fs
+++ b/src/Farmer/Arm/Compute.fs
@@ -7,8 +7,8 @@ open Farmer.Vm
 open System
 open System.Text
 
-let virtualMachines = ResourceType "Microsoft.Compute/virtualMachines"
-let extensions = ResourceType "Microsoft.Compute/virtualMachines/extensions"
+let virtualMachines = ResourceType ("Microsoft.Compute/virtualMachines", "2018-10-01")
+let extensions = ResourceType ("Microsoft.Compute/virtualMachines/extensions", "2019-12-01")
 
 type CustomScriptExtension =
     { Name : ResourceName
@@ -21,8 +21,8 @@ type CustomScriptExtension =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = extensions.ArmValue
-               apiVersion = "2019-12-01"
+            {| ``type`` = extensions.Path
+               apiVersion = extensions.Version
                name = this.VirtualMachine.Value + "/" + this.Name.Value
                location = this.Location.ArmValue
                dependsOn = [
@@ -71,8 +71,8 @@ type VirtualMachine =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = virtualMachines.ArmValue
-               apiVersion = "2018-10-01"
+            {| ``type`` = virtualMachines.Path
+               apiVersion = virtualMachines.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                dependsOn = [

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -30,118 +30,112 @@ type ContainerGroup =
       RestartPolicy : RestartPolicy
       IpAddress : ContainerGroupIpAddress
       NetworkProfile : ResourceName option
-      Volumes : Map<string, {| Volume:Volume |}>
+      Volumes : Map<string, Volume>
       Tags: Map<string,string>  }
     member this.NetworkProfilePath =
         this.NetworkProfile
-        |> Option.map (fun networkProfile -> ArmExpression.resourceId(Network.networkProfiles, networkProfile).Eval())
-    member private this.dependencies =
-        seq {
-            if this.NetworkProfilePath.IsSome then
-                yield this.NetworkProfilePath.Value
-            let fileShares =
-                this.Volumes |> Seq.choose (fun v ->
-                    match v.Value.Volume with
-                    | Volume.AzureFileShare (shareName, storageAccountName) -> Some (shareName, storageAccountName)
-                    | _ -> None)
-            for shareName, storageAccountName in fileShares do
+        |> Option.map (fun networkProfile -> ArmExpression.resourceId(networkProfiles, networkProfile).Eval())
+    member private this.Dependencies = [
+        match this.NetworkProfilePath with
+        | Some path -> ResourceName path
+        | None -> ()
+
+        for _, volume in this.Volumes |> Map.toSeq do
+            match volume with
+            | Volume.AzureFileShare (shareName, storageAccountName) ->
                 let fullShareName = [ storageAccountName; "default"; shareName ] |> Seq.map ResourceName |> Array.ofSeq
-                yield ArmExpression.resourceId(Storage.fileShares, fullShareName).Eval()
-        }
+                ArmExpression.resourceId(fileShares, fullShareName).Eval() |> ResourceName
+            | _ ->
+                ()
+    ]
 
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = containerGroups.Path
-               apiVersion = containerGroups.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               dependsOn = this.dependencies
-               properties =
-                   {| containers =
-                       this.ContainerInstances
-                       |> List.map (fun container ->
-                           {| name = container.Name.Value.ToLowerInvariant ()
-                              properties =
-                               {| image = container.Image
-                                  ports = container.Ports |> Set.map (fun port -> {| port = port |})
-                                  environmentVariables =
-                                      container.EnvironmentVariables
-                                      |> Seq.map (fun kvp ->
-                                          if kvp.Value.Secure then
-                                              {| name = kvp.Key; value=null; secureValue=kvp.Value.Value |}
-                                          else
-                                              {| name = kvp.Key; value=kvp.Value.Value; secureValue=null |})
-                                  resources =
-                                   {| requests =
-                                       {| cpu = container.Cpu
-                                          memoryInGB = container.Memory |}
+            {| containerGroups.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
+                   properties =
+                       {| containers =
+                           this.ContainerInstances
+                           |> List.map (fun container ->
+                               {| name = container.Name.Value.ToLowerInvariant ()
+                                  properties =
+                                   {| image = container.Image
+                                      ports = container.Ports |> Set.map (fun port -> {| port = port |})
+                                      environmentVariables = [
+                                          for (key, value) in Map.toSeq container.EnvironmentVariables do
+                                              if value.Secure then {| name = key; value = null; secureValue = value.Value |}
+                                              else {| name = key; value = value.Value; secureValue = null |}
+                                      ]
+                                      resources =
+                                       {| requests =
+                                           {| cpu = container.Cpu
+                                              memoryInGB = container.Memory |}
+                                       |}
+                                      volumeMounts = container.VolumeMounts |> Seq.map (fun kvp -> {| name=kvp.Key; mountPath=kvp.Value |}) |> List.ofSeq
                                    |}
-                                  volumeMounts = container.VolumeMounts |> Seq.map (fun kvp -> {| name=kvp.Key; mountPath=kvp.Value |}) |> List.ofSeq
-                               |}
-                           |})
-                      osType = string this.OperatingSystem
-                      restartPolicy =
-                        match this.RestartPolicy with
-                        | AlwaysRestart -> "Always"
-                        | NeverRestart -> "Never"
-                        | RestartOnFailure -> "OnFailure"
-                      ipAddress =
-                        {| ``type`` =
-                            match this.IpAddress.Type with
-                            | PublicAddress | PublicAddressWithDns _ -> "Public"
-                            | PrivateAddress _ -> "Private"
-                           ports = [
-                               for port in this.IpAddress.Ports do
-                                {| protocol = string port.Protocol
-                                   port = port.Port |}
-                           ]
-                           dnsNameLabel =
-                            match this.IpAddress.Type with
-                            | PublicAddressWithDns dnsLabel -> dnsLabel
-                            | _ -> null
-                        |}
-                      networkProfile =
-                        this.NetworkProfilePath
-                        |> Option.map(fun path -> box {| id = path |})
-                        |> Option.toObj
-                      volumes = this.Volumes |> Seq.map (fun volume ->
-                          match volume.Key, volume.Value.Volume with
-                          |  volumeName, Volume.AzureFileShare (shareName, accountName) ->
-                              {| name = volumeName
-                                 azureFile =
-                                     {| shareName = shareName
-                                        storageAccountName = accountName
-                                        storageAccountKey = sprintf "[listKeys('Microsoft.Storage/storageAccounts/%s', '2018-07-01').keys[0].value]" accountName |}
-                                 emptyDir = null
-                                 gitRepo = Unchecked.defaultof<_>
-                                 secret = Unchecked.defaultof<_> |}
-                          |  volumeName, Volume.EmptyDirectory ->
-                              {| name = volumeName
-                                 azureFile = Unchecked.defaultof<_>
-                                 emptyDir = obj()
-                                 gitRepo = Unchecked.defaultof<_>
-                                 secret = Unchecked.defaultof<_> |}
-                          |  volumeName, Volume.GitRepo (repository, directory, revision) ->
-                              {| name = volumeName
-                                 azureFile = Unchecked.defaultof<_>
-                                 emptyDir = null
-                                 gitRepo = {| repository = repository
-                                              directory = directory |> Option.toObj
-                                              revision = revision |> Option.toObj |}
-                                 secret = Unchecked.defaultof<_> |}
-                          |  volumeName, Volume.Secret secrets->
-                              {| name = volumeName
-                                 azureFile = Unchecked.defaultof<_>
-                                 emptyDir = null
-                                 gitRepo = Unchecked.defaultof<_>
-                                 secret =
-                                     let jobj = JObject()
-                                     for (SecretFile (name, secret)) in secrets do
-                                         jobj.Add (name, secret |> System.Convert.ToBase64String |> JValue)
-                                     jobj
-                                 |}
-                      )
-                   |}
-               tags = this.Tags
+                               |})
+                          osType = string this.OperatingSystem
+                          restartPolicy =
+                            match this.RestartPolicy with
+                            | AlwaysRestart -> "Always"
+                            | NeverRestart -> "Never"
+                            | RestartOnFailure -> "OnFailure"
+                          ipAddress =
+                            {| ``type`` =
+                                match this.IpAddress.Type with
+                                | PublicAddress | PublicAddressWithDns _ -> "Public"
+                                | PrivateAddress _ -> "Private"
+                               ports = [
+                                   for port in this.IpAddress.Ports do
+                                    {| protocol = string port.Protocol
+                                       port = port.Port |}
+                               ]
+                               dnsNameLabel =
+                                match this.IpAddress.Type with
+                                | PublicAddressWithDns dnsLabel -> dnsLabel
+                                | _ -> null
+                            |}
+                          networkProfile =
+                            this.NetworkProfilePath
+                            |> Option.map(fun path -> box {| id = path |})
+                            |> Option.toObj
+                          volumes = [
+                            for (key, value) in Map.toSeq this.Volumes do
+                                match key, value with
+                                |  volumeName, Volume.AzureFileShare (shareName, accountName) ->
+                                    {| name = volumeName
+                                       azureFile =
+                                           {| shareName = shareName
+                                              storageAccountName = accountName
+                                              storageAccountKey = sprintf "[listKeys('Microsoft.Storage/storageAccounts/%s', '2018-07-01').keys[0].value]" accountName |}
+                                       emptyDir = null
+                                       gitRepo = Unchecked.defaultof<_>
+                                       secret = Unchecked.defaultof<_> |}
+                                |  volumeName, Volume.EmptyDirectory ->
+                                    {| name = volumeName
+                                       azureFile = Unchecked.defaultof<_>
+                                       emptyDir = obj()
+                                       gitRepo = Unchecked.defaultof<_>
+                                       secret = Unchecked.defaultof<_> |}
+                                |  volumeName, Volume.GitRepo (repository, directory, revision) ->
+                                    {| name = volumeName
+                                       azureFile = Unchecked.defaultof<_>
+                                       emptyDir = null
+                                       gitRepo = {| repository = repository
+                                                    directory = directory |> Option.toObj
+                                                    revision = revision |> Option.toObj |}
+                                       secret = Unchecked.defaultof<_> |}
+                                |  volumeName, Volume.Secret secrets->
+                                    {| name = volumeName
+                                       azureFile = Unchecked.defaultof<_>
+                                       emptyDir = null
+                                       gitRepo = Unchecked.defaultof<_>
+                                       secret =
+                                           let jobj = JObject()
+                                           for (SecretFile (name, secret)) in secrets do
+                                               jobj.Add (name, secret |> System.Convert.ToBase64String |> JValue)
+                                           jobj
+                                       |}
+                          ]
+                       |}
             |} :> _

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -6,7 +6,7 @@ open Farmer.ContainerGroup
 open Farmer.CoreTypes
 open Newtonsoft.Json.Linq
 
-let containerGroups = ResourceType "Microsoft.ContainerInstance/containerGroups"
+let containerGroups = ResourceType ("Microsoft.ContainerInstance/containerGroups", "2018-10-01")
 
 type ContainerGroupIpAddress =
     { Type : IpAddressType
@@ -52,8 +52,8 @@ type ContainerGroup =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = containerGroups.ArmValue
-               apiVersion = "2018-10-01"
+            {| ``type`` = containerGroups.Path
+               apiVersion = containerGroups.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                dependsOn = this.dependencies

--- a/src/Farmer/Arm/ContainerRegistry.fs
+++ b/src/Farmer/Arm/ContainerRegistry.fs
@@ -16,11 +16,7 @@ type Registries =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| name = this.Name.Value
-               ``type`` = registries.Path
-               apiVersion = registries.Version
-               sku = {| name = this.Sku.ToString() |}
-               location = this.Location.ArmValue
-               tags = this.Tags
-               properties = {| adminUserEnabled = this.AdminUserEnabled |}
+            {| registries.Create(this.Name, this.Location, tags = this.Tags) with
+                 sku = {| name = this.Sku.ToString() |}
+                 properties = {| adminUserEnabled = this.AdminUserEnabled |}
             |} :> _

--- a/src/Farmer/Arm/ContainerRegistry.fs
+++ b/src/Farmer/Arm/ContainerRegistry.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.ContainerRegistry
 open Farmer.CoreTypes
 
-let registries = ResourceType "Microsoft.ContainerRegistry/registries"
+let registries = ResourceType ("Microsoft.ContainerRegistry/registries", "2019-05-01")
 
 type Registries =
     { Name : ResourceName
@@ -17,8 +17,8 @@ type Registries =
         member this.ResourceName = this.Name
         member this.JsonModel =
             {| name = this.Name.Value
-               ``type`` = registries.ArmValue
-               apiVersion = "2019-05-01"
+               ``type`` = registries.Path
+               apiVersion = registries.Version
                sku = {| name = this.Sku.ToString() |}
                location = this.Location.ArmValue
                tags = this.Tags

--- a/src/Farmer/Arm/ContainerService.fs
+++ b/src/Farmer/Arm/ContainerService.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.Vm
 
-let managedClusters = ResourceType "Microsoft.ContainerService/managedClusters"
+let managedClusters = ResourceType ("Microsoft.ContainerService/managedClusters", "2020-04-01")
 
 type AgentPoolMode = System | User
 
@@ -40,7 +40,7 @@ type ManagedCluster =
         {| ClientId : string
            ClientSecret : SecureParameter |} option
     }
-    
+
     interface IParameters with
         member this.SecureParameters =
             [
@@ -56,8 +56,8 @@ type ManagedCluster =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = managedClusters.ArmValue
-               apiVersion = "2020-04-01"
+            {| ``type`` = managedClusters.Path
+               apiVersion = managedClusters.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                dependsOn =
@@ -69,7 +69,7 @@ type ManagedCluster =
                    {| agentPoolProfiles =
                        this.AgentPoolProfiles
                        |> List.mapi (fun idx agent ->
-                           {| name = if agent.Name = ResourceName.Empty then (sprintf "%s-agent-pool%i" this.Name.Value idx) 
+                           {| name = if agent.Name = ResourceName.Empty then (sprintf "%s-agent-pool%i" this.Name.Value idx)
                                      else agent.Name.Value.ToLowerInvariant ()
                               count = agent.Count
                               maxPods = agent.MaxPods |> Option.toNullable

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -30,11 +30,8 @@ module Servers =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {|  ``type`` = databases.Path
-                    apiVersion = databases.Version
-                    name = this.Server.Value + "/" + this.Name.Value
-                    dependsOn = [ this.Server.Value ]
-                    properties = {|  charset = this.Charset; collation = this.Collation |}
+                {|  databases.Create(this.Server + this.Name, dependsOn = [ this.Server ]) with
+                        properties = {|  charset = this.Charset; collation = this.Collation |}
                 |} :> _
 
     type FirewallRule =
@@ -46,12 +43,8 @@ module Servers =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {|  ``type`` = firewallRules.Path
-                    apiVersion = firewallRules.Version
-                    name = this.Server.Value + "/" + this.Name.Value
-                    location = this.Location.ArmValue
+                {| firewallRules.Create(this.Server + this.Name, this.Location, [ this.Server ]) with
                     properties = {| startIpAddress = string this.Start; endIpAddress = string this.End; |}
-                    dependsOn = [ this.Server.Value ]
                 |} :> _
 
 type Server =
@@ -101,12 +94,7 @@ type Server =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {|
-                ``type`` = servers.Path
-                apiVersion = servers.Version
-                name = this.Name.Value
-                location = this.Location.ArmValue
-                tags = this.Tags |> Map.add "displayName" this.Name.Value
-                sku = this.Sku
-                properties = this.GetProperties()
+            {| servers.Create(this.Name, this.Location, tags = (this.Tags |> Map.add "displayName" this.Name.Value)) with
+                    sku = this.Sku
+                    properties = this.GetProperties()
             |} :> _

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -6,17 +6,16 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.PostgreSQL
 
-let databases = ResourceType "Microsoft.DBforPostgreSQL/servers/databases"
-let firewallRules = ResourceType "Microsoft.DBforPostgreSQL/servers/firewallrules"
-let servers = ResourceType "Microsoft.DBforPostgreSQL/servers"
+let databases = ResourceType ("Microsoft.DBforPostgreSQL/servers/databases", "2017-12-01")
+let firewallRules = ResourceType ("Microsoft.DBforPostgreSQL/servers/firewallrules",  "2017-12-01")
+let servers = ResourceType ("Microsoft.DBforPostgreSQL/servers", "2017-12-01")
 
-type [<RequireQualifiedAccess>] PostgreSQLFamily = 
-| Gen5
-
+[<RequireQualifiedAccess>]
+type PostgreSQLFamily =
+    | Gen5
     override this.ToString() =
         match this with
         | Gen5 -> "Gen5"
-
     member this.AsArmValue =
         match this with
         | Gen5 -> "Gen5"
@@ -31,9 +30,9 @@ module Servers =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {|  ``type`` = databases.ArmValue
+                {|  ``type`` = databases.Path
+                    apiVersion = databases.Version
                     name = this.Server.Value + "/" + this.Name.Value
-                    apiVersion = "2017-12-01"
                     dependsOn = [ this.Server.Value ]
                     properties = {|  charset = this.Charset; collation = this.Collation |}
                 |} :> _
@@ -47,9 +46,9 @@ module Servers =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {|  ``type`` = firewallRules.ArmValue
+                {|  ``type`` = firewallRules.Path
+                    apiVersion = firewallRules.Version
                     name = this.Server.Value + "/" + this.Name.Value
-                    apiVersion = "2017-12-01"
                     location = this.Location.ArmValue
                     properties = {| startIpAddress = string this.Start; endIpAddress = string this.End; |}
                     dependsOn = [ this.Server.Value ]
@@ -68,7 +67,7 @@ type Server =
       StorageAutoGrow : FeatureFlag
       BackupRetention : int<Days>
       Tags: Map<string,string>  }
-       
+
     member this.Sku =
         {| name = sprintf "%s_%s_%d" this.Tier.Name this.Family.AsArmValue this.Capacity
            tier = string this.Tier
@@ -103,8 +102,8 @@ type Server =
         member this.ResourceName = this.Name
         member this.JsonModel =
             {|
-                ``type`` = servers.ArmValue
-                apiVersion = "2017-12-01"
+                ``type`` = servers.Path
+                apiVersion = servers.Version
                 name = this.Name.Value
                 location = this.Location.ArmValue
                 tags = this.Tags |> Map.add "displayName" this.Name.Value

--- a/src/Farmer/Arm/DataLakeStore.fs
+++ b/src/Farmer/Arm/DataLakeStore.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.DataLake
 
-let accounts = ResourceType "Microsoft.DataLakeStore/accounts"
+let accounts = ResourceType ("Microsoft.DataLakeStore/accounts", "2016-11-01")
 
 type Account =
     { Name : ResourceName
@@ -17,8 +17,8 @@ type Account =
         member this.ResourceName = this.Name
         member this.JsonModel =
             {| name = this.Name.Value
-               ``type`` = accounts.ArmValue
-               apiVersion = "2016-11-01"
+               ``type`` = accounts.Path
+               apiVersion = accounts.Version
                location = this.Location.ArmValue
                properties =
                 {| newTier = this.Sku.ToString()

--- a/src/Farmer/Arm/DataLakeStore.fs
+++ b/src/Farmer/Arm/DataLakeStore.fs
@@ -16,12 +16,8 @@ type Account =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| name = this.Name.Value
-               ``type`` = accounts.Path
-               apiVersion = accounts.Version
-               location = this.Location.ArmValue
-               properties =
-                {| newTier = this.Sku.ToString()
-                   encryptionState = this.EncryptionState.ToString() |}
-               tags = this.Tags
+            {| accounts.Create(this.Name, this.Location, tags = this.Tags) with
+                 properties =
+                  {| newTier = this.Sku.ToString()
+                     encryptionState = this.EncryptionState.ToString() |}
             |} :> _

--- a/src/Farmer/Arm/Devices.fs
+++ b/src/Farmer/Arm/Devices.fs
@@ -4,8 +4,8 @@ module Farmer.Arm.Devices
 open Farmer
 open Farmer.CoreTypes
 
-let iotHubs = ResourceType "Microsoft.Devices/IotHubs"
-let provisioningServices = ResourceType "Microsoft.Devices/provisioningServices"
+let iotHubs = ResourceType ("Microsoft.Devices/IotHubs", "2019-03-22")
+let provisioningServices = ResourceType ("Microsoft.Devices/provisioningServices",  "2018-01-22")
 
 type Sku =
 | Free
@@ -48,8 +48,8 @@ type iotHubs =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = iotHubs.ArmValue
-               apiVersion = "2019-03-22"
+            {| ``type`` = iotHubs.Path
+               apiVersion = iotHubs.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                properties =
@@ -99,12 +99,12 @@ type ProvisioningServices =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = provisioningServices.ArmValue
+            {| ``type`` = provisioningServices.Path
+               apiVersion = provisioningServices.Version
                sku =
                  {| name = "S1"
                     capacity = 1 |}
                name = this.Name.Value
-               apiVersion = "2018-01-22"
                location = this.Location.ArmValue
                properties =
                  {| iotHubs = [

--- a/src/Farmer/Arm/Devices.fs
+++ b/src/Farmer/Arm/Devices.fs
@@ -48,39 +48,35 @@ type iotHubs =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = iotHubs.Path
-               apiVersion = iotHubs.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               properties =
-                {| eventHubEndpoints =
-                    match this.RetentionDays, this.PartitionCount with
-                    | None, None ->
-                        null
-                    | _ ->
-                        box
-                            {| events =
-                                {| retentionTimeInDays = this.RetentionDays |> Option.toNullable
-                                   partitionCount = this.PartitionCount |> Option.toNullable |}
-                            |}
-                   cloudToDevice =
-                    match this with
-                    | { DefaultTtl = None; MaxDeliveryCount = None; Feedback = None } ->
-                        null
-                    | _ ->
-                        box
-                            {| defaultTtlAsIso8601 = this.DefaultTtl |> Option.map(fun v -> v.Value) |> Option.toObj
-                               maxDeliveryCount = this.MaxDeliveryCount |> Option.toNullable
-                               feedback = this.Feedback |> Option.map (serialize >> box) |> Option.toObj |}
-                   messagingEndpoints =
-                    this.FileNotifications
-                    |> Option.map(fun fileNotifications -> box {| fileNotifications = fileNotifications |> serialize |})
-                    |> Option.toObj
-                |}
-               sku =
-                {| name = this.Sku.Name
-                   capacity = this.Sku.Capacity |}
-               tags = this.Tags
+            {| iotHubs.Create(this.Name, this.Location, tags = this.Tags) with
+                   properties =
+                    {| eventHubEndpoints =
+                        match this.RetentionDays, this.PartitionCount with
+                        | None, None ->
+                            null
+                        | _ ->
+                            box
+                                {| events =
+                                    {| retentionTimeInDays = this.RetentionDays |> Option.toNullable
+                                       partitionCount = this.PartitionCount |> Option.toNullable |}
+                                |}
+                       cloudToDevice =
+                        match this with
+                        | { DefaultTtl = None; MaxDeliveryCount = None; Feedback = None } ->
+                            null
+                        | _ ->
+                            box
+                                {| defaultTtlAsIso8601 = this.DefaultTtl |> Option.map(fun v -> v.Value) |> Option.toObj
+                                   maxDeliveryCount = this.MaxDeliveryCount |> Option.toNullable
+                                   feedback = this.Feedback |> Option.map (serialize >> box) |> Option.toObj |}
+                       messagingEndpoints =
+                        this.FileNotifications
+                        |> Option.map(fun fileNotifications -> box {| fileNotifications = fileNotifications |> serialize |})
+                        |> Option.toObj
+                    |}
+                   sku =
+                    {| name = this.Sku.Name
+                       capacity = this.Sku.Capacity |}
             |} :> _
 
 type ProvisioningServices =
@@ -99,20 +95,15 @@ type ProvisioningServices =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = provisioningServices.Path
-               apiVersion = provisioningServices.Version
-               sku =
-                 {| name = "S1"
-                    capacity = 1 |}
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               properties =
-                 {| iotHubs = [
-                       {| connectionString = this.IotHubConnection.Eval()
-                          location = this.Location.ArmValue
-                          name = this.IotHubPath |}
-                   ]
-                 |}
-               dependsOn = [ this.IotHubName.Value ]
-               tags = this.Tags
+            {| provisioningServices.Create(this.Name, this.Location, [ this.IotHubName ], this.Tags) with
+                   sku =
+                     {| name = "S1"
+                        capacity = 1 |}
+                   properties =
+                     {| iotHubs = [
+                           {| connectionString = this.IotHubConnection.Eval()
+                              location = this.Location.ArmValue
+                              name = this.IotHubPath |}
+                       ]
+                     |}
             |} :> _

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -5,9 +5,9 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.CosmosDb
 
-let containers = ResourceType "Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers"
-let sqlDatabases = ResourceType "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
-let databaseAccounts = ResourceType "Microsoft.DocumentDB/databaseAccounts"
+let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2020-03-01")
+let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2020-03-01")
+let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2020-03-01")
 
 module DatabaseAccounts =
     module SqlDatabases =
@@ -30,9 +30,9 @@ module DatabaseAccounts =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                    {| ``type`` = containers.ArmValue
+                    {| ``type`` = containers.Path
+                       apiVersion = containers.Version
                        name = sprintf "%s/%s/%s" this.Account.Value this.Database.Value this.Name.Value
-                       apiVersion = "2020-03-01"
                        dependsOn = [ this.Database.Value ]
                        properties =
                            {| resource =
@@ -72,9 +72,9 @@ module DatabaseAccounts =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = sqlDatabases.ArmValue
+                {| ``type`` = sqlDatabases.Path
+                   apiVersion = sqlDatabases.Version
                    name = sprintf "%s/%s" this.Account.Value this.Name.Value
-                   apiVersion = "2020-03-01"
                    dependsOn = [ this.Account.Value ]
                    properties =
                        {| resource = {| id = this.Name.Value |}
@@ -118,9 +118,9 @@ type DatabaseAccount =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = databaseAccounts.ArmValue
+            {| ``type`` = databaseAccounts.Path
+               apiVersion = databaseAccounts.Version
                name = this.Name.Value
-               apiVersion = "2020-03-01"
                location = this.Location.ArmValue
                kind = "GlobalDocumentDB"
                properties =

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -30,39 +30,37 @@ module DatabaseAccounts =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                    {| ``type`` = containers.Path
-                       apiVersion = containers.Version
-                       name = sprintf "%s/%s/%s" this.Account.Value this.Database.Value this.Name.Value
-                       dependsOn = [ this.Database.Value ]
-                       properties =
-                           {| resource =
-                               {| id = this.Name.Value
-                                  partitionKey =
-                                   {| paths = this.PartitionKey.Paths
-                                      kind = string this.PartitionKey.Kind |}
-                                  uniqueKeyPolicy =
-                                   {| uniqueKeys =
-                                      this.UniqueKeyPolicy.UniqueKeys
-                                      |> Set.map (fun k -> {| paths = k.Paths |}) |}
-                                  indexingPolicy =
-                                   {| indexingMode = "consistent"
-                                      includedPaths =
-                                          this.IndexingPolicy.IncludedPaths
-                                          |> List.map(fun p ->
-                                           {| path = p.Path
-                                              indexes =
-                                               p.Indexes
-                                               |> List.map(fun (dataType, kind) ->
-                                                   {| kind = string kind
-                                                      dataType = dataType.ToString().ToLower()
-                                                      precision = -1 |})
-                                           |})
-                                      excludedPaths =
-                                       this.IndexingPolicy.ExcludedPaths
-                                       |> List.map(fun p -> {| path = p |})
+                    {| containers.Create(this.Account + this.Database + this.Name, dependsOn = [ this.Database ])
+                        with
+                           properties =
+                               {| resource =
+                                   {| id = this.Name.Value
+                                      partitionKey =
+                                       {| paths = this.PartitionKey.Paths
+                                          kind = string this.PartitionKey.Kind |}
+                                      uniqueKeyPolicy =
+                                       {| uniqueKeys =
+                                          this.UniqueKeyPolicy.UniqueKeys
+                                          |> Set.map (fun k -> {| paths = k.Paths |}) |}
+                                      indexingPolicy =
+                                       {| indexingMode = "consistent"
+                                          includedPaths =
+                                              this.IndexingPolicy.IncludedPaths
+                                              |> List.map(fun p ->
+                                               {| path = p.Path
+                                                  indexes =
+                                                   p.Indexes
+                                                   |> List.map(fun (dataType, kind) ->
+                                                       {| kind = string kind
+                                                          dataType = dataType.ToString().ToLower()
+                                                          precision = -1 |})
+                                               |})
+                                          excludedPaths =
+                                           this.IndexingPolicy.ExcludedPaths
+                                           |> List.map(fun p -> {| path = p |})
+                                       |}
                                    |}
                                |}
-                           |}
                     |} :> _
 
     type SqlDatabase =
@@ -72,13 +70,10 @@ module DatabaseAccounts =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = sqlDatabases.Path
-                   apiVersion = sqlDatabases.Version
-                   name = sprintf "%s/%s" this.Account.Value this.Name.Value
-                   dependsOn = [ this.Account.Value ]
-                   properties =
-                       {| resource = {| id = this.Name.Value |}
-                          options = {| throughput = string this.Throughput |} |}
+                {| sqlDatabases.Create(this.Account + this.Name, dependsOn = [ this.Account ]) with
+                       properties =
+                           {| resource = {| id = this.Name.Value |}
+                              options = {| throughput = string this.Throughput |} |}
                 |} :> _
 
 type DatabaseAccount =
@@ -118,29 +113,25 @@ type DatabaseAccount =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = databaseAccounts.Path
-               apiVersion = databaseAccounts.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               kind = "GlobalDocumentDB"
-               properties =
-                   {| consistencyPolicy =
-                        {| defaultConsistencyLevel =
-                            match this.ConsistencyPolicy with
-                            | BoundedStaleness _ -> "BoundedStaleness"
-                            | Session | Eventual | ConsistentPrefix | Strong as policy -> string policy
-                           maxStalenessPrefix = this.MaxStatelessPrefix |> Option.toNullable
-                           maxIntervalInSeconds = this.MaxInterval |> Option.toNullable
-                        |}
-                      databaseAccountOfferType = "Standard"
-                      enableAutomaticFailover = this.EnableAutomaticFailover |> Option.toNullable
-                      autoenableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
-                      locations =
-                        match this.FailoverLocations with
-                        | [] -> null
-                        | locations -> box locations
-                      publicNetworkAccess = string this.PublicNetworkAccess
-                      enableFreeTier = this.FreeTier
-                   |} |> box
-               tags = this.Tags
+            {| databaseAccounts.Create(this.Name, this.Location, tags = this.Tags) with
+                   kind = "GlobalDocumentDB"
+                   properties =
+                       {| consistencyPolicy =
+                            {| defaultConsistencyLevel =
+                                match this.ConsistencyPolicy with
+                                | BoundedStaleness _ -> "BoundedStaleness"
+                                | Session | Eventual | ConsistentPrefix | Strong as policy -> string policy
+                               maxStalenessPrefix = this.MaxStatelessPrefix |> Option.toNullable
+                               maxIntervalInSeconds = this.MaxInterval |> Option.toNullable
+                            |}
+                          databaseAccountOfferType = "Standard"
+                          enableAutomaticFailover = this.EnableAutomaticFailover |> Option.toNullable
+                          autoenableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
+                          locations =
+                            match this.FailoverLocations with
+                            | [] -> null
+                            | locations -> box locations
+                          publicNetworkAccess = string this.PublicNetworkAccess
+                          enableFreeTier = this.FreeTier
+                       |} |> box
             |} :> _

--- a/src/Farmer/Arm/EventGrid.fs
+++ b/src/Farmer/Arm/EventGrid.fs
@@ -5,8 +5,8 @@ open Farmer
 open Farmer.EventGrid
 open Farmer.CoreTypes
 
-let systemTopics = ResourceType "Microsoft.EventGrid/systemTopics"
-let eventSubscriptions = ResourceType "Microsoft.EventGrid/systemTopics/eventSubscriptions"
+let systemTopics = ResourceType ("Microsoft.EventGrid/systemTopics", "2020-04-01-preview")
+let eventSubscriptions = ResourceType ("Microsoft.EventGrid/systemTopics/eventSubscriptions", "2020-04-01-preview")
 
 type TopicType =
     | TopicType of ResourceType * topic:string
@@ -39,8 +39,8 @@ type Topic =
         member this.ResourceName = this.Name
         member this.JsonModel =
             {| name = this.Name.Value
-               ``type`` = systemTopics.ArmValue
-               apiVersion = "2020-04-01-preview"
+               ``type`` = systemTopics.Path
+               apiVersion = systemTopics.Version
                location = this.Location.ArmValue
                dependsOn = [ this.Source.Value ]
                properties =
@@ -58,8 +58,8 @@ type Subscription =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = eventSubscriptions.ArmValue
-               apiVersion = "2020-04-01-preview"
+            {| ``type`` = eventSubscriptions.Path
+               apiVersion = eventSubscriptions.Version
                name = this.Topic.Value + "/" + this.Name.Value
                dependsOn = [ this.Topic.Value; this.Destination.Value ]
                properties =

--- a/src/Farmer/Arm/EventHub.fs
+++ b/src/Farmer/Arm/EventHub.fs
@@ -5,10 +5,10 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.EventHub
 
-let namespaces = ResourceType "Microsoft.EventHub/namespaces"
-let eventHubs = ResourceType "Microsoft.EventHub/namespaces/eventhubs"
-let consumerGroups = ResourceType "Microsoft.EventHub/namespaces/eventhubs/consumergroups"
-let authorizationRules = ResourceType "Microsoft.EventHub/namespaces/eventhubs/AuthorizationRules"
+let namespaces = ResourceType ("Microsoft.EventHub/namespaces", "2017-04-01")
+let eventHubs = ResourceType ("Microsoft.EventHub/namespaces/eventhubs", "2017-04-01")
+let consumerGroups = ResourceType ("Microsoft.EventHub/namespaces/eventhubs/consumergroups", "2017-04-01")
+let authorizationRules = ResourceType ("Microsoft.EventHub/namespaces/eventhubs/AuthorizationRules", "2017-04-01")
 
 type CaptureDestination =
     | StorageAccount of ResourceName * containerName:string
@@ -29,8 +29,8 @@ type Namespace =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = namespaces.ArmValue
-               apiVersion = "2017-04-01"
+            {| ``type`` = namespaces.Path
+               apiVersion = namespaces.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                sku =
@@ -61,8 +61,8 @@ module Namespaces =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-               {| ``type`` = eventHubs.ArmValue
-                  apiVersion = "2017-04-01"
+               {| ``type`` = eventHubs.Path
+                  apiVersion = eventHubs.Version
                   name = this.Name.Value
                   location = this.Location.ArmValue
                   dependsOn = this.Dependencies |> List.map(fun d -> d.Value)
@@ -96,8 +96,8 @@ module Namespaces =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                    {| ``type`` = consumerGroups.ArmValue
-                       apiVersion = "2017-04-01"
+                    {| ``type`` = consumerGroups.Path
+                       apiVersion = consumerGroups.Version
                        name = this.Name.Value
                        location = this.Location.ArmValue
                        dependsOn = this.Dependencies |> List.map(fun d -> d.Value)
@@ -111,8 +111,8 @@ module Namespaces =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                    {| ``type`` = authorizationRules.ArmValue
-                       apiVersion = "2017-04-01"
+                    {| ``type`` = authorizationRules.Path
+                       apiVersion = authorizationRules.Version
                        name = this.Name.Value
                        location = this.Location.ArmValue
                        dependsOn = this.Dependencies |> List.map(fun d -> d.Value)

--- a/src/Farmer/Arm/EventHub.fs
+++ b/src/Farmer/Arm/EventHub.fs
@@ -29,25 +29,21 @@ type Namespace =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = namespaces.Path
-               apiVersion = namespaces.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               sku =
-                    {| name = string this.Sku.Name
-                       tier = string this.Sku.Name
-                       capacity = this.Sku.Capacity |}
-               properties =
-                    {| zoneRedundant = this.ZoneRedundant |> Option.toNullable
-                       isAutoInflateEnabled =
-                        this.AutoInflateSettings
-                        |> Option.map (function
-                            | AutoInflate _ -> true
-                            | ManualInflate -> false)
-                        |> Option.toNullable
-                       maximumThroughputUnits = this.MaxThroughputUnits |> Option.toNullable
-                       kafkaEnabled = this.KafkaEnabled |> Option.toNullable |}
-               tags = this.Tags
+            {| namespaces.Create(this.Name, this.Location, tags = this.Tags) with
+                   sku =
+                        {| name = string this.Sku.Name
+                           tier = string this.Sku.Name
+                           capacity = this.Sku.Capacity |}
+                   properties =
+                        {| zoneRedundant = this.ZoneRedundant |> Option.toNullable
+                           isAutoInflateEnabled =
+                            this.AutoInflateSettings
+                            |> Option.map (function
+                                | AutoInflate _ -> true
+                                | ManualInflate -> false)
+                            |> Option.toNullable
+                           maximumThroughputUnits = this.MaxThroughputUnits |> Option.toNullable
+                           kafkaEnabled = this.KafkaEnabled |> Option.toNullable |}
             |} :> _
 module Namespaces =
     type EventHub =
@@ -61,47 +57,37 @@ module Namespaces =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-               {| ``type`` = eventHubs.Path
-                  apiVersion = eventHubs.Version
-                  name = this.Name.Value
-                  location = this.Location.ArmValue
-                  dependsOn = this.Dependencies |> List.map(fun d -> d.Value)
-                  properties =
-                    {| messageRetentionInDays = this.MessageRetentionDays |> Option.toNullable
-                       partitionCount = this.Partitions
-                       status = "Active"
-                       captureDescription =
-                        match this.CaptureDestination with
-                        | Some (StorageAccount(name, container)) ->
-                            {| enabled = true
-                               encoding = "Avro"
-                               destination =
-                                {| name = "EventHubArchive.AzureBlockBlob"
-                                   properties =
-                                    {| storageAccountResourceId = ArmExpression.resourceId(storageAccounts, name).Eval()
-                                       blobContainer = container
+               {| eventHubs.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
+                      properties =
+                        {| messageRetentionInDays = this.MessageRetentionDays |> Option.toNullable
+                           partitionCount = this.Partitions
+                           status = "Active"
+                           captureDescription =
+                            match this.CaptureDestination with
+                            | Some (StorageAccount(name, container)) ->
+                                {| enabled = true
+                                   encoding = "Avro"
+                                   destination =
+                                    {| name = "EventHubArchive.AzureBlockBlob"
+                                       properties =
+                                        {| storageAccountResourceId = ArmExpression.resourceId(storageAccounts, name).Eval()
+                                           blobContainer = container
+                                        |}
                                     |}
-                                |}
-                            |} |> box
-                        | None ->
-                            null
-                    |}
-                  tags = this.Tags
+                                |} |> box
+                            | None ->
+                                null
+                        |}
                |} :> _
     module EventHubs =
         type ConsumerGroup =
-            { Name : ResourceName
+            { ConsumerGroupName : ResourceName
+              EventHub : ResourceName
               Location : Location
               Dependencies : ResourceName list }
             interface IArmResource with
-                member this.ResourceName = this.Name
-                member this.JsonModel =
-                    {| ``type`` = consumerGroups.Path
-                       apiVersion = consumerGroups.Version
-                       name = this.Name.Value
-                       location = this.Location.ArmValue
-                       dependsOn = this.Dependencies |> List.map(fun d -> d.Value)
-                    |} :> _
+                member this.ResourceName = this.ConsumerGroupName
+                member this.JsonModel = consumerGroups.Create(this.EventHub + this.ConsumerGroupName, this.Location, this.Dependencies) :> _
 
         type AuthorizationRule =
             { Name : ResourceName
@@ -111,10 +97,6 @@ module Namespaces =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                    {| ``type`` = authorizationRules.Path
-                       apiVersion = authorizationRules.Version
-                       name = this.Name.Value
-                       location = this.Location.ArmValue
-                       dependsOn = this.Dependencies |> List.map(fun d -> d.Value)
-                       properties = {| rights = this.Rights |> Set.map string |> Set.toList |}
+                    {| authorizationRules.Create(this.Name, this.Location, this.Dependencies) with
+                        properties = {| rights = this.Rights |> Set.map string |> Set.toList |}
                     |} :> _

--- a/src/Farmer/Arm/EventHub.fs
+++ b/src/Farmer/Arm/EventHub.fs
@@ -30,20 +30,20 @@ type Namespace =
         member this.ResourceName = this.Name
         member this.JsonModel =
             {| namespaces.Create(this.Name, this.Location, tags = this.Tags) with
-                   sku =
-                        {| name = string this.Sku.Name
-                           tier = string this.Sku.Name
-                           capacity = this.Sku.Capacity |}
-                   properties =
-                        {| zoneRedundant = this.ZoneRedundant |> Option.toNullable
-                           isAutoInflateEnabled =
-                            this.AutoInflateSettings
-                            |> Option.map (function
-                                | AutoInflate _ -> true
-                                | ManualInflate -> false)
-                            |> Option.toNullable
-                           maximumThroughputUnits = this.MaxThroughputUnits |> Option.toNullable
-                           kafkaEnabled = this.KafkaEnabled |> Option.toNullable |}
+                sku =
+                     {| name = string this.Sku.Name
+                        tier = string this.Sku.Name
+                        capacity = this.Sku.Capacity |}
+                properties =
+                     {| zoneRedundant = this.ZoneRedundant |> Option.toNullable
+                        isAutoInflateEnabled =
+                         this.AutoInflateSettings
+                         |> Option.map (function
+                             | AutoInflate _ -> true
+                             | ManualInflate -> false)
+                         |> Option.toNullable
+                        maximumThroughputUnits = this.MaxThroughputUnits |> Option.toNullable
+                        kafkaEnabled = this.KafkaEnabled |> Option.toNullable |}
             |} :> _
 module Namespaces =
     type EventHub =

--- a/src/Farmer/Arm/Insights.fs
+++ b/src/Farmer/Arm/Insights.fs
@@ -4,7 +4,7 @@ module Farmer.Arm.Insights
 open Farmer
 open Farmer.CoreTypes
 
-let components = ResourceType "Microsoft.Insights/components"
+let components = ResourceType("Microsoft.Insights/components", "2014-04-01")
 
 type Components =
     { Name : ResourceName
@@ -16,11 +16,11 @@ type Components =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = components.ArmValue
+            {| ``type`` = components.Path
                kind = "web"
                name = this.Name.Value
                location = this.Location.ArmValue
-               apiVersion = "2014-04-01"
+               apiVersion = components.Version
                tags =
                    [ match this.LinkedWebsite with
                      | Some linkedWebsite -> sprintf "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', '%s')]" linkedWebsite.Value, "Resource"

--- a/src/Farmer/Arm/Insights.fs
+++ b/src/Farmer/Arm/Insights.fs
@@ -16,23 +16,20 @@ type Components =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = components.Path
-               kind = "web"
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               apiVersion = components.Version
-               tags =
-                   [ match this.LinkedWebsite with
-                     | Some linkedWebsite -> sprintf "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', '%s')]" linkedWebsite.Value, "Resource"
-                     | None -> () ]
-                   |> List.fold (fun map (key,value) -> Map.add key value map ) this.Tags
-               properties =
-                {| name = this.Name.Value
-                   Application_Type = "web"
-                   ApplicationId =
-                     match this.LinkedWebsite with
-                     | Some linkedWebsite -> linkedWebsite.Value
-                     | None -> null
-                   DisableIpMasking = this.DisableIpMasking
-                   SamplingPercentage = this.SamplingPercentage |}
+            let tags =
+                match this.LinkedWebsite with
+                | Some linkedWebsite -> this.Tags.Add(sprintf "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', '%s')]" linkedWebsite.Value, "Resource")
+                | None -> this.Tags
+
+            {| components.Create(this.Name, this.Location, tags = tags) with
+                 kind = "web"
+                 properties =
+                  {| name = this.Name.Value
+                     Application_Type = "web"
+                     ApplicationId =
+                       match this.LinkedWebsite with
+                       | Some linkedWebsite -> linkedWebsite.Value
+                       | None -> null
+                     DisableIpMasking = this.DisableIpMasking
+                     SamplingPercentage = this.SamplingPercentage |}
             |} :> _

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -29,23 +29,17 @@ module Vaults =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = secrets.Path
-                   apiVersion = secrets.Version
-                   name = this.Name.Value
-                   location = this.Location.ArmValue
-                   dependsOn = [
-                       for dependency in this.Dependencies do
-                           dependency.Value ]
-                   properties =
-                       {| value = this.Value.Value
-                          contentType = this.ContentType |> Option.toObj
-                          attributes =
-                           {| enabled = this.Enabled |> Option.toNullable
-                              nbf = this.ActivationDate |> Option.map Secret.TotalSecondsSince1970 |> Option.toNullable
-                              exp = this.ExpirationDate |> Option.map Secret.TotalSecondsSince1970 |> Option.toNullable
-                           |}
-                       |}
-                   |} :> _
+                {| secrets.Create(this.Name, this.Location, this.Dependencies) with
+                    properties =
+                        {| value = this.Value.Value
+                           contentType = this.ContentType |> Option.toObj
+                           attributes =
+                            {| enabled = this.Enabled |> Option.toNullable
+                               nbf = this.ActivationDate |> Option.map Secret.TotalSecondsSince1970 |> Option.toNullable
+                               exp = this.ExpirationDate |> Option.map Secret.TotalSecondsSince1970 |> Option.toNullable
+                            |}
+                        |}
+                |} :> _
 
 type CreateMode = Recover | Default
 type Vault =
@@ -85,45 +79,40 @@ type Vault =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = vaults.Path
-               apiVersion = vaults.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               dependsOn = this.Dependencies |> List.map (fun p -> p.Value)
-               properties =
-                 {| tenantId = this.TenantId
-                    sku = {| name = this.Sku.ArmValue; family = "A" |}
-                    enabledForDeployment = this.Deployment |> Option.map(fun f -> f.AsBoolean) |> Option.toNullable
-                    enabledForDiskEncryption = this.DiskEncryption |> Option.map(fun f -> f.AsBoolean) |> Option.toNullable
-                    enabledForTemplateDeployment = this.TemplateDeployment |> Option.map(fun f -> f.AsBoolean) |> Option.toNullable
-                    enableSoftDelete =
+            {| vaults.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
+                properties =
+                    {| tenantId = this.TenantId
+                       sku = {| name = this.Sku.ArmValue; family = "A" |}
+                       enabledForDeployment = this.Deployment |> Option.map(fun f -> f.AsBoolean) |> Option.toNullable
+                       enabledForDiskEncryption = this.DiskEncryption |> Option.map(fun f -> f.AsBoolean) |> Option.toNullable
+                       enabledForTemplateDeployment = this.TemplateDeployment |> Option.map(fun f -> f.AsBoolean) |> Option.toNullable
+                       enableSoftDelete =
                         match this.SoftDelete with
                         | None ->
                             Nullable()
                         | Some SoftDeleteWithPurgeProtection
                         | Some SoftDeletionOnly ->
                             Nullable true
-                    createMode = this.CreateMode |> Option.map(fun m -> m.ToString().ToLower()) |> Option.toObj
-                    enablePurgeProtection = this.PurgeProtection
-                    vaultUri = this.Uri |> Option.map string |> Option.toObj
-                    accessPolicies =
-                         [| for policy in this.AccessPolicies do
-                             {| objectId = ArmExpression.Eval policy.ObjectId
-                                tenantId = this.TenantId
-                                applicationId = policy.ApplicationId |> Option.map string |> Option.toObj
-                                permissions =
-                                 {| keys = this.ToStringArray policy.Permissions.Keys
-                                    storage = this.ToStringArray policy.Permissions.Storage
-                                    certificates = this.ToStringArray policy.Permissions.Certificates
-                                    secrets = this.ToStringArray policy.Permissions.Secrets |}
-                             |}
-                         |]
-                    networkAcls =
-                     {| defaultAction = this.DefaultAction  |> Option.map string |> Option.toObj
-                        bypass = this.Bypass  |> Option.map string |> Option.toObj
-                        ipRules = this.IpRules
-                        virtualNetworkRules = this.VnetRules |}
-                 |}
-               tags = this.Tags
-             |} :> _
+                       createMode = this.CreateMode |> Option.map(fun m -> m.ToString().ToLower()) |> Option.toObj
+                       enablePurgeProtection = this.PurgeProtection
+                       vaultUri = this.Uri |> Option.map string |> Option.toObj
+                       accessPolicies = [|
+                        for policy in this.AccessPolicies do
+                            {| objectId = ArmExpression.Eval policy.ObjectId
+                               tenantId = this.TenantId
+                               applicationId = policy.ApplicationId |> Option.map string |> Option.toObj
+                               permissions =
+                                {| keys = this.ToStringArray policy.Permissions.Keys
+                                   storage = this.ToStringArray policy.Permissions.Storage
+                                   certificates = this.ToStringArray policy.Permissions.Certificates
+                                   secrets = this.ToStringArray policy.Permissions.Secrets |}
+                            |}
+                       |]
+                       networkAcls =
+                        {| defaultAction = this.DefaultAction  |> Option.map string |> Option.toObj
+                           bypass = this.Bypass  |> Option.map string |> Option.toObj
+                           ipRules = this.IpRules
+                           virtualNetworkRules = this.VnetRules |}
+                    |}
+            |} :> _
 

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -6,8 +6,8 @@ open Farmer.CoreTypes
 open Farmer.KeyVault
 open System
 
-let secrets = ResourceType "Microsoft.KeyVault/vaults/secrets"
-let vaults = ResourceType "Microsoft.KeyVault/vaults"
+let secrets = ResourceType ("Microsoft.KeyVault/vaults/secrets", "2018-02-14")
+let vaults = ResourceType ("Microsoft.KeyVault/vaults", "2018-02-14")
 
 module Vaults =
     type Secret =
@@ -29,9 +29,9 @@ module Vaults =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = secrets.ArmValue
+                {| ``type`` = secrets.Path
+                   apiVersion = secrets.Version
                    name = this.Name.Value
-                   apiVersion = "2018-02-14"
                    location = this.Location.ArmValue
                    dependsOn = [
                        for dependency in this.Dependencies do
@@ -85,9 +85,9 @@ type Vault =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = vaults.ArmValue
+            {| ``type`` = vaults.Path
+               apiVersion = vaults.Version
                name = this.Name.Value
-               apiVersion = "2018-02-14"
                location = this.Location.ArmValue
                dependsOn = this.Dependencies |> List.map (fun p -> p.Value)
                properties =

--- a/src/Farmer/Arm/Maps.fs
+++ b/src/Farmer/Arm/Maps.fs
@@ -11,19 +11,14 @@ type Maps =
     { Name : ResourceName
       Location : Location
       Sku : Sku
-      Tags: Map<string,string>  }
+      Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = accounts.Path
-               apiVersion = accounts.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               sku =
-                   {|
-                     name =
-                         match this.Sku with
-                         | S0 -> "S0"
-                         | S1 -> "S1" |}
-               tags = this.Tags
+            {| accounts.Create(this.Name, this.Location, tags = this.Tags) with
+                sku =
+                    {| name =
+                        match this.Sku with
+                        | S0 -> "S0"
+                        | S1 -> "S1" |}
             |} :> _

--- a/src/Farmer/Arm/Maps.fs
+++ b/src/Farmer/Arm/Maps.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.Maps
 
-let accounts = ResourceType "Microsoft.Maps/accounts"
+let accounts = ResourceType ("Microsoft.Maps/accounts", "2018-05-01")
 
 type Maps =
     { Name : ResourceName
@@ -15,8 +15,8 @@ type Maps =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = accounts.ArmValue
-               apiVersion = "2018-05-01"
+            {| ``type`` = accounts.Path
+               apiVersion = accounts.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                sku =

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -6,14 +6,14 @@ open Farmer.CoreTypes
 open Farmer.ExpressRoute
 open Farmer.VirtualNetworkGateway
 
-let connections = ResourceType ("Microsoft.Network/connections", "")
+let connections = ResourceType ("Microsoft.Network/connections", "2020-04-01")
 let expressRouteCircuits = ResourceType ("Microsoft.Network/expressRouteCircuits", "2019-02-01")
 let networkInterfaces = ResourceType ("Microsoft.Network/networkInterfaces", "2018-11-01")
 let networkProfiles = ResourceType ("Microsoft.Network/networkProfiles", "2020-04-01")
 let publicIPAddresses = ResourceType ("Microsoft.Network/publicIPAddresses", "2018-11-01")
 let subnets = ResourceType ("Microsoft.Network/virtualNetworks/subnets", "")
 let virtualNetworks = ResourceType ("Microsoft.Network/virtualNetworks", "2018-11-01")
-let virtualNetworkGateways = ResourceType ("Microsoft.Network/virtualNetworkGateways", "")
+let virtualNetworkGateways = ResourceType ("Microsoft.Network/virtualNetworkGateways", "2020-05-01")
 let localNetworkGateways = ResourceType ("Microsoft.Network/localNetworkGateways", "")
 
 type PublicIpAddress =
@@ -24,17 +24,13 @@ type PublicIpAddress =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = publicIPAddresses.Path
-               apiVersion = publicIPAddresses.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               properties =
-                  {| publicIPAllocationMethod = "Dynamic"
-                     dnsSettings =
+            {| publicIPAddresses.Create(this.Name, this.Location, tags = this.Tags) with
+                properties =
+                    {| publicIPAllocationMethod = "Dynamic"
+                       dnsSettings =
                         match this.DomainNameLabel with
                         | Some label -> box {| domainNameLabel = label.ToLower() |}
                         | None -> null |}
-               tags = this.Tags
             |} :> _
 
 type VirtualNetwork =
@@ -46,27 +42,23 @@ type VirtualNetwork =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = virtualNetworks.Path
-               apiVersion = virtualNetworks.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               properties =
+            {| virtualNetworks.Create(this.Name, this.Location, tags = this.Tags) with
+                properties =
                     {| addressSpace = {| addressPrefixes = this.AddressSpacePrefixes |}
                        subnets =
                         this.Subnets
                         |> List.map(fun subnet ->
-                           {| name = subnet.Name.Value
-                              properties =
-                                  {| addressPrefix = subnet.Prefix
-                                     delegations = subnet.Delegations
-                                     |> List.map (fun delegation ->
-                                         {| name = delegation.Name.Value
-                                            properties = {| serviceName = delegation.ServiceName |}
-                                         |})
-                                  |}
-                           |})
+                            {| name = subnet.Name.Value
+                               properties =
+                                {| addressPrefix = subnet.Prefix
+                                   delegations = subnet.Delegations
+                                   |> List.map (fun delegation ->
+                                    {| name = delegation.Name.Value
+                                       properties = {| serviceName = delegation.ServiceName |}
+                                    |})
+                                |}
+                            |})
                     |}
-               tags = this.Tags
             |} :> _
 type VirtualNetworkGateway =
     { Name : ResourceName
@@ -82,39 +74,37 @@ type VirtualNetworkGateway =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = "Microsoft.Network/virtualNetworkGateways"
-               apiVersion = "2020-05-01"
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               dependsOn = [
-                   ArmExpression.resourceId(virtualNetworks, this.VirtualNetwork).Eval()
-                   for config in this.IpConfigs do
-                        ArmExpression.resourceId(publicIPAddresses, config.PublicIpName).Eval()
-               ]
-               properties =
-                    {| ipConfigurations = this.IpConfigs
-                        |> List.mapi(fun index ipConfig ->
-                           {| name = sprintf "ipconfig%i" (index + 1)
-                              properties =
-                                let allocationMethod, ip =
-                                    match ipConfig.PrivateIpAllocationMethod with
-                                    | DynamicPrivateIp -> "Dynamic", null
-                                    | StaticPrivateIp ip -> "Static", string ip
-                                {| privateIpAllocationMethod = allocationMethod; privateIpAddress = ip
-                                   publicIPAddress = {| id = ArmExpression.resourceId(publicIPAddresses, ipConfig.PublicIpName).Eval() |}
-                                   subnet = {| id = ArmExpression.resourceId(subnets, this.VirtualNetwork, ResourceName "GatewaySubnet").Eval() |}
-                                |}
-                           |})
-                       sku =
-                           match this.GatewayType with
-                           | GatewayType.ExpressRoute sku -> {| name = sku.ArmValue; tier = sku.ArmValue |}
-                           | GatewayType.Vpn sku -> {| name = sku.ArmValue; tier = sku.ArmValue |}
-                       gatewayType = this.GatewayType.ArmValue
-                       vpnType = this.VpnType.ArmValue
-                       enableBgp = this.EnableBgp
-                       activeActive = this.IpConfigs |> List.length > 1
-                    |}
-               tags = this.Tags
+            let dependsOn = [
+                ArmExpression.resourceId(virtualNetworks, this.VirtualNetwork).Eval() |> ResourceName
+                for config in this.IpConfigs do
+                    ArmExpression.resourceId(publicIPAddresses, config.PublicIpName).Eval() |> ResourceName
+            ]
+
+            {| virtualNetworkGateways.Create(this.Name, this.Location, dependsOn, this.Tags) with
+                properties =
+                     {| ipConfigurations =
+                            this.IpConfigs
+                            |> List.mapi(fun index ipConfig ->
+                                {| name = sprintf "ipconfig%i" (index + 1)
+                                   properties =
+                                    let allocationMethod, ip =
+                                        match ipConfig.PrivateIpAllocationMethod with
+                                        | DynamicPrivateIp -> "Dynamic", null
+                                        | StaticPrivateIp ip -> "Static", string ip
+                                    {| privateIpAllocationMethod = allocationMethod; privateIpAddress = ip
+                                       publicIPAddress = {| id = ArmExpression.resourceId(publicIPAddresses, ipConfig.PublicIpName).Eval() |}
+                                       subnet = {| id = ArmExpression.resourceId(subnets, this.VirtualNetwork, ResourceName "GatewaySubnet").Eval() |}
+                                    |}
+                                |})
+                        sku =
+                            match this.GatewayType with
+                            | GatewayType.ExpressRoute sku -> {| name = sku.ArmValue; tier = sku.ArmValue |}
+                            | GatewayType.Vpn sku -> {| name = sku.ArmValue; tier = sku.ArmValue |}
+                        gatewayType = this.GatewayType.ArmValue
+                        vpnType = this.VpnType.ArmValue
+                        enableBgp = this.EnableBgp
+                        activeActive = this.IpConfigs |> List.length > 1
+                     |}
             |} :> _
 type Connection =
     { Name : ResourceName
@@ -133,36 +123,28 @@ type Connection =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = "Microsoft.Network/connections"
-               apiVersion = "2020-04-01"
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               dependsOn =
-                    [ Some this.VNetGateway1ResourceId; this.VNetGateway2ResourceId; this.LocalNetworkGatewayResourceId ]
-                    |> List.choose id
-                    |> List.map(fun r -> r.Eval())
-               properties =
-                    {| authorizationKey =
-                            match this.AuthorizationKey with
-                            | Some key -> key
-                            | None -> null
-                       connectionType = this.ConnectionType.ArmValue
-                       virtualNetworkGateway1 =
-                            {| id = this.VNetGateway1ResourceId.Eval() |}
-                       virtualNetworkGateway2 =
+            let dependsOn =
+                [ Some this.VNetGateway1ResourceId; this.VNetGateway2ResourceId; this.LocalNetworkGatewayResourceId ]
+                |> List.choose id
+                |> List.map(fun r -> r.Eval() |> ResourceName)
+            {| connections.Create(this.Name, this.Location, dependsOn, this.Tags) with
+                properties =
+                     {| authorizationKey = this.AuthorizationKey |> Option.toObj
+                        connectionType = this.ConnectionType.ArmValue
+                        virtualNetworkGateway1 = {| id = this.VNetGateway1ResourceId.Eval() |}
+                        virtualNetworkGateway2 =
                             match this.VNetGateway2ResourceId with
                             | Some vng2 -> box {| id = vng2.Eval() |}
                             | None -> null
-                       localNetworkGateway1 =
+                        localNetworkGateway1 =
                             match this.LocalNetworkGatewayResourceId with
                             | Some lng -> box {| id = lng.Eval() |}
                             | None -> null
-                       peer =
+                        peer =
                             match this.PeerId with
                             | Some peerId -> box {| id = peerId |}
                             | None -> null
-                    |}
-               tags = this.Tags
+                     |}
             |} :> _
 type NetworkInterface =
     { Name : ResourceName
@@ -175,17 +157,14 @@ type NetworkInterface =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = networkInterfaces.Path
-               apiVersion = networkInterfaces.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               dependsOn = [
-                   this.VirtualNetwork.Value
-                   for config in this.IpConfigs do
-                       config.PublicIpName.Value
-               ]
-               properties =
-                   {| ipConfigurations =
+            let dependsOn = [
+               this.VirtualNetwork
+               for config in this.IpConfigs do
+                   config.PublicIpName
+            ]
+            {| networkInterfaces.Create(this.Name, this.Location, dependsOn, this.Tags) with
+                properties =
+                    {| ipConfigurations =
                         this.IpConfigs
                         |> List.mapi(fun index ipConfig ->
                             {| name = sprintf "ipconfig%i" (index + 1)
@@ -195,48 +174,40 @@ type NetworkInterface =
                                    subnet = {| id = ArmExpression.resourceId(subnets, this.VirtualNetwork, ipConfig.SubnetName).Eval() |}
                                 |}
                             |})
-                   |}
-               tags = this.Tags
+                    |}
             |} :> _
 type NetworkProfile =
     { Name : ResourceName
       Location : Location
       ContainerNetworkInterfaceConfigurations :
-        {| IpConfigs :
-            {| SubnetName : ResourceName |} list
+        {| IpConfigs : {| SubnetName : ResourceName |} list
         |} list
       VirtualNetwork : ResourceName
-      Tags: Map<string,string>  }
+      Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = networkProfiles.Path
-               apiVersion = networkProfiles.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               dependsOn = [
-                   ArmExpression.resourceId(virtualNetworks, this.VirtualNetwork).Eval()
-                ]
-               properties =
-                   {| containerNetworkInterfaceConfigurations =
-                       this.ContainerNetworkInterfaceConfigurations
-                       |> List.mapi (fun index containerIfConfig ->
-                           {| name = sprintf "eth%i" index
-                              properties =
+            let dependsOn = [ ArmExpression.resourceId(virtualNetworks, this.VirtualNetwork).Eval() |> ResourceName ]
+            {| networkProfiles.Create(this.Name, this.Location, dependsOn, this.Tags) with
+                properties =
+                    {| containerNetworkInterfaceConfigurations =
+                        this.ContainerNetworkInterfaceConfigurations
+                        |> List.mapi (fun index containerIfConfig ->
+                            {| name = sprintf "eth%i" index
+                               properties =
                                 {| ipConfigurations =
                                    containerIfConfig.IpConfigs
                                    |> List.mapi (fun index ipConfig ->
-                                      {| name = sprintf "ipconfig%i" (index + 1)
-                                         properties =
-                                            {| subnet =
-                                                {| id = ArmExpression.resourceId(subnets, this.VirtualNetwork, ipConfig.SubnetName).Eval() |}
-                                            |}
-                                      |})
+                                    {| name = sprintf "ipconfig%i" (index + 1)
+                                       properties =
+                                        {| subnet =
+                                            {| id = ArmExpression.resourceId(subnets, this.VirtualNetwork, ipConfig.SubnetName).Eval() |}
+                                        |}
+                                    |})
                                 |}
-                           |}
-                       )
-                   |}
-               tags = this.Tags
+                            |}
+                        )
+                    |}
             |} :> _
 type ExpressRouteCircuit =
     { Name : ResourceName
@@ -261,32 +232,28 @@ type ExpressRouteCircuit =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = expressRouteCircuits.Path
-               apiVersion = expressRouteCircuits.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               sku =
-                {| name = sprintf "%O_%O" this.Tier this.Family
-                   tier = string this.Tier
-                   family = string this.Family |}
-               properties =
-                   {| peerings = [
+            {| expressRouteCircuits.Create(this.Name, this.Location, tags = this.Tags) with
+                sku =
+                 {| name = sprintf "%O_%O" this.Tier this.Family
+                    tier = string this.Tier
+                    family = string this.Family |}
+                properties =
+                    {| peerings = [
                         for peer in this.Peerings do
                             {| name = peer.PeeringType.Value
                                properties =
-                                   {| peeringType = peer.PeeringType.Value
-                                      azureASN = peer.AzureASN
-                                      peerASN = peer.PeerASN
-                                      primaryPeerAddressPrefix = IPAddressCidr.format peer.PrimaryPeerAddressPrefix
-                                      secondaryPeerAddressPrefix = IPAddressCidr.format peer.SecondaryPeerAddressPrefix
-                                      vlanId = peer.VlanId
-                                      sharedKey = peer.SharedKey |}
+                                {| peeringType = peer.PeeringType.Value
+                                   azureASN = peer.AzureASN
+                                   peerASN = peer.PeerASN
+                                   primaryPeerAddressPrefix = IPAddressCidr.format peer.PrimaryPeerAddressPrefix
+                                   secondaryPeerAddressPrefix = IPAddressCidr.format peer.SecondaryPeerAddressPrefix
+                                   vlanId = peer.VlanId
+                                   sharedKey = peer.SharedKey |}
                             |}
-                      ]
-                      serviceProviderProperties =
+                       ]
+                       serviceProviderProperties =
                         {| serviceProviderName = this.ServiceProviderName
                            peeringLocation = this.PeeringLocation
                            bandwidthInMbps = this.Bandwidth |}
-                      globalReachEnabled = this.GlobalReachEnabled |}
-               tags = this.Tags
+                       globalReachEnabled = this.GlobalReachEnabled |}
             |} :> _

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -6,15 +6,15 @@ open Farmer.CoreTypes
 open Farmer.ExpressRoute
 open Farmer.VirtualNetworkGateway
 
-let connections = ResourceType "Microsoft.Network/connections"
-let expressRouteCircuits = ResourceType "Microsoft.Network/expressRouteCircuits"
-let networkInterfaces = ResourceType "Microsoft.Network/networkInterfaces"
-let networkProfiles = ResourceType "Microsoft.Network/networkProfiles"
-let publicIPAddresses = ResourceType "Microsoft.Network/publicIPAddresses"
-let subnets = ResourceType "Microsoft.Network/virtualNetworks/subnets"
-let virtualNetworks = ResourceType "Microsoft.Network/virtualNetworks"
-let virtualNetworkGateways = ResourceType "Microsoft.Network/virtualNetworkGateways"
-let localNetworkGateways = ResourceType "Microsoft.Network/localNetworkGateways"
+let connections = ResourceType ("Microsoft.Network/connections", "")
+let expressRouteCircuits = ResourceType ("Microsoft.Network/expressRouteCircuits", "2019-02-01")
+let networkInterfaces = ResourceType ("Microsoft.Network/networkInterfaces", "2018-11-01")
+let networkProfiles = ResourceType ("Microsoft.Network/networkProfiles", "2020-04-01")
+let publicIPAddresses = ResourceType ("Microsoft.Network/publicIPAddresses", "2018-11-01")
+let subnets = ResourceType ("Microsoft.Network/virtualNetworks/subnets", "")
+let virtualNetworks = ResourceType ("Microsoft.Network/virtualNetworks", "2018-11-01")
+let virtualNetworkGateways = ResourceType ("Microsoft.Network/virtualNetworkGateways", "")
+let localNetworkGateways = ResourceType ("Microsoft.Network/localNetworkGateways", "")
 
 type PublicIpAddress =
     { Name : ResourceName
@@ -24,8 +24,8 @@ type PublicIpAddress =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = publicIPAddresses.ArmValue
-               apiVersion = "2018-11-01"
+            {| ``type`` = publicIPAddresses.Path
+               apiVersion = publicIPAddresses.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                properties =
@@ -46,8 +46,8 @@ type VirtualNetwork =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = virtualNetworks.ArmValue
-               apiVersion = "2018-11-01"
+            {| ``type`` = virtualNetworks.Path
+               apiVersion = virtualNetworks.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                properties =
@@ -175,8 +175,8 @@ type NetworkInterface =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = networkInterfaces.ArmValue
-               apiVersion = "2018-11-01"
+            {| ``type`` = networkInterfaces.Path
+               apiVersion = networkInterfaces.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                dependsOn = [
@@ -210,8 +210,8 @@ type NetworkProfile =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = networkProfiles.ArmValue
-               apiVersion = "2020-04-01"
+            {| ``type`` = networkProfiles.Path
+               apiVersion = networkProfiles.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                dependsOn = [
@@ -261,8 +261,8 @@ type ExpressRouteCircuit =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = expressRouteCircuits.ArmValue
-               apiVersion = "2019-02-01"
+            {| ``type`` = expressRouteCircuits.Path
+               apiVersion = expressRouteCircuits.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                sku =

--- a/src/Farmer/Arm/NetworkSecurityGroup.fs
+++ b/src/Farmer/Arm/NetworkSecurityGroup.fs
@@ -5,8 +5,8 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.NetworkSecurity
 
-let networkSecurityGroups = ResourceType "Microsoft.Network/networkSecurityGroups"
-let securityRules = ResourceType "Microsoft.Network/networkSecurityGroups/securityRules"
+let networkSecurityGroups = ResourceType ("Microsoft.Network/networkSecurityGroups", "2020-04-01")
+let securityRules = ResourceType ("Microsoft.Network/networkSecurityGroups/securityRules", "2020-04-01")
 
 type NetworkSecurityGroup =
     { Name : ResourceName
@@ -15,8 +15,8 @@ type NetworkSecurityGroup =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = networkSecurityGroups.ArmValue
-               apiVersion = "2020-04-01"
+            {| ``type`` = networkSecurityGroups.Path
+               apiVersion = networkSecurityGroups.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                tags = this.Tags |} :> _
@@ -68,8 +68,8 @@ type SecurityRule =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = securityRules.ArmValue
-               apiVersion = "2020-04-01"
+            {| ``type`` = securityRules.Path
+               apiVersion = securityRules.Version
                name = sprintf "%s/%s" this.SecurityGroup.Name.Value this.Name.Value
                dependsOn = [ ArmExpression.resourceId(networkSecurityGroups, this.SecurityGroup.Name).Eval() ]
                properties =

--- a/src/Farmer/Arm/NetworkSecurityGroup.fs
+++ b/src/Farmer/Arm/NetworkSecurityGroup.fs
@@ -15,11 +15,7 @@ type NetworkSecurityGroup =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = networkSecurityGroups.Path
-               apiVersion = networkSecurityGroups.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               tags = this.Tags |} :> _
+            networkSecurityGroups.Create(this.Name, this.Location, tags = this.Tags) :> _
 
 let (|SingleEndpoint|ManyEndpoints|) endpoints =
     // Use a wildcard if there is one
@@ -68,23 +64,21 @@ type SecurityRule =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = securityRules.Path
-               apiVersion = securityRules.Version
-               name = sprintf "%s/%s" this.SecurityGroup.Name.Value this.Name.Value
-               dependsOn = [ ArmExpression.resourceId(networkSecurityGroups, this.SecurityGroup.Name).Eval() ]
-               properties =
-                {| description = this.Description |> Option.toObj
-                   protocol = this.Protocol.ArmValue
-                   sourcePortRange = this.SourcePorts |> EndpointWriter.toRange
-                   sourcePortRanges = this.SourcePorts |> EndpointWriter.toRanges
-                   destinationPortRange = this.DestinationPorts |> EndpointWriter.toRange
-                   destinationPortRanges = this.DestinationPorts |> EndpointWriter.toRanges
-                   sourceAddressPrefix = this.SourceAddresses |> EndpointWriter.toPrefix
-                   sourceAddressPrefixes = this.SourceAddresses |> EndpointWriter.toPrefixes
-                   destinationAddressPrefix = this.DestinationAddresses |> EndpointWriter.toPrefix
-                   destinationAddressPrefixes = this.DestinationAddresses |> EndpointWriter.toPrefixes
-                   access = this.Access.ArmValue
-                   priority = this.Priority
-                   direction = this.Direction.ArmValue
-                |}
+            let dependsOn = [ ArmExpression.resourceId(networkSecurityGroups, this.SecurityGroup.Name).Eval() |> ResourceName ]
+            {| securityRules.Create(this.SecurityGroup.Name + this.Name, dependsOn = dependsOn) with
+                properties =
+                 {| description = this.Description |> Option.toObj
+                    protocol = this.Protocol.ArmValue
+                    sourcePortRange = this.SourcePorts |> EndpointWriter.toRange
+                    sourcePortRanges = this.SourcePorts |> EndpointWriter.toRanges
+                    destinationPortRange = this.DestinationPorts |> EndpointWriter.toRange
+                    destinationPortRanges = this.DestinationPorts |> EndpointWriter.toRanges
+                    sourceAddressPrefix = this.SourceAddresses |> EndpointWriter.toPrefix
+                    sourceAddressPrefixes = this.SourceAddresses |> EndpointWriter.toPrefixes
+                    destinationAddressPrefix = this.DestinationAddresses |> EndpointWriter.toPrefix
+                    destinationAddressPrefixes = this.DestinationAddresses |> EndpointWriter.toPrefixes
+                    access = this.Access.ArmValue
+                    priority = this.Priority
+                    direction = this.Direction.ArmValue
+                 |}
             |} :> _

--- a/src/Farmer/Arm/Search.fs
+++ b/src/Farmer/Arm/Search.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.Search
 
-let searchServices = ResourceType "Microsoft.Search/searchServices"
+let searchServices = ResourceType ("Microsoft.Search/searchServices", "2015-08-19")
 
 type SearchService =
     { Name : ResourceName
@@ -21,8 +21,8 @@ type SearchService =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = searchServices.ArmValue
-               apiVersion = "2015-08-19"
+            {| ``type`` = searchServices.Path
+               apiVersion = searchServices.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                sku =

--- a/src/Farmer/Arm/Search.fs
+++ b/src/Farmer/Arm/Search.fs
@@ -21,23 +21,19 @@ type SearchService =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = searchServices.Path
-               apiVersion = searchServices.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               sku =
-                {| name =
-                    match this.Sku with
-                    | Free -> "free"
-                    | Basic -> "basic"
-                    | Standard -> "standard"
-                    | Standard2 -> "standard2"
-                    | Standard3 _ -> "standard3"
-                    | StorageOptimisedL1 -> "storage_optimized_l1"
-                    | StorageOptimisedL2 -> "storage_optimized_l2" |}
-               properties =
-                {| replicaCount = this.ReplicaCount
-                   partitionCount = this.PartitionCount
-                   hostingMode = this.HostingMode |}
-               tags = this.Tags
+            {| searchServices.Create(this.Name, this.Location, tags = this.Tags) with
+                sku =
+                 {| name =
+                     match this.Sku with
+                     | Free -> "free"
+                     | Basic -> "basic"
+                     | Standard -> "standard"
+                     | Standard2 -> "standard2"
+                     | Standard3 _ -> "standard3"
+                     | StorageOptimisedL1 -> "storage_optimized_l1"
+                     | StorageOptimisedL2 -> "storage_optimized_l2" |}
+                properties =
+                 {| replicaCount = this.ReplicaCount
+                    partitionCount = this.PartitionCount
+                    hostingMode = this.HostingMode |}
             |} :> _

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -29,42 +29,39 @@ module Namespaces =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                    {| ``type`` = subscriptions.Path
-                       apiVersion = subscriptions.Version
-                       name = this.Namespace.Value + "/" + this.Topic.Value + "/" + this.Name.Value
-                       dependsOn = [ this.Topic.Value ]
-                       properties =
-                        {| defaultMessageTimeToLive = tryGetIso this.DefaultMessageTimeToLive
-                           requiresDuplicateDetection =
-                               match this.DuplicateDetectionHistoryTimeWindow with
-                               | Some _ -> Nullable true
-                               | None -> Nullable()
-                           duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
-                           deadLetteringOnMessageExpiration = this.DeadLetteringOnMessageExpiration |> Option.toNullable
-                           maxDeliveryCount = this.MaxDeliveryCount |> Option.toNullable
-                           requiresSession = this.Session |> Option.toNullable
-                           lockDuration = tryGetIso this.LockDuration
-                        |}
-                       resources = [
-                        for rule in this.Rules do
-                           {| apiVersion = "2017-04-01"
-                              name = rule.Name.Value
-                              ``type`` = "Rules"
-                              dependsOn = [ this.Name.Value ]
-                              properties =
-                               match rule with
-                               | SqlFilter (_, expression) ->
-                                   {| filterType = "SqlFilter"
-                                      sqlFilter = box {| sqlExpression = expression |}
-                                      correlationFilter = null |}
-                               | CorrelationFilter (_, correlationId, properties) ->
-                                   {| filterType = "CorrelationFilter"
-                                      correlationFilter =
-                                          box {| correlationId = correlationId |> Option.toObj
-                                                 properties = properties |}
-                                      sqlFilter = null |}
-                           |}
-                       ]
+                    {| subscriptions.Create(this.Namespace + this.Topic + this.Name, dependsOn = [ this.Topic ]) with
+                        properties =
+                         {| defaultMessageTimeToLive = tryGetIso this.DefaultMessageTimeToLive
+                            requiresDuplicateDetection =
+                                match this.DuplicateDetectionHistoryTimeWindow with
+                                | Some _ -> Nullable true
+                                | None -> Nullable()
+                            duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
+                            deadLetteringOnMessageExpiration = this.DeadLetteringOnMessageExpiration |> Option.toNullable
+                            maxDeliveryCount = this.MaxDeliveryCount |> Option.toNullable
+                            requiresSession = this.Session |> Option.toNullable
+                            lockDuration = tryGetIso this.LockDuration
+                         |}
+                        resources = [
+                         for rule in this.Rules do
+                            {| apiVersion = "2017-04-01"
+                               name = rule.Name.Value
+                               ``type`` = "Rules"
+                               dependsOn = [ this.Name.Value ]
+                               properties =
+                                match rule with
+                                | SqlFilter (_, expression) ->
+                                    {| filterType = "SqlFilter"
+                                       sqlFilter = box {| sqlExpression = expression |}
+                                       correlationFilter = null |}
+                                | CorrelationFilter (_, correlationId, properties) ->
+                                    {| filterType = "CorrelationFilter"
+                                       correlationFilter =
+                                           box {| correlationId = correlationId |> Option.toObj
+                                                  properties = properties |}
+                                       sqlFilter = null |}
+                            |}
+                        ]
                     |} :> _
 
     type Queue =
@@ -80,22 +77,19 @@ module Namespaces =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = queues.Path
-                   apiVersion = queues.Version
-                   name = this.Namespace.Value + "/" + this.Name.Value
-                   dependsOn = [ this.Namespace.Value ]
-                   properties =
-                    {| lockDuration = tryGetIso this.LockDuration
-                       requiresDuplicateDetection =
-                           match this.DuplicateDetectionHistoryTimeWindow with
-                           | Some _ -> Nullable true
-                           | None -> Nullable()
-                       duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
-                       defaultMessageTimeToLive = this.DefaultMessageTimeToLive.Value
-                       requiresSession = this.Session |> Option.toNullable
-                       deadLetteringOnMessageExpiration = this.DeadLetteringOnMessageExpiration |> Option.toNullable
-                       maxDeliveryCount = this.MaxDeliveryCount |> Option.toNullable
-                       enablePartitioning = this.EnablePartitioning |> Option.toNullable |}
+                {| queues.Create(this.Namespace + this.Name, dependsOn = [ this.Namespace ]) with
+                    properties =
+                     {| lockDuration = tryGetIso this.LockDuration
+                        requiresDuplicateDetection =
+                            match this.DuplicateDetectionHistoryTimeWindow with
+                            | Some _ -> Nullable true
+                            | None -> Nullable()
+                        duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
+                        defaultMessageTimeToLive = this.DefaultMessageTimeToLive.Value
+                        requiresSession = this.Session |> Option.toNullable
+                        deadLetteringOnMessageExpiration = this.DeadLetteringOnMessageExpiration |> Option.toNullable
+                        maxDeliveryCount = this.MaxDeliveryCount |> Option.toNullable
+                        enablePartitioning = this.EnablePartitioning |> Option.toNullable |}
                 |} :> _
 
     type Topic =
@@ -107,18 +101,15 @@ module Namespaces =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = topics.Path
-                   apiVersion = topics.Version
-                   name = this.Namespace.Value + "/" + this.Name.Value
-                   dependsOn = [ this.Namespace.Value ]
-                   properties =
-                       {| defaultMessageTimeToLive = tryGetIso this.DefaultMessageTimeToLive
-                          requiresDuplicateDetection =
-                              match this.DuplicateDetectionHistoryTimeWindow with
-                              | Some _ -> Nullable true
-                              | None -> Nullable()
-                          duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
-                          enablePartitioning = this.EnablePartitioning |> Option.toNullable |}
+                {| topics.Create(this.Namespace + this.Name, dependsOn = [ this.Namespace ]) with
+                    properties =
+                        {| defaultMessageTimeToLive = tryGetIso this.DefaultMessageTimeToLive
+                           requiresDuplicateDetection =
+                               match this.DuplicateDetectionHistoryTimeWindow with
+                               | Some _ -> Nullable true
+                               | None -> Nullable()
+                           duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
+                           enablePartitioning = this.EnablePartitioning |> Option.toNullable |}
                 |} :> _
 
 type Namespace =
@@ -137,14 +128,9 @@ type Namespace =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = namespaces.Path
-               apiVersion = namespaces.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               sku =
-                    {| name = string this.Sku
-                       tier = string this.Sku
-                       capacity = this.Capacity |> Option.toNullable |}
-               dependsOn = this.DependsOn |> List.map (fun r -> r.Value)
-               tags = this.Tags
+            {| namespaces.Create(this.Name, this.Location, this.DependsOn, this.Tags) with
+                sku =
+                     {| name = string this.Sku
+                        tier = string this.Sku
+                        capacity = this.Capacity |> Option.toNullable |}
             |} :> _

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -15,6 +15,7 @@ let namespaces = ResourceType ("Microsoft.ServiceBus/namespaces", "2017-04-01")
 
 module Namespaces =
     module Topics =
+        let rules = ResourceType ("Rules", "2017-04-01")
         type Subscription =
             { Name : ResourceName
               Namespace : ResourceName
@@ -44,22 +45,19 @@ module Namespaces =
                          |}
                         resources = [
                          for rule in this.Rules do
-                            {| apiVersion = "2017-04-01"
-                               name = rule.Name.Value
-                               ``type`` = "Rules"
-                               dependsOn = [ this.Name.Value ]
-                               properties =
-                                match rule with
-                                | SqlFilter (_, expression) ->
-                                    {| filterType = "SqlFilter"
-                                       sqlFilter = box {| sqlExpression = expression |}
-                                       correlationFilter = null |}
-                                | CorrelationFilter (_, correlationId, properties) ->
-                                    {| filterType = "CorrelationFilter"
-                                       correlationFilter =
-                                           box {| correlationId = correlationId |> Option.toObj
-                                                  properties = properties |}
-                                       sqlFilter = null |}
+                            {| rules.Create(rule.Name, dependsOn = [ this.Name ]) with
+                                properties =
+                                 match rule with
+                                 | SqlFilter (_, expression) ->
+                                     {| filterType = "SqlFilter"
+                                        sqlFilter = box {| sqlExpression = expression |}
+                                        correlationFilter = null |}
+                                 | CorrelationFilter (_, correlationId, properties) ->
+                                     {| filterType = "CorrelationFilter"
+                                        correlationFilter =
+                                            box {| correlationId = correlationId |> Option.toObj
+                                                   properties = properties |}
+                                        sqlFilter = null |}
                             |}
                         ]
                     |} :> _

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -8,10 +8,10 @@ open System
 
 let private tryGetIso (v:IsoDateTime option) = v |> Option.map(fun v -> v.Value) |> Option.toObj
 
-let subscriptions = ResourceType "Microsoft.ServiceBus/namespaces/topics/subscriptions"
-let queues = ResourceType "Microsoft.ServiceBus/namespaces/queues"
-let topics = ResourceType "Microsoft.ServiceBus/namespaces/topics"
-let namespaces = ResourceType "Microsoft.ServiceBus/namespaces"
+let subscriptions = ResourceType ("Microsoft.ServiceBus/namespaces/topics/subscriptions", "2017-04-01")
+let queues = ResourceType ("Microsoft.ServiceBus/namespaces/queues", "2017-04-01")
+let topics = ResourceType ("Microsoft.ServiceBus/namespaces/topics", "2017-04-01")
+let namespaces = ResourceType ("Microsoft.ServiceBus/namespaces", "2017-04-01")
 
 module Namespaces =
     module Topics =
@@ -29,9 +29,9 @@ module Namespaces =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                    {| apiVersion = "2017-04-01"
+                    {| ``type`` = subscriptions.Path
+                       apiVersion = subscriptions.Version
                        name = this.Namespace.Value + "/" + this.Topic.Value + "/" + this.Name.Value
-                       ``type`` = subscriptions.ArmValue
                        dependsOn = [ this.Topic.Value ]
                        properties =
                         {| defaultMessageTimeToLive = tryGetIso this.DefaultMessageTimeToLive
@@ -80,9 +80,9 @@ module Namespaces =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| apiVersion = "2017-04-01"
+                {| ``type`` = queues.Path
+                   apiVersion = queues.Version
                    name = this.Namespace.Value + "/" + this.Name.Value
-                   ``type`` = queues.ArmValue
                    dependsOn = [ this.Namespace.Value ]
                    properties =
                     {| lockDuration = tryGetIso this.LockDuration
@@ -107,9 +107,9 @@ module Namespaces =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| apiVersion = "2017-04-01"
+                {| ``type`` = topics.Path
+                   apiVersion = topics.Version
                    name = this.Namespace.Value + "/" + this.Name.Value
-                   ``type`` = topics.ArmValue
                    dependsOn = [ this.Namespace.Value ]
                    properties =
                        {| defaultMessageTimeToLive = tryGetIso this.DefaultMessageTimeToLive
@@ -137,8 +137,8 @@ type Namespace =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| apiVersion = "2017-04-01"
-               ``type`` = namespaces.ArmValue
+            {| ``type`` = namespaces.Path
+               apiVersion = namespaces.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                sku =

--- a/src/Farmer/Arm/SignalR.fs
+++ b/src/Farmer/Arm/SignalR.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.CoreTypes
 open Farmer.SignalR
 
-let signalR = ResourceType "Microsoft.SignalRService/signalR"
+let signalR = ResourceType ("Microsoft.SignalRService/signalR", "2018-10-01")
 
 type SignalR =
     { Name : ResourceName
@@ -17,8 +17,8 @@ type SignalR =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = signalR.ArmValue
-               apiVersion = "2018-10-01"
+            {| ``type`` = signalR.Path
+               apiVersion = signalR.Version
                name = this.Name.Value
                location = this.Location.ArmValue
                sku =

--- a/src/Farmer/Arm/SignalR.fs
+++ b/src/Farmer/Arm/SignalR.fs
@@ -17,23 +17,19 @@ type SignalR =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = signalR.Path
-               apiVersion = signalR.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               sku =
-                   {| name =
-                         match this.Sku with
-                         | Free -> "Free_F1"
-                         | Standard -> "Standard_S1"
-                      capacity =
-                          match this.Capacity with
-                          | Some c -> c.ToString()
-                          | None -> null |}
-               properties =
-                   {| cors =
-                          match this.AllowedOrigins with
-                          | [] -> null
-                          | aos -> box {| allowedOrigins = aos |} |}
-               tags = this.Tags
+            {| signalR.Create(this.Name, this.Location, tags = this.Tags) with
+                sku =
+                    {| name =
+                        match this.Sku with
+                        | Free -> "Free_F1"
+                        | Standard -> "Standard_S1"
+                       capacity =
+                        match this.Capacity with
+                        | Some c -> c.ToString()
+                        | None -> null |}
+                properties =
+                    {| cors =
+                        match this.AllowedOrigins with
+                        | [] -> null
+                        | aos -> box {| allowedOrigins = aos |} |}
             |} :> _

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -115,9 +115,7 @@ module Servers =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                   {| ``type`` = transparentDataEncryption.Path
-                      apiVersion = transparentDataEncryption.Version
-                      comments = "Transparent Data Encryption"
-                      name = this.Name.Value
-                      properties = {| status = string Enabled |}
-                      dependsOn = [ this.Database.Value ] |} :> _
+                   {| transparentDataEncryption.Create(this.Name, dependsOn = [ this.Database ]) with
+                        comments = "Transparent Data Encryption"
+                        properties = {| status = string Enabled |}
+                   |} :> _

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -6,11 +6,11 @@ open Farmer.CoreTypes
 open Farmer.Sql
 open System.Net
 
-let servers = ResourceType "Microsoft.Sql/servers"
-let elasticPools = ResourceType "Microsoft.Sql/servers/elasticPools"
-let firewallRules = ResourceType "Microsoft.Sql/servers/firewallrules"
-let databases = ResourceType "Microsoft.Sql/servers/databases"
-let transparentDataEncryption = ResourceType "Microsoft.Sql/servers/databases/transparentDataEncryption"
+let servers = ResourceType ("Microsoft.Sql/servers", "2019-06-01-preview")
+let elasticPools = ResourceType ("Microsoft.Sql/servers/elasticPools", "2017-10-01-preview")
+let firewallRules = ResourceType ("Microsoft.Sql/servers/firewallrules", "2014-04-01")
+let databases = ResourceType ("Microsoft.Sql/servers/databases", "2019-06-01-preview")
+let transparentDataEncryption = ResourceType ("Microsoft.Sql/servers/databases/transparentDataEncryption", "2014-04-01-preview")
 
 type DbKind = Standalone of DbPurchaseModel | Pool of ResourceName
 
@@ -24,9 +24,9 @@ type Server =
     interface IArmResource with
         member this.ResourceName = this.ServerName
         member this.JsonModel =
-            {| ``type`` = servers.ArmValue
+            {| ``type`` = servers.Path
+               apiVersion = servers.Version
                name = this.ServerName.Value
-               apiVersion = "2019-06-01-preview"
                location = this.Location.ArmValue
                tags =
                 this.Tags
@@ -48,7 +48,8 @@ module Servers =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = elasticPools.ArmValue
+                {| ``type`` = elasticPools.Path
+                   apiVersion = elasticPools.Version
                    name = this.Server.Value + "/" + this.Name.Value
                    properties =
                     {| maxSizeBytes = this.MaxSizeBytes |> Option.toNullable
@@ -57,7 +58,6 @@ module Servers =
                         | Some (min, max) -> box {| minCapacity = min; maxCapacity = max |}
                         | None -> null
                     |}
-                   apiVersion = "2017-10-01-preview"
                    location = this.Location.ArmValue
                    sku = {| name = this.Sku.Name; tier = this.Sku.Edition; size = string this.Sku.Capacity |}
                    dependsOn = [ this.Server.Value ] |} :> _
@@ -71,9 +71,9 @@ module Servers =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = firewallRules.ArmValue
+                {| ``type`` = firewallRules.Path
+                   apiVersion = firewallRules.Version
                    name = this.Server.Value + "/" + this.Name.Value
-                   apiVersion = "2014-04-01"
                    location = this.Location.ArmValue
                    properties =
                     {| endIpAddress = string this.Start
@@ -91,9 +91,9 @@ module Servers =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = databases.ArmValue
+                {| ``type`` = databases.Path
+                   apiVersion = databases.Version
                    name = this.Server.Value + "/" + this.Name.Value
-                   apiVersion = "2019-06-01-preview"
                    location = this.Location.ArmValue
                    tags = {| displayName = this.Name.Value |}
                    sku =
@@ -133,9 +133,9 @@ module Servers =
             interface IArmResource with
                 member this.ResourceName = this.Name
                 member this.JsonModel =
-                   {| ``type`` = transparentDataEncryption.ArmValue
+                   {| ``type`` = transparentDataEncryption.Path
+                      apiVersion = transparentDataEncryption.Version
                       comments = "Transparent Data Encryption"
                       name = this.Name.Value
-                      apiVersion = "2014-04-01-preview"
                       properties = {| status = string Enabled |}
                       dependsOn = [ this.Database.Value ] |} :> _

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -105,34 +105,31 @@ module ManagementPolicies =
         interface IArmResource with
             member this.ResourceName = this.ResourceName
             member this.JsonModel =
-                {| name = this.ResourceName.Value
-                   ``type`` = managementPolicies.Path
-                   apiVersion = managementPolicies.Version
-                   dependsOn = [ this.StorageAccount.Value ]
-                   properties =
-                    {| policy =
-                        {| rules = [
-                            for rule in this.Rules do
-                                {| enabled = true
-                                   name = rule.Name.Value
-                                   ``type`` = "Lifecycle"
-                                   definition =
-                                    {| actions =
-                                        {| baseBlob =
-                                            {| tierToCool = rule.CoolBlobAfter |> Option.map (fun days -> {| daysAfterModificationGreaterThan = days |} |> box) |> Option.toObj
-                                               tierToArchive = rule.ArchiveBlobAfter |> Option.map (fun days -> {| daysAfterModificationGreaterThan = days |} |> box) |> Option.toObj
-                                               delete = rule.DeleteBlobAfter |> Option.map (fun days -> {| daysAfterModificationGreaterThan = days |} |> box) |> Option.toObj |}
-                                           snapshot =
-                                            rule.DeleteSnapshotAfter
-                                            |> Option.map (fun days -> {| delete = {| daysAfterCreationGreaterThan = days |} |} |> box)
-                                            |> Option.toObj
-                                        |}
-                                       filters =
-                                        {| blobTypes = [ "blockBlob" ]
-                                           prefixMatch = rule.Filters |}
-                                    |}
-                                |}
-                            ]
-                        |}
-                    |}
+                {| managementPolicies.Create(this.ResourceName, dependsOn = [ this.StorageAccount ]) with
+                    properties =
+                     {| policy =
+                         {| rules = [
+                             for rule in this.Rules do
+                                 {| enabled = true
+                                    name = rule.Name.Value
+                                    ``type`` = "Lifecycle"
+                                    definition =
+                                     {| actions =
+                                         {| baseBlob =
+                                             {| tierToCool = rule.CoolBlobAfter |> Option.map (fun days -> {| daysAfterModificationGreaterThan = days |} |> box) |> Option.toObj
+                                                tierToArchive = rule.ArchiveBlobAfter |> Option.map (fun days -> {| daysAfterModificationGreaterThan = days |} |> box) |> Option.toObj
+                                                delete = rule.DeleteBlobAfter |> Option.map (fun days -> {| daysAfterModificationGreaterThan = days |} |> box) |> Option.toObj |}
+                                            snapshot =
+                                             rule.DeleteSnapshotAfter
+                                             |> Option.map (fun days -> {| delete = {| daysAfterCreationGreaterThan = days |} |} |> box)
+                                             |> Option.toObj
+                                         |}
+                                        filters =
+                                         {| blobTypes = [ "blockBlob" ]
+                                            prefixMatch = rule.Filters |}
+                                     |}
+                                 |}
+                             ]
+                         |}
+                     |}
                 |} :> _

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -4,13 +4,12 @@ module Farmer.Arm.Storage
 open Farmer
 open Farmer.Storage
 open Farmer.CoreTypes
-open System
 
-let storageAccounts = ResourceType "Microsoft.Storage/storageAccounts"
-let containers = ResourceType "Microsoft.Storage/storageAccounts/blobServices/containers"
-let fileShares = ResourceType "Microsoft.Storage/storageAccounts/fileServices/shares"
-let queues = ResourceType "Microsoft.Storage/storageAccounts/queueServices/queues"
-let managementPolicies = ResourceType "Microsoft.Storage/storageAccounts/managementPolicies"
+let storageAccounts = ResourceType ("Microsoft.Storage/storageAccounts", "2018-07-01")
+let containers = ResourceType ("Microsoft.Storage/storageAccounts/blobServices/containers", "2018-03-01-preview")
+let fileShares = ResourceType ("Microsoft.Storage/storageAccounts/fileServices/shares", "2019-06-01")
+let queues = ResourceType ("Microsoft.Storage/storageAccounts/queueServices/queues", "2019-06-01")
+let managementPolicies = ResourceType ("Microsoft.Storage/storageAccounts/managementPolicies", "2019-06-01")
 
 type StorageAccount =
     { Name : StorageAccountName
@@ -22,11 +21,11 @@ type StorageAccount =
     interface IArmResource with
         member this.ResourceName = this.Name.ResourceName
         member this.JsonModel =
-            {| ``type`` = storageAccounts.ArmValue
+            {| ``type`` = storageAccounts.Path
+               apiVersion = storageAccounts.Version
                sku = {| name = this.Sku.ArmValue |}
                kind = "StorageV2"
                name = this.Name.ResourceName.Value
-               apiVersion = "2018-07-01"
                location = this.Location.ArmValue
                properties =
                 match this.EnableHierarchicalNamespace with
@@ -52,8 +51,8 @@ module BlobServices =
         interface IArmResource with
             member this.ResourceName = this.Name.ResourceName
             member this.JsonModel =
-                {| ``type`` = containers.ArmValue
-                   apiVersion = "2018-03-01-preview"
+                {| ``type`` = containers.Path
+                   apiVersion = containers.Version
                    name = this.StorageAccount.Value + "/default/" + this.Name.ResourceName.Value
                    dependsOn = [ this.StorageAccount.Value ]
                    properties =
@@ -72,8 +71,8 @@ module FileShares =
         interface IArmResource with
             member this.ResourceName = this.Name.ResourceName
             member this.JsonModel =
-                {| ``type`` = fileShares.ArmValue
-                   apiVersion = "2019-06-01"
+                {| ``type`` = fileShares.Path
+                   apiVersion = fileShares.Version
                    name = this.StorageAccount.Value + "/default/" + this.Name.ResourceName.Value
                    properties = {| shareQuota = this.ShareQuota |> Option.defaultValue 5120<Gb> |}
                    dependsOn = [ this.StorageAccount.Value ]
@@ -87,9 +86,9 @@ module Queues =
             member this.ResourceName = this.Name.ResourceName
             member this.JsonModel =
                 {| name = this.StorageAccount.Value + "/default/" + this.Name.ResourceName.Value
-                   ``type`` = queues.ArmValue
+                   ``type`` = queues.Path
+                   apiVersion = queues.Version
                    dependsOn = [ this.StorageAccount.Value ]
-                   apiVersion = "2019-06-01"
                 |} :> _
 
 module ManagementPolicies =
@@ -107,8 +106,8 @@ module ManagementPolicies =
             member this.ResourceName = this.ResourceName
             member this.JsonModel =
                 {| name = this.ResourceName.Value
-                   ``type`` = managementPolicies.ArmValue
-                   apiVersion = "2019-06-01"
+                   ``type`` = managementPolicies.Path
+                   apiVersion = managementPolicies.Version
                    dependsOn = [ this.StorageAccount.Value ]
                    properties =
                     {| policy =

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -214,14 +214,9 @@ module Sites =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = sourceControls.Path
-                   apiVersion = sourceControls.Version
-                   name = this.Name.Value
-                   location = this.Location.ArmValue
-                   dependsOn = [ this.Website.Value ]
-                   properties =
-                    {| repoUrl = this.Repository.ToString()
-                       branch = this.Branch
-                       isManualIntegration = this.ContinuousIntegration.AsBoolean |> not
-                    |}
+                {| sourceControls.Create(this.Name, this.Location, [ this.Website ]) with
+                    properties =
+                        {| repoUrl = this.Repository.ToString()
+                           branch = this.Branch
+                           isManualIntegration = this.ContinuousIntegration.AsBoolean |> not |}
                 |} :> _

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -6,9 +6,9 @@ open Farmer.CoreTypes
 open Farmer.WebApp
 open System
 
-let serverFarms = ResourceType "Microsoft.Web/serverfarms"
-let sites = ResourceType "Microsoft.Web/sites"
-let sourceControls = ResourceType "Microsoft.Web/sites/sourcecontrols"
+let serverFarms = ResourceType ("Microsoft.Web/serverfarms", "2018-02-01")
+let sites = ResourceType ("Microsoft.Web/sites", "2016-08-01")
+let sourceControls = ResourceType ("Microsoft.Web/sites/sourcecontrols", "2019-08-01")
 
 type ServerFarm =
     { Name : ResourceName
@@ -43,7 +43,8 @@ type ServerFarm =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = serverFarms.ArmValue
+            {| ``type`` = serverFarms.Path
+               apiVersion = serverFarms.Version
                sku =
                    {| name =
                         match this.Sku with
@@ -69,7 +70,6 @@ type ServerFarm =
                       family = if this.IsDynamic then "Y" else null
                       capacity = if this.IsDynamic then 0 else this.WorkerCount |}
                name = this.Name.Value
-               apiVersion = "2018-02-01"
                location = this.Location.ArmValue
                properties =
                     {| name = this.Name.Value
@@ -163,9 +163,9 @@ type Site =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = sites.ArmValue
+            {| ``type`` = sites.Path
+               apiVersion = sites.Version
                name = this.Name.Value
-               apiVersion = "2016-08-01"
                location = this.Location.ArmValue
                dependsOn = this.Dependencies |> List.map(fun p -> p.Value)
                kind = this.Kind
@@ -214,8 +214,8 @@ module Sites =
         interface IArmResource with
             member this.ResourceName = this.Name
             member this.JsonModel =
-                {| ``type`` = sourceControls.ArmValue
-                   apiVersion = "2019-08-01"
+                {| ``type`` = sourceControls.Path
+                   apiVersion = sourceControls.Version
                    name = this.Name.Value
                    location = this.Location.ArmValue
                    dependsOn = [ this.Website.Value ]

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -43,9 +43,8 @@ type ServerFarm =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = serverFarms.Path
-               apiVersion = serverFarms.Version
-               sku =
+            {| serverFarms.Create(this.Name, this.Location, tags = this.Tags) with
+                 sku =
                    {| name =
                         match this.Sku with
                         | Free ->
@@ -69,15 +68,12 @@ type ServerFarm =
                         | Serverless -> "Y1"
                       family = if this.IsDynamic then "Y" else null
                       capacity = if this.IsDynamic then 0 else this.WorkerCount |}
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               properties =
-                    {| name = this.Name.Value
-                       computeMode = if this.IsDynamic then "Dynamic" else null
-                       perSiteScaling = if this.IsDynamic then Nullable() else Nullable false
-                       reserved = this.Reserved |}
-               kind = this.Kind |> Option.toObj
-               tags = this.Tags
+                 properties =
+                      {| name = this.Name.Value
+                         computeMode = if this.IsDynamic then "Dynamic" else null
+                         perSiteScaling = if this.IsDynamic then Nullable() else Nullable false
+                         reserved = this.Reserved |}
+                 kind = this.Kind |> Option.toObj
             |} :> _
 
 module ZipDeploy =
@@ -163,44 +159,39 @@ type Site =
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =
-            {| ``type`` = sites.Path
-               apiVersion = sites.Version
-               name = this.Name.Value
-               location = this.Location.ArmValue
-               dependsOn = this.Dependencies |> List.map(fun p -> p.Value)
-               kind = this.Kind
-               identity =
-                 match this.Identity with
-                 | Some Enabled -> box {| ``type`` = "SystemAssigned" |}
-                 | Some Disabled -> box {| ``type`` = "None" |}
-                 | None -> null
-               tags = this.Tags
-               properties =
-                    {| serverFarmId = this.ServicePlan.Value
-                       httpsOnly = this.HTTPSOnly
-                       clientAffinityEnabled = match this.ClientAffinityEnabled with Some v -> box v | None -> null
-                       siteConfig =
-                        {| alwaysOn = this.AlwaysOn
-                           appSettings = this.AppSettings |> Map.toList |> List.map(fun (k,v) -> {| name = k; value = v.Value |})
-                           connectionStrings = this.ConnectionStrings |> Map.toList |> List.map(fun (k,(v, t)) -> {| name = k; connectionString = v.Value; ``type`` = t.ToString() |})
-                           linuxFxVersion = this.LinuxFxVersion |> Option.toObj
-                           appCommandLine = this.AppCommandLine |> Option.toObj
-                           netFrameworkVersion = this.NetFrameworkVersion |> Option.toObj
-                           javaVersion = this.JavaVersion |> Option.toObj
-                           javaContainer = this.JavaContainer |> Option.toObj
-                           javaContainerVersion = this.JavaContainerVersion |> Option.toObj
-                           phpVersion = this.PhpVersion |> Option.toObj
-                           pythonVersion = this.PythonVersion |> Option.toObj
-                           http20Enabled = this.HTTP20Enabled |> Option.toNullable
-                           webSocketsEnabled = this.WebSocketsEnabled |> Option.toNullable
-                           metadata = this.Metadata |> List.map(fun (k,v) -> {| name = k; value = v |})
-                           cors =
-                            match this.Cors with
-                            | None -> null
-                            | Some AllOrigins -> box {| allowedOrigins = [ "*" ] |}
-                            | Some (SpecificOrigins origins) -> box {| allowedOrigins = origins |}
-                        |}
-                    |}
+            {| sites.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
+                 kind = this.Kind
+                 identity =
+                   match this.Identity with
+                   | Some Enabled -> box {| ``type`` = "SystemAssigned" |}
+                   | Some Disabled -> box {| ``type`` = "None" |}
+                   | None -> null
+                 properties =
+                      {| serverFarmId = this.ServicePlan.Value
+                         httpsOnly = this.HTTPSOnly
+                         clientAffinityEnabled = match this.ClientAffinityEnabled with Some v -> box v | None -> null
+                         siteConfig =
+                          {| alwaysOn = this.AlwaysOn
+                             appSettings = this.AppSettings |> Map.toList |> List.map(fun (k,v) -> {| name = k; value = v.Value |})
+                             connectionStrings = this.ConnectionStrings |> Map.toList |> List.map(fun (k,(v, t)) -> {| name = k; connectionString = v.Value; ``type`` = t.ToString() |})
+                             linuxFxVersion = this.LinuxFxVersion |> Option.toObj
+                             appCommandLine = this.AppCommandLine |> Option.toObj
+                             netFrameworkVersion = this.NetFrameworkVersion |> Option.toObj
+                             javaVersion = this.JavaVersion |> Option.toObj
+                             javaContainer = this.JavaContainer |> Option.toObj
+                             javaContainerVersion = this.JavaContainerVersion |> Option.toObj
+                             phpVersion = this.PhpVersion |> Option.toObj
+                             pythonVersion = this.PythonVersion |> Option.toObj
+                             http20Enabled = this.HTTP20Enabled |> Option.toNullable
+                             webSocketsEnabled = this.WebSocketsEnabled |> Option.toNullable
+                             metadata = this.Metadata |> List.map(fun (k,v) -> {| name = k; value = v |})
+                             cors =
+                              match this.Cors with
+                              | None -> null
+                              | Some AllOrigins -> box {| allowedOrigins = [ "*" ] |}
+                              | Some (SpecificOrigins origins) -> box {| allowedOrigins = origins |}
+                          |}
+                      |}
             |} :> _
 
 module Sites =

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -6,12 +6,12 @@ open Farmer.CoreTypes
 open Farmer.Arm.Insights
 
 type AppInsights =
-    static member getInstrumentationKey (resourceId:ArmExpression) =
+    static member getInstrumentationKey (name, ?resourceGroup) =
+        let resourceId = ArmExpression.resourceId(components, name, ?group = resourceGroup)
         ArmExpression
             .reference(components, resourceId)
             .Map(fun r -> r + ".InstrumentationKey")
-    static member resourceId (name:ResourceName) = ArmExpression.resourceId(components, name)
-    static member resourceId (name, group) = ArmExpression.resourceId(components, name, group)
+    static member getInstrumentationKey (name, ?resourceGroup) = AppInsights.getInstrumentationKey(ResourceName name, ?resourceGroup = resourceGroup)
 
 type AppInsightsConfig =
     { Name : ResourceName
@@ -19,7 +19,7 @@ type AppInsightsConfig =
       SamplingPercentage : int
       Tags : Map<string,string> }
     /// Gets the ARM expression path to the instrumentation key of this App Insights instance.
-    member this.InstrumentationKey = AppInsights.getInstrumentationKey(ArmExpression.resourceId(components, this.Name))
+    member this.InstrumentationKey = AppInsights.getInstrumentationKey this.Name
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -6,16 +6,12 @@ open Farmer.CoreTypes
 open Farmer.Arm.Insights
 
 type AppInsights =
-    static member GetInstrumentationKey (name:ResourceName, ?resourceGroup:string) =
-        let aiResourceId =
-            match resourceGroup with
-            | Some resourceGroup -> ArmExpression.resourceId(components, name, resourceGroup)
-            | None -> ArmExpression.resourceId(components, name)
-
+    static member getInstrumentationKey (resourceId:ArmExpression) =
         ArmExpression
-            .reference(components, aiResourceId)
+            .reference(components, resourceId)
             .Map(fun r -> r + ".InstrumentationKey")
-    static member GetInstrumentationKey (name, resourceGroup) = AppInsights.GetInstrumentationKey(ResourceName name, resourceGroup)
+    static member resourceId (name:ResourceName) = ArmExpression.resourceId(components, name)
+    static member resourceId (name, group) = ArmExpression.resourceId(components, name, group)
 
 type AppInsightsConfig =
     { Name : ResourceName
@@ -23,7 +19,7 @@ type AppInsightsConfig =
       SamplingPercentage : int
       Tags : Map<string,string> }
     /// Gets the ARM expression path to the instrumentation key of this App Insights instance.
-    member this.InstrumentationKey = AppInsights.GetInstrumentationKey this.Name
+    member this.InstrumentationKey = AppInsights.getInstrumentationKey(ArmExpression.resourceId(components, this.Name))
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -15,6 +15,7 @@ type AppInsights =
         ArmExpression
             .reference(components, aiResourceId)
             .Map(fun r -> r + ".InstrumentationKey")
+    static member GetInstrumentationKey (name, resourceGroup) = AppInsights.GetInstrumentationKey(ResourceName name, resourceGroup)
 
 type AppInsightsConfig =
     { Name : ResourceName

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -8,21 +8,21 @@ open Farmer.Arm.Network
 
 type volume_mount =
     static member empty_dir volumeName =
-        volumeName, {| Volume = Volume.EmptyDirectory |}
-    static member azureFile volumeName  shareName storageAccountName =
-        volumeName, {| Volume = Volume.AzureFileShare (shareName, storageAccountName) |}
+        volumeName, Volume.EmptyDirectory
+    static member azureFile volumeName shareName storageAccountName =
+        volumeName, Volume.AzureFileShare (shareName, storageAccountName)
     static member git_repo volumeName repository =
-        volumeName, {| Volume = Volume.GitRepo (repository, None, None) |}
+        volumeName, Volume.GitRepo (repository, None, None)
     static member git_repo_directory volumeName  repository directory =
-        volumeName, {| Volume = Volume.GitRepo (repository, Some directory, None) |}
+        volumeName, Volume.GitRepo (repository, Some directory, None)
     static member git_repo_directory_revision volumeName  repository directory revision =
-        volumeName, {| Volume = Volume.GitRepo (repository, Some directory, Some revision) |}
+        volumeName, Volume.GitRepo (repository, Some directory, Some revision)
     static member secret volumeName  (file:string) (secret:byte array) =
-        volumeName, {| Volume = Volume.Secret [ SecretFile (file, secret) ] |}
+        volumeName, Volume.Secret [ SecretFile (file, secret) ]
     static member secrets volumeName  (secrets:(string * byte array) list) =
-        volumeName, {| Volume = secrets |> List.map SecretFile |> Volume.Secret |}
+        volumeName, secrets |> List.map SecretFile |> Volume.Secret
     static member secret_string volumeName  (file:string) (secret:string) =
-        volumeName, {| Volume = Volume.Secret [ SecretFile (file, secret |> System.Text.Encoding.UTF8.GetBytes) ] |}
+        volumeName, Volume.Secret [ SecretFile (file, secret |> System.Text.Encoding.UTF8.GetBytes) ]
 
 /// Represents configuration for a single Container.
 type ContainerInstanceConfig =
@@ -55,7 +55,7 @@ type ContainerGroupConfig =
       /// The instances in this container group.
       Instances : ContainerInstanceConfig list
       /// Volumes to mount on the container group.
-      Volumes : Map<string, {| Volume:Volume |}>
+      Volumes : Map<string, Volume>
       Tags: Map<string,string>  }
     interface IBuilder with
         member this.DependencyName = this.Name
@@ -140,8 +140,8 @@ type ContainerGroupBuilder() =
         let updatedVolumes = state.Volumes |> Map.fold (fun current key vol -> Map.add key vol current) newVolumes
         { state with Volumes = updatedVolumes }
     [<CustomOperation "add_tags">]
-    member _.Tags(state:ContainerGroupConfig, pairs) = 
-        { state with 
+    member _.Tags(state:ContainerGroupConfig, pairs) =
+        { state with
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
     [<CustomOperation "add_tag">]
     member this.Tag(state:ContainerGroupConfig, key, value) = this.Tags(state, [ (key,value) ])
@@ -235,8 +235,8 @@ type NetworkProfileBuilder() =
     [<CustomOperation "vnet">]
     member __.VirtualNetwork(state:NetworkProfileConfig, vnet) = { state with VirtualNetwork = ResourceName vnet }
     [<CustomOperation "add_tags">]
-    member _.Tags(state:NetworkProfileConfig, pairs) = 
-        { state with 
+    member _.Tags(state:NetworkProfileConfig, pairs) =
+        { state with
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
     [<CustomOperation "add_tag">]
     member this.Tag(state:NetworkProfileConfig, key, value) = this.Tags(state, [ (key,value) ])

--- a/src/Farmer/Builders/Builders.EventGrid.fs
+++ b/src/Farmer/Builders/Builders.EventGrid.fs
@@ -124,7 +124,7 @@ type EventGridBuilder() =
         }
     member _.Yield _ =
         { TopicName = ResourceName.Empty
-          Source = (ResourceName.Empty, TopicType(Farmer.CoreTypes.ResourceType "", ""))
+          Source = ResourceName.Empty, TopicType(CoreTypes.ResourceType("", ""), "")
           Subscriptions = []
           Tags = Map.empty  }
     [<CustomOperation "topic_name">]

--- a/src/Farmer/Builders/Builders.EventHub.fs
+++ b/src/Farmer/Builders/Builders.EventHub.fs
@@ -21,7 +21,7 @@ type EventHubConfig =
       KafkaEnabled : bool option
       MessageRetentionInDays : int option
       Partitions : int
-      ConsumerGroups : string Set
+      ConsumerGroups : ResourceName Set
       CaptureDestination : CaptureDestination option
       AuthorizationRules : Map<ResourceName, AuthorizationRuleRight Set>
       Dependencies : ResourceName list
@@ -77,7 +77,8 @@ type EventHubConfig =
 
             // Consumer groups
             for consumerGroup in this.ConsumerGroups do
-              { Name = eventHubName.Map(fun hubName -> sprintf "%s/%s" hubName consumerGroup)
+              { ConsumerGroupName = consumerGroup
+                EventHub = eventHubName
                 Location = location
                 Dependencies = [
                     eventHubNamespaceName
@@ -107,7 +108,7 @@ type EventHubBuilder() =
           MessageRetentionInDays = None
           Partitions = 1
           CaptureDestination = None
-          ConsumerGroups = Set [ "$Default" ]
+          ConsumerGroups = Set [ ResourceName "$Default" ]
           AuthorizationRules = Map.empty
           Dependencies = []
           Tags = Map.empty }
@@ -141,7 +142,7 @@ type EventHubBuilder() =
     [<CustomOperation "partitions">]
     member __.Partitions(state:EventHubConfig, partitions) = { state with Partitions = partitions }
     [<CustomOperation "add_consumer_group">]
-    member __.AddConsumerGroup(state:EventHubConfig, name) = { state with ConsumerGroups = state.ConsumerGroups.Add name }
+    member __.AddConsumerGroup(state:EventHubConfig, name) = { state with ConsumerGroups = state.ConsumerGroups.Add (ResourceName name) }
     [<CustomOperation "add_authorization_rule">]
     member __.AddAuthorizationRule(state:EventHubConfig, name, rights) = { state with AuthorizationRules = state.AuthorizationRules.Add(ResourceName name, Set rights) }
     [<CustomOperation "capture_to_storage">]

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -38,7 +38,7 @@ type FunctionsConfig =
     /// Gets the ARM expression path to the storage account key of this functions app.
     member this.StorageAccountKey = StorageAccount.getConnectionString this.StorageAccountName
     /// Gets the ARM expression path to the app insights key of this functions app, if it exists.
-    member this.AppInsightsKey = this.AppInsightsName |> Option.map (AppInsights.resourceId >> AppInsights.getInstrumentationKey)
+    member this.AppInsightsKey = this.AppInsightsName |> Option.map AppInsights.getInstrumentationKey
     /// Gets the default key for the functions site
     member this.DefaultKey =
         sprintf "listkeys(concat(resourceId('Microsoft.Web/sites', '%s'), '/host/default/'),'2016-08-01').functionKeys.default" this.Name.Value
@@ -50,7 +50,7 @@ type FunctionsConfig =
     /// Gets the Service Plan name for this functions app.
     member this.ServicePlanName = this.ServicePlan.CreateResourceName this
     /// Gets the App Insights name for this functions app, if it exists.
-    member this.AppInsightsName = this.AppInsights |> Option.map (fun ai -> ai.CreateResourceName this)
+    member this.AppInsightsName : ResourceName option = this.AppInsights |> Option.map (fun ai -> ai.CreateResourceName this)
     /// Gets the Storage Account name for this functions app.
     member this.StorageAccountName : Storage.StorageAccountName = this.StorageAccount.CreateResourceName this |> Storage.StorageAccountName.Create |> Result.get
     interface IBuilder with

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -36,9 +36,9 @@ type FunctionsConfig =
     /// Gets the ARM expression path to the publishing password of this functions app.
     member this.PublishingPassword = publishingPassword this.Name
     /// Gets the ARM expression path to the storage account key of this functions app.
-    member this.StorageAccountKey = StorageAccount.GetConnectionString this.StorageAccountName
+    member this.StorageAccountKey = StorageAccount.getConnectionString this.StorageAccountName
     /// Gets the ARM expression path to the app insights key of this functions app, if it exists.
-    member this.AppInsightsKey = this.AppInsightsName |> Option.map AppInsights.GetInstrumentationKey
+    member this.AppInsightsKey = this.AppInsightsName |> Option.map (AppInsights.resourceId >> AppInsights.getInstrumentationKey)
     /// Gets the default key for the functions site
     member this.DefaultKey =
         sprintf "listkeys(concat(resourceId('Microsoft.Web/sites', '%s'), '/host/default/'),'2016-08-01').functionKeys.default" this.Name.Value
@@ -66,15 +66,15 @@ type FunctionsConfig =
                 "FUNCTIONS_WORKER_RUNTIME", (string this.Runtime).ToLower()
                 "WEBSITE_NODE_DEFAULT_VERSION", "10.14.1"
                 "FUNCTIONS_EXTENSION_VERSION", match this.ExtensionVersion with V1 -> "~1" | V2 -> "~2" | V3 -> "~3"
-                "AzureWebJobsStorage", StorageAccount.GetConnectionString this.StorageAccountName |> ArmExpression.Eval
-                "AzureWebJobsDashboard", StorageAccount.GetConnectionString this.StorageAccountName |> ArmExpression.Eval
+                "AzureWebJobsStorage", StorageAccount.getConnectionString this.StorageAccountName |> ArmExpression.Eval
+                "AzureWebJobsDashboard", StorageAccount.getConnectionString this.StorageAccountName |> ArmExpression.Eval
 
                 match this.AppInsightsKey with
                 | Some key -> "APPINSIGHTS_INSTRUMENTATIONKEY", key |> ArmExpression.Eval
                 | None -> ()
 
                 if this.OperatingSystem = Windows then
-                    "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", StorageAccount.GetConnectionString this.StorageAccountName |> ArmExpression.Eval
+                    "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", StorageAccount.getConnectionString this.StorageAccountName |> ArmExpression.Eval
                     "WEBSITE_CONTENTSHARE", this.Name.Value.ToLower()
               ]
               |> List.map Setting.AsLiteral

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -38,7 +38,7 @@ type FunctionsConfig =
     /// Gets the ARM expression path to the storage account key of this functions app.
     member this.StorageAccountKey = Storage.buildKey this.StorageAccountName
     /// Gets the ARM expression path to the app insights key of this functions app, if it exists.
-    member this.AppInsightsKey = this.AppInsightsName |> Option.map instrumentationKey
+    member this.AppInsightsKey = this.AppInsightsName |> Option.map AppInsights.GetInstrumentationKey
     /// Gets the default key for the functions site
     member this.DefaultKey =
         sprintf "listkeys(concat(resourceId('Microsoft.Web/sites', '%s'), '/host/default/'),'2016-08-01').functionKeys.default" this.Name.Value

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -10,7 +10,7 @@ open FileShares
 
 type StorageAccount =
     /// Gets an ARM Expression connection string for any Storage Account.
-    static member GetConnectionString (name:string, ?resourceGroup:string) =
+    static member getConnectionString (name:string, ?resourceGroup:string) =
         let resourcePath =
             match resourceGroup with
             | Some resourceGroup -> ArmExpression.resourceId(storageAccounts, ResourceName name, resourceGroup).Value
@@ -21,8 +21,8 @@ type StorageAccount =
                 resourcePath
         |> ArmExpression.create
     /// Gets an ARM Expression connection string for any Storage Account.
-    static member GetConnectionString (name:StorageAccountName) =
-        StorageAccount.GetConnectionString(name.ResourceName.Value)
+    static member getConnectionString (name:StorageAccountName) =
+        StorageAccount.getConnectionString(name.ResourceName.Value)
 
 type StoragePolicy =
     { CoolBlobAfter : int<Days> option
@@ -51,7 +51,7 @@ type StorageAccountConfig =
       /// Tags to apply to the storage account
       Tags: Map<string,string> }
     /// Gets the ARM expression path to the key of this storage account.
-    member this.Key = StorageAccount.GetConnectionString this.Name
+    member this.Key = StorageAccount.getConnectionString this.Name
     /// Gets the Primary endpoint for static website (if enabled)
     member this.WebsitePrimaryEndpoint = sprintf "https://%s.z6.web.core.windows.net" this.Name.ResourceName.Value
     member this.Endpoint = sprintf "%s.blob.core.windows.net" this.Name.ResourceName.Value

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -10,19 +10,19 @@ open FileShares
 
 type StorageAccount =
     /// Gets an ARM Expression connection string for any Storage Account.
-    static member GetConnectionString (name:StorageAccountName, ?resourceGroup:string) =
-        let fullyQualified =
+    static member GetConnectionString (name:string, ?resourceGroup:string) =
+        let resourcePath =
             match resourceGroup with
-            | Some resourceGroup -> ArmExpression.resourceId(storageAccounts, name.ResourceName, resourceGroup).Value
-            | None -> sprintf "'%s'" name.ResourceName.Value
+            | Some resourceGroup -> ArmExpression.resourceId(storageAccounts, ResourceName name, resourceGroup).Value
+            | None -> ArmExpression.resourceId(storageAccounts, ResourceName name).Value
         sprintf
             "concat('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=', listKeys(%s, '2017-10-01').keys[0].value)"
-                name.ResourceName.Value
-                fullyQualified
+                name
+                resourcePath
         |> ArmExpression.create
     /// Gets an ARM Expression connection string for any Storage Account.
-    static member GetConnectionString (name:string, resourceGroup:string) =
-        StorageAccount.GetConnectionString(StorageAccountName.Create(name).OkValue, resourceGroup)
+    static member GetConnectionString (name:StorageAccountName) =
+        StorageAccount.GetConnectionString(name.ResourceName.Value)
 
 type StoragePolicy =
     { CoolBlobAfter : int<Days> option

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -21,11 +21,8 @@ type StorageAccount =
                 fullyQualified
         |> ArmExpression.create
     /// Gets an ARM Expression connection string for any Storage Account.
-    static member GetConnectionString (name:string, ?resourceGroup:string) =
-        let name = StorageAccountName.Create(name).OkValue
-        match resourceGroup with
-        | Some resourceGroup -> StorageAccount.GetConnectionString(name, resourceGroup)
-        | None -> StorageAccount.GetConnectionString(name)
+    static member GetConnectionString (name:string, resourceGroup:string) =
+        StorageAccount.GetConnectionString(StorageAccountName.Create(name).OkValue, resourceGroup)
 
 type StoragePolicy =
     { CoolBlobAfter : int<Days> option

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -10,19 +10,16 @@ open FileShares
 
 type StorageAccount =
     /// Gets an ARM Expression connection string for any Storage Account.
-    static member getConnectionString (name:string, ?resourceGroup:string) =
-        let resourcePath =
-            match resourceGroup with
-            | Some resourceGroup -> ArmExpression.resourceId(storageAccounts, ResourceName name, resourceGroup).Value
-            | None -> ArmExpression.resourceId(storageAccounts, ResourceName name).Value
+    static member getConnectionString (name:StorageAccountName, ?resourceGroup:string) =
+        let resourcePath = ArmExpression.resourceId(storageAccounts, name.ResourceName, ?group = resourceGroup).Value
         sprintf
             "concat('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=', listKeys(%s, '2017-10-01').keys[0].value)"
-                name
-                resourcePath
+            name.ResourceName.Value
+            resourcePath
         |> ArmExpression.create
     /// Gets an ARM Expression connection string for any Storage Account.
-    static member getConnectionString (name:StorageAccountName) =
-        StorageAccount.getConnectionString(name.ResourceName.Value)
+    static member getConnectionString (name, ?resourceGroup) =
+        StorageAccount.getConnectionString(StorageAccountName.Create(ResourceName name).OkValue, ?resourceGroup = resourceGroup)
 
 type StoragePolicy =
     { CoolBlobAfter : int<Days> option

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -133,7 +133,7 @@ type WebAppConfig =
 
                     match this.OperatingSystem, this.AppInsights with
                     | Windows, Some resource ->
-                        "APPINSIGHTS_INSTRUMENTATIONKEY", instrumentationKey (resource.CreateResourceName this) |> ArmExpression.Eval
+                        "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.GetInstrumentationKey (resource.CreateResourceName this) |> ArmExpression.Eval
                         "APPINSIGHTS_PROFILERFEATURE_VERSION", "1.0.0"
                         "APPINSIGHTS_SNAPSHOTFEATURE_VERSION", "1.0.0"
                         "ApplicationInsightsAgent_EXTENSION_VERSION", "~2"

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -133,7 +133,7 @@ type WebAppConfig =
 
                     match this.OperatingSystem, this.AppInsights with
                     | Windows, Some resource ->
-                        "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.GetInstrumentationKey (resource.CreateResourceName this) |> ArmExpression.Eval
+                        "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.resourceId(resource.CreateResourceName this) |> AppInsights.getInstrumentationKey |> ArmExpression.Eval
                         "APPINSIGHTS_PROFILERFEATURE_VERSION", "1.0.0"
                         "APPINSIGHTS_SNAPSHOTFEATURE_VERSION", "1.0.0"
                         "ApplicationInsightsAgent_EXTENSION_VERSION", "~2"

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -133,7 +133,7 @@ type WebAppConfig =
 
                     match this.OperatingSystem, this.AppInsights with
                     | Windows, Some resource ->
-                        "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.resourceId(resource.CreateResourceName this) |> AppInsights.getInstrumentationKey |> ArmExpression.Eval
+                        "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.getInstrumentationKey(resource.CreateResourceName this).Eval()
                         "APPINSIGHTS_PROFILERFEATURE_VERSION", "1.0.0"
                         "APPINSIGHTS_SNAPSHOTFEATURE_VERSION", "1.0.0"
                         "ApplicationInsightsAgent_EXTENSION_VERSION", "~2"

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -52,6 +52,7 @@ module LocationExtensions =
         static member GermanyWestCentral = Location "GermanyWestCentral"
         static member NorwayWest = Location "NorwayWest"
         static member NorwayEast = Location "NorwayEast"
+        static member Global = Location "global"
 
 type OS = Windows | Linux
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -12,8 +12,8 @@ type ResourceName =
         | r when r = ResourceName.Empty -> ResourceName fallbackValue
         | r -> r
     member this.Map mapper = match this with ResourceName r -> ResourceName (mapper r)
-    static member (+) (a:ResourceName, b) = ResourceName(a.Value + b)
-    static member (+) (a:ResourceName, b:ResourceName) = ResourceName(a.Value + "/" + b.Value)
+    static member (+) (a:ResourceName, b) = ResourceName(a.Value + "/" + b)
+    static member (+) (a:ResourceName, b:ResourceName) = a + b.Value
 
 type Location =
     | Location of string

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -41,8 +41,8 @@ open System
 type ResourceType =
     | ResourceType of path:string * version:string
     /// Returns the ARM resource type string value.
-    member this.Path = match this with ResourceType (p, _) -> p
-    member this.Version = match this with ResourceType (_, v) -> v
+    member this.Type = match this with ResourceType (p, _) -> p
+    member this.ApiVersion = match this with ResourceType (_, v) -> v
     member this.Create(name:ResourceName, ?location:Location, ?dependsOn:ResourceName list, ?tags:Map<string,string>) =
         match this with
         ResourceType (path, version) ->
@@ -76,18 +76,18 @@ type ArmExpression =
     /// Builds a resourceId ARM expression from the parts of a resource ID.
     static member resourceId (resourceType:ResourceType, name:ResourceName, ?group:string, ?subscriptionId:string) =
         match name, group, subscriptionId with
-        | name, Some group, Some sub -> sprintf "resourceId('%s', '%s', '%s', '%s')" sub group resourceType.Path name.Value
-        | name, Some group, None -> sprintf "resourceId('%s', '%s', '%s')" group resourceType.Path name.Value
-        | name, _, _ -> sprintf "resourceId('%s', '%s')" resourceType.Path name.Value
+        | name, Some group, Some sub -> sprintf "resourceId('%s', '%s', '%s', '%s')" sub group resourceType.Type name.Value
+        | name, Some group, None -> sprintf "resourceId('%s', '%s', '%s')" group resourceType.Type name.Value
+        | name, _, _ -> sprintf "resourceId('%s', '%s')" resourceType.Type name.Value
         |> ArmExpression.create
     static member resourceId (resourceType:ResourceType, [<ParamArray>] resourceSegments:ResourceName []) =
         sprintf
             "resourceId('%s', %s)"
-            resourceType.Path
+            resourceType.Type
             (resourceSegments |> Array.map (fun r -> sprintf "'%s'" r.Value) |> String.concat ", ")
         |> ArmExpression.create
     static member reference (resourceType:ResourceType, resourceId:ArmExpression) =
-        sprintf "reference(%s, '%s')" resourceId.Value resourceType.Version
+        sprintf "reference(%s, '%s')" resourceId.Value resourceType.ApiVersion
         |> ArmExpression.create
 
 /// A secure parameter to be captured in an ARM template.

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -36,12 +36,17 @@ let tests = testList "Cosmos" [
         Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" (db.SecondaryConnectionString.Eval()) "Secondary Connection String is incorrect"
     }
     test "Correctly serializes to JSON" {
-        let t = arm {
-            add_resource (cosmosDb { name "test" })
-        }
+        let t = arm { add_resource (cosmosDb { name "test" }) }
 
         t.Template
         |> Writer.toJson
         |> ignore
+    }
+    test "Creates connection string and keys with resource groups" {
+        let conn = CosmosDb.getConnectionString("db", PrimaryConnectionString, "group").Eval()
+        let key = CosmosDb.getKey("db", PrimaryKey, ReadWrite, "group").Eval()
+
+        Expect.equal "[listKeys(resourceId('group', 'Microsoft.DocumentDb/databaseAccounts', 'db'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" key "Primary Key is incorrect"
+        Expect.equal "[listConnectionStrings(resourceId('group', 'Microsoft.DocumentDb/databaseAccounts', 'db'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" conn "Primary Connection String is incorrect"
     }
 ]

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -27,13 +27,13 @@ let tests = testList "Cosmos" [
     }
     test "DB properties are correctly evaluated" {
         let db = cosmosDb { name "test" }
-        Expect.equal "[reference(concat('Microsoft.DocumentDb/databaseAccounts/', 'test-account')).documentEndpoint]" (db.Endpoint.Eval()) "Endpoint is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryMasterKey]" (db.PrimaryKey.Eval()) "Primary Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).secondaryMasterKey]" (db.SecondaryKey.Eval()) "Secondary Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).primaryReadonlyMasterKey]" (db.PrimaryReadonlyKey.Eval()) "Primary Readonly Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).secondaryReadonlyMasterKey]" (db.SecondaryReadonlyKey.Eval()) "Secondary Readonly Key is incorrect"
-        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" (db.PrimaryConnectionString.Eval()) "Primary Connection String is incorrect"
-        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDB','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" (db.SecondaryConnectionString.Eval()) "Secondary Connection String is incorrect"
+        Expect.equal "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2020-03-01').documentEndpoint]" (db.Endpoint.Eval()) "Endpoint is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" (db.PrimaryKey.Eval()) "Primary Key is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryMasterKey]" (db.SecondaryKey.Eval()) "Secondary Key is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryreadonlyMasterKey]" (db.PrimaryReadonlyKey.Eval()) "Primary Readonly Key is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryreadonlyMasterKey]" (db.SecondaryReadonlyKey.Eval()) "Secondary Readonly Key is incorrect"
+        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" (db.PrimaryConnectionString.Eval()) "Primary Connection String is incorrect"
+        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" (db.SecondaryConnectionString.Eval()) "Secondary Connection String is incorrect"
     }
     test "Correctly serializes to JSON" {
         let t = arm {

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -133,9 +133,9 @@ let tests = testList "Storage Tests" [
         Expect.equal (rule.Definition.Filters.PrefixMatch |> Seq.toList) [ "foo/bar" ] "incorrect filter"
     }
     test "Creates connection strings correctly" {
-        let strongConn = StorageAccount.GetConnectionString (StorageAccountName.Create("account").OkValue)
-        let simpleConn = StorageAccount.GetConnectionString("account")
-        let rgConn = StorageAccount.GetConnectionString("account", "rg")
+        let strongConn = StorageAccount.getConnectionString (StorageAccountName.Create("account").OkValue)
+        let simpleConn = StorageAccount.getConnectionString("account")
+        let rgConn = StorageAccount.getConnectionString("account", "rg")
 
         Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" strongConn.Value "Strong connection string"
         Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" simpleConn.Value "Simple connection string"

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -134,11 +134,13 @@ let tests = testList "Storage Tests" [
     }
     test "Creates connection strings correctly" {
         let strongConn = StorageAccount.getConnectionString (StorageAccountName.Create("account").OkValue)
-        let simpleConn = StorageAccount.getConnectionString("account")
-        let rgConn = StorageAccount.getConnectionString("account", "rg")
+        let rgConn = StorageAccount.getConnectionString(StorageAccountName.Create("account").OkValue, "rg")
 
         Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" strongConn.Value "Strong connection string"
-        Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" simpleConn.Value "Simple connection string"
         Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('rg', 'Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" rgConn.Value "Complex connection string"
+    }
+
+    test "Validates Storage Connection from string" {
+        Expect.throws (fun _ -> StorageAccount.getConnectionString "Ac3294*()FS" |> ignore) "Should throw."
     }
 ]

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -133,13 +133,12 @@ let tests = testList "Storage Tests" [
         Expect.equal (rule.Definition.Filters.PrefixMatch |> Seq.toList) [ "foo/bar" ] "incorrect filter"
     }
     test "Creates connection strings correctly" {
-        let simpleConn = StorageAccount.GetConnectionString (StorageAccountName.Create("account").OkValue)
+        let strongConn = StorageAccount.GetConnectionString (StorageAccountName.Create("account").OkValue)
+        let simpleConn = StorageAccount.GetConnectionString("account")
         let rgConn = StorageAccount.GetConnectionString("account", "rg")
 
-        Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys('account', '2017-10-01').keys[0].value)" simpleConn.Value "Simple connection string"
+        Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" strongConn.Value "Strong connection string"
+        Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" simpleConn.Value "Simple connection string"
         Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('rg', 'Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" rgConn.Value "Complex connection string"
-    }
-    test "Ensures Storage Account Names are valid" {
-        Expect.throws (fun _ -> StorageAccount.GetConnectionString("IFDJI$*(£", "") |> ignore) "Did not validate"
     }
 ]

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -133,13 +133,13 @@ let tests = testList "Storage Tests" [
         Expect.equal (rule.Definition.Filters.PrefixMatch |> Seq.toList) [ "foo/bar" ] "incorrect filter"
     }
     test "Creates connection strings correctly" {
-        let simpleConn = StorageAccount.GetConnectionString "account"
+        let simpleConn = StorageAccount.GetConnectionString (StorageAccountName.Create("account").OkValue)
         let rgConn = StorageAccount.GetConnectionString("account", "rg")
 
         Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys('account', '2017-10-01').keys[0].value)" simpleConn.Value "Simple connection string"
         Expect.equal "concat('DefaultEndpointsProtocol=https;AccountName=account;AccountKey=', listKeys(resourceId('rg', 'Microsoft.Storage/storageAccounts', 'account'), '2017-10-01').keys[0].value)" rgConn.Value "Complex connection string"
     }
     test "Ensures Storage Account Names are valid" {
-        Expect.throws (fun _ -> StorageAccount.GetConnectionString "IFDJI$*(£" |> ignore) "Did not validate"
+        Expect.throws (fun _ -> StorageAccount.GetConnectionString("IFDJI$*(£", "") |> ignore) "Did not validate"
     }
 ]


### PR DESCRIPTION
This PR refactors how we store and construct ARM resources to be slightly more type safe as well as more succinct.

The changes in this PR are as follows:

* `ResourceType` now stores both the name of the type and the version number.
* `ResourceType` has a factory method to create the core parts of an ARM resource (name, location, dependsOn and Tags)
* `ResourceName` can now be added together e.g. "A" + "B" restults in "A/B". This simple change simplifies *a lot* of boilerplate.
* Start to expose key / connection string expression builders e.g. Cosmos, AppInsights.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the contributions guide and ensured my code adheres to them.
