### PR TITLE
Add support for Cognitive Services Key.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.1.0-beta4
+* Cognitive Services: Retrieve ARM expression to the Key of the Cognitive Services instance.
+
 ## 1.1.0-beta3
 * Web App / Functions: Allow CORS enable credentials (https://github.com/CompositionalIT/farmer/issues/265)
 * Container Instance: Change modelling from an anonymous type to a discriminated union (interop) (https://github.com/CompositionalIT/farmer/issues/372)

--- a/docs/content/api-overview/resources/cognitive-services.md
+++ b/docs/content/api-overview/resources/cognitive-services.md
@@ -15,7 +15,13 @@ The Cognitive Services builder is used to create Azure Cognitive Services instan
 |-|-|
 | name | Sets the name of the Cognitive Services instance. |
 | sku | Sets the SKU of the instance. Defaults to F0 (free). |
-| api | Specifies the API to use for the service instance. Defaults to `AllInOne`. |
+| api | Specifies the Kind of api to use for the service instance. Defaults to `AllInOne`. |
+
+#### Configuration Members
+
+| Member | Purpose |
+|-|-|
+| Key | Gets the ARM expression path to the Key of this Cognitive Services instance. |
 
 #### Example
 ```fsharp
@@ -27,4 +33,6 @@ let translator = cognitiveServices {
     sku CognitiveServices.F0
     api CognitiveServices.AnomalyDetector
 }
+
+let key : ArmExpression = translator.Key
 ```

--- a/src/Farmer/Builders/Builders.CognitiveServices.fs
+++ b/src/Farmer/Builders/Builders.CognitiveServices.fs
@@ -19,6 +19,8 @@ type CognitiveServicesConfig =
       Sku : Sku
       Api : Kind
       Tags: Map<string,string>  }
+    /// Gets an ARM expression to the key of this Cognitive Services instance.
+    member this.Key = CognitiveServices.getKey this.Name
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
@@ -28,8 +30,6 @@ type CognitiveServicesConfig =
               Kind = this.Api
               Tags = this.Tags }
         ]
-    /// Gets an ARM expression to the key of this Cognitive Services instance.
-    member this.Key = CognitiveServices.getKey this.Name
 
 type CognitiveServicesBuilder() =
     member _.Yield _ =

--- a/src/Farmer/Builders/Builders.CognitiveServices.fs
+++ b/src/Farmer/Builders/Builders.CognitiveServices.fs
@@ -4,6 +4,15 @@ module Farmer.Builders.CognitiveServices
 open Farmer
 open Farmer.Arm.CognitiveServices
 open Farmer.CognitiveServices
+open Farmer.CoreTypes
+
+type CognitiveServices =
+    /// Gets an ARM Expression key for any Cognitives Services instance.
+    static member getKey (name:ResourceName, ?resourceGroup:string) =
+        let resourcePath = ArmExpression.resourceId(accounts, name, ?group = resourceGroup)
+
+        sprintf "listKeys(%s, '%s').key1" resourcePath.Value accounts.ApiVersion
+        |> ArmExpression.create
 
 type CognitiveServicesConfig =
     { Name : ResourceName
@@ -19,6 +28,8 @@ type CognitiveServicesConfig =
               Kind = this.Api
               Tags = this.Tags }
         ]
+    /// Gets an ARM expression to the key of this Cognitive Services instance.
+    member this.Key = CognitiveServices.getKey this.Name
 
 type CognitiveServicesBuilder() =
     member _.Yield _ =
@@ -33,8 +44,8 @@ type CognitiveServicesBuilder() =
     [<CustomOperation "api">]
     member _.Api (state:CognitiveServicesConfig, api) = { state with Api = api }
     [<CustomOperation "add_tags">]
