### PR TITLE
Change environment variables from anonymous type to ADT

### DIFF
--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -37,7 +37,7 @@ type ContainerInstanceConfig =
       /// Max gigabytes of memory the container instance may use
       Memory : float<Gb>
       /// Environment variables for the container
-      EnvironmentVariables : Map<string, {|Value:string; Secure:bool|}>
+      EnvironmentVariables : Map<string, EnvVarValue>
       /// Volume mounts for the container
       VolumeMounts : Map<string, string> }
 
@@ -190,8 +190,8 @@ type ContainerInstanceBuilder() =
     member __.AddVolumeMount (state:ContainerInstanceConfig, volumeName, mountPath) =
         { state with VolumeMounts = state.VolumeMounts |> Map.add volumeName mountPath }
 
-let env_var (name:string) (value:string) = name, {|Value=value; Secure=false|}
-let secure_env_var (name:string) (value:string) = name, {|Value=value; Secure=true|}
+let env_var (name:string) (value:string) = name, EnvValue value
+let secure_env_var (name:string) (value:string) = name, EnvSecureValue value
 
 let containerGroup = ContainerGroupBuilder()
 let containerInstance = ContainerInstanceBuilder()


### PR DESCRIPTION
Linked issue: #372 

The changes in this PR are as follows:

* Changed values of environment values of containers from anonymous records to an ADT.

The unit tests pass on macOS, although I can't run them on Linux and Windows (as described here https://compositionalit.github.io/farmer/contributing/).
I will create an issue to go with this PR momentarily.