### PR TITLE
Adds dedicated exception to finding Azure CLI tools

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 ## 1.1.0-beta2
 * Create Storage Account connection string expressions.
 * Small updates to SQL naming
+* Better error message when Azure CLI tooling cannot be found (https://github.com/CompositionalIT/farmer/pull/369)
 
 ## 1.1.0-beta1
 * AppInsights: Support for IP Masking and Sampling


### PR DESCRIPTION
This PR closes issue #368

The changes in this PR are as follows:

* Adds dedicated exception to finding Azure CLI tools

Instead of a cryptic message " No such file or directory": 

```
  X All Tests.Control.Azure CLI.Can connect to Az CLI [9ms]
  Error Message:
   No such file or directory
  Stack Trace:
     at System.Diagnostics.Process.ForkAndExecProcess(String filename, String[] argv, String[] envp, String cwd, Boolean redirectStdin, Boolean redirectStdout, Boolean redirectStderr, Boolean setCredentials, UInt32 userId, UInt32 groupId, UInt32[] groups, Int32& stdinFd, Int32& stdoutFd, Int32& stderrFd, Boolean usesTerminal, Boolean throwOnNoExec)
   at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start()
   at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   at Farmer.Deploy.Az.AzHelpers.executeAz(String arguments) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 46
   at Farmer.Deploy.Az.az@78.Invoke(String arguments) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 78
   at Farmer.Deploy.Az.az@78-2.Invoke(String x) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 78
   at Farmer.Deploy.Az.version() in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 85
   at Farmer.Deploy.checkVersion@158.Invoke(Unit unitVar) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 158
   at Result.ResultBuilder.Run[m](FSharpFunc`2 f) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Result.fs:line 40
   at Farmer.Deploy.checkVersion(Version minimum) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 157
   at AzCli.tests@9-75.Invoke(Unit unitVar) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Tests/AzCli.fs:line 9
   at Expecto.Impl.execTestAsync@566-1.Invoke(Unit unitVar)
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 398
   at <StartupCode$FSharp-Core>.$Async.StartChild@1666-5.Invoke(AsyncActivation`1 ctxt) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 1666
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 109
```

I've created a dedicated `AzureCLIToolsNotFound` exception with the message of:

> Could not find Azure CLI tools on {azCliPath}. Make sure you've setup the Azure CLI tools.  Go to https://compositionalit.github.io/farmer/quickstarts/quickstart-3/#install-the-azure-cli for more information.

```
  X All Tests.Control.Azure CLI.Can connect to Az CLI [11ms]
  Error Message:
   Could not find Azure CLI tools on azlol. Make sure you've setup the Azure CLI tools.  Go to https://compositionalit.github.io/farmer/quickstarts/quickstart-3/#install-the-azure-cli for more information.
  Stack Trace:
     at Farmer.Deploy.Az.AzHelpers.executeAz(String arguments) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 69
   at Farmer.Deploy.Az.az@78.Invoke(String arguments) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 78
   at Farmer.Deploy.Az.az@78-2.Invoke(String x) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 78
   at Farmer.Deploy.Az.version() in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 85
   at Farmer.Deploy.checkVersion@158.Invoke(Unit unitVar) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 158
   at Result.ResultBuilder.Run[m](FSharpFunc`2 f) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Result.fs:line 40
   at Farmer.Deploy.checkVersion(Version minimum) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Farmer/Deploy.fs:line 157
   at AzCli.tests@9-75.Invoke(Unit unitVar) in /Users/jimmybyrd/Documents/repos/public/farmer/src/Tests/AzCli.fs:line 9
   at Expecto.Impl.execTestAsync@566-1.Invoke(Unit unitVar)
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 398
   at <StartupCode$FSharp-Core>.$Async.StartChild@1666-5.Invoke(AsyncActivation`1 ctxt) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 1666
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 109
```

---


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription. 
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the contributions guide and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

I tested this by directly changing `azCliPath` and running the tests in `src/Tests/AzCli.fs`.

Given how the code is today, I'm unsure if I should write a test dedicated for this since we'd need to pass in the `azureCliPath` to the `executeAz` function.  Let me know if it's appropriate. 

I'm also unsure if this requires a documentation change.  Let know if there's an appropriate place for the change.