-    member _.Tags(state:CognitiveServicesConfig, pairs) = 
-        { state with 
+    member _.Tags(state:CognitiveServicesConfig, pairs) =
+        { state with
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
     [<CustomOperation "add_tag">]
     member this.Tag(state:CognitiveServicesConfig, key, value) = this.Tags(state, [ (key,value) ])

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -78,7 +78,7 @@ type ArmExpression =
         match name, group, subscriptionId with
         | name, Some group, Some sub -> sprintf "resourceId('%s', '%s', '%s', '%s')" sub group resourceType.Type name.Value
         | name, Some group, None -> sprintf "resourceId('%s', '%s', '%s')" group resourceType.Type name.Value
-        | name, _, _ -> sprintf "resourceId('%s', '%s')" resourceType.Type name.Value
+        | name, None, _ -> sprintf "resourceId('%s', '%s')" resourceType.Type name.Value
         |> ArmExpression.create
     static member resourceId (resourceType:ResourceType, [<ParamArray>] resourceSegments:ResourceName []) =
         sprintf

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -10,6 +10,7 @@ let allTests =
         testList "All Tests" [
             testList "Builders" [
                 Cdn.tests
+                CognitiveServices.tests
                 ContainerGroup.tests
                 ContainerService.tests
                 IotHub.tests

--- a/src/Tests/CognitiveServices.fs
+++ b/src/Tests/CognitiveServices.fs
@@ -1,0 +1,39 @@
+module CognitiveServices
+
+open Expecto
+open Farmer
+open Farmer.Builders
+open Farmer.CognitiveServices
+open Microsoft.Azure.Management.CognitiveServices
+open Microsoft.Rest
+open System
+
+let dummyClient = new CognitiveServicesManagementClient (Uri "http://management.azure.com", TokenCredentials "NotNullOrWhiteSpace")
+let getResourceAtIndex o = o |> getResourceAtIndex dummyClient.SerializationSettings
+
+let tests = testList "Cognitive Services" [
+    test "Basic Cognitive Services test" {
+        let service = cognitiveServices {
+            name "test"
+            api TextAnalytics
+            sku S0
+            add_tags [ "a", "1"; "b", "2" ]
+        }
+        let model : Models.CognitiveServicesAccount = service |> getResourceAtIndex 0
+
+        Expect.equal model.Name "test" "Name is wrong"
+        Expect.equal model.Kind "TextAnalytics" "Kind is wrong"
+        Expect.equal model.Sku.Name "S0" "Sku is wrong"
+        Expect.sequenceEqual (model.Tags |> Seq.map(fun x -> x.Key, x.Value) ) [ "a", "1"; "b", "2" ] "Tags are wrong"
+    }
+
+    test "Key is correctly calculated on a CS instance" {
+        let service = cognitiveServices { name "test" }
+        Expect.equal service.Key.Value "listKeys(resourceId('Microsoft.CognitiveServices/accounts', 'test'), '2017-04-18').key1" "Key is wrong"
+    }
+
+    test "Key is correctly calculated with a resource group" {
+        let key = CognitiveServices.getKey(ResourceName "test", "resource group")
+        Expect.equal key.Value "listKeys(resourceId('resource group', 'Microsoft.CognitiveServices/accounts', 'test'), '2017-04-18').key1" "Key is wrong"
+    }
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Cdn.fs" />
     <Compile Include="ContainerGroup.fs" />
     <Compile Include="ContainerService.fs" />
+    <Compile Include="CognitiveServices.fs" />
     <Compile Include="ExpressRoute.fs" />
     <Compile Include="NetworkSecurityGroup.fs" />
     <Compile Include="Storage.fs" />
@@ -35,6 +36,7 @@
   <ItemGroup>
     <PackageReference Include="expecto" Version="9.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.Cdn" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Management.CognitiveServices" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.Compute" Version="35.2.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerService" Version="1.0.0" />


### PR DESCRIPTION
This PR closes issue #377

The changes in this PR are as follows:

* Adds a Key member onto a Cognitive Service instance.
* Adds a builder function to allow creating keys for any CS instance, even ones not created by Farmer.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the contributions guide and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
