### PR TITLE
No longer require callers to explicitly set dependencies where not required.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 ## 1.2.0-beta1
 * Bastion Hosts: Create bastion hosts for accessing resources on a virtual network.
+* Support for implicitly adding dependencies based on usage e.g. add settings, connection strings etc.
 
 ## 1.1.0
 * Cognitive Services: Retrieve ARM expression to the Key of the Cognitive Services instance.

--- a/samples/scripts/keyvault.fsx
+++ b/samples/scripts/keyvault.fsx
@@ -52,7 +52,7 @@ let vault =
         add_secret complexSecret
         add_secret "simpleSecret"
         add_secrets ["firstSecret"; "secondSecret"]
-        add_secret ("thirdSecret", store, store.Key)
+        add_secret ("thirdSecret", store.Key)
     }
 
 vault.Policies

--- a/samples/scripts/webapp-storage.fsx
+++ b/samples/scripts/webapp-storage.fsx
@@ -16,7 +16,6 @@ let myWebApp = webApp {
     sku WebApp.Sku.S1
     app_insights_off
     setting "storage_key" myStorage.Key
-    depends_on myStorage
 }
 
 let deployment = arm {

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -140,7 +140,7 @@ type Site =
             @ (Map.toList this.ConnectionStrings |> List.map(fun (k, (v,_)) -> k, v))
             |> List.choose(snd >> function
                 | ParameterSetting s -> Some s
-                | LiteralSetting _ -> None)
+                | ExpressionSetting _ | LiteralSetting _ -> None)
 
     interface IPostDeploy with
         member this.Run resourceGroupName =

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -11,7 +11,9 @@ type AppInsights =
         ArmExpression
             .reference(components, resourceId)
             .Map(fun r -> r + ".InstrumentationKey")
-    static member getInstrumentationKey (name, ?resourceGroup) = AppInsights.getInstrumentationKey(ResourceName name, ?resourceGroup = resourceGroup)
+            .WithOwner(name)
+    static member getInstrumentationKey (name, ?resourceGroup) =
+        AppInsights.getInstrumentationKey(ResourceName name, ?resourceGroup = resourceGroup)
 
 type AppInsightsConfig =
     { Name : ResourceName

--- a/src/Farmer/Builders/Builders.CognitiveServices.fs
+++ b/src/Farmer/Builders/Builders.CognitiveServices.fs
@@ -10,9 +10,8 @@ type CognitiveServices =
     /// Gets an ARM Expression key for any Cognitives Services instance.
     static member getKey (name:ResourceName, ?resourceGroup:string) =
         let resourcePath = ArmExpression.resourceId(accounts, name, ?group = resourceGroup)
-
-        sprintf "listKeys(%s, '%s').key1" resourcePath.Value accounts.ApiVersion
-        |> ArmExpression.create
+        let expr = sprintf "listKeys(%s, '%s').key1" resourcePath.Value accounts.ApiVersion
+        ArmExpression.create(expr, name)
 
 type CognitiveServicesConfig =
     { Name : ResourceName

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -17,12 +17,17 @@ type CosmosDb =
     static member getKey (name, keyType:KeyType, keyAccess:KeyAccess, ?resourceGroup) =
         let resourceId = ArmExpression.resourceId(databaseAccounts, name, ?group = resourceGroup)
         let keyPath = sprintf "%s%sMasterKey" keyType.ArmValue keyAccess.ArmValue
-        resourceId.Map(fun db -> sprintf "listKeys(%s, %s).%s" db CosmosDb.providerPath keyPath)
+        resourceId
+            .Map(fun db -> sprintf "listKeys(%s, %s).%s" db CosmosDb.providerPath keyPath)
+            .WithOwner(name)
     static member getKey (name, keyType, keyAccess, ?resourceGroup) = CosmosDb.getKey(ResourceName name, keyType, keyAccess, ?resourceGroup = resourceGroup)
     static member getConnectionString (name, connectionStringKind:ConnectionStringKind, ?resourceGroup) =
         let resourceId = ArmExpression.resourceId(databaseAccounts, name, ?group = resourceGroup)
-        resourceId.Map(fun db -> sprintf "listConnectionStrings(%s, %s).connectionStrings[%i].connectionString" db CosmosDb.providerPath connectionStringKind.KeyIndex)
-    static member getConnectionString (name, connectionStringKind, ?resourceGroup) = CosmosDb.getConnectionString (ResourceName name, connectionStringKind, ?resourceGroup = resourceGroup)
+        resourceId
+            .Map(fun db -> sprintf "listConnectionStrings(%s, %s).connectionStrings[%i].connectionString" db CosmosDb.providerPath connectionStringKind.KeyIndex)
+            .WithOwner(name)
+    static member getConnectionString (name, connectionStringKind, ?resourceGroup) =
+        CosmosDb.getConnectionString (ResourceName name, connectionStringKind, ?resourceGroup = resourceGroup)
 
 type CosmosDbContainerConfig =
     { Name : ResourceName

--- a/src/Farmer/Builders/Builders.EventHub.fs
+++ b/src/Farmer/Builders/Builders.EventHub.fs
@@ -32,13 +32,15 @@ type EventHubConfig =
     member this.GetKey (ruleName:string) =
         ArmExpression
             .resourceId(authorizationRules, this.EventHubNamespaceName, this.Name, ResourceName ruleName)
-            .Map this.ToKeyExpression
+            .Map(this.ToKeyExpression)
+            .WithOwner(this.Name)
 
     /// Gets an ARM expression for the path to the key of the default RootManageSharedAccessKey for the entire namespace.
     member this.DefaultKey =
         ArmExpression
             .resourceId(authorizationRules, this.EventHubNamespaceName, ResourceName "RootManageSharedAccessKey")
-            .Map this.ToKeyExpression
+            .Map(this.ToKeyExpression)
+            .WithOwner(this.Name)
     interface IBuilder with
         member this.DependencyName = this.EventHubNamespaceName
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -91,6 +91,14 @@ type FunctionsConfig =
                 match this.AppInsights with
                 | Some (DependableResource this resourceName) -> resourceName
                 | _ -> ()
+                for setting in this.Settings do
+                    match setting.Value with
+                    | ExpressionSetting e ->
+                        match e.Owner with
+                        | Some owner -> owner
+                        | None -> ()
+                    | ParameterSetting _ | LiteralSetting _ ->
+                        ()
                 match this.ServicePlan with
                 | DependableResource this resourceName -> resourceName
                 | _ -> ()
@@ -211,11 +219,11 @@ type FunctionsBuilder() =
     [<CustomOperation "setting">]
     member __.AddSetting(state:FunctionsConfig, key, value) =
         { state with Settings = state.Settings.Add(key, LiteralSetting value) }
-    member this.AddSetting(state:FunctionsConfig, key, value:ArmExpression) =
-        this.AddSetting(state, key, value.Eval())
+    member _.AddSetting(state:FunctionsConfig, key, value:ArmExpression) =
+        { state with Settings = state.Settings.Add(key, ExpressionSetting value) }
     /// Sets a list of app setting of the web app in the form "key" "value".
     [<CustomOperation "settings">]
-    member __.AddSettings(state:FunctionsConfig, settings: (string*string) list) =
+    member __.AddSettings(state:FunctionsConfig, settings: (string * string) list) =
         settings
         |> List.fold (fun state (key,value: string) -> __.AddSetting(state, key, value)) state
     /// Sets a dependency for the functions app.

--- a/src/Farmer/Builders/Builders.Redis.fs
+++ b/src/Farmer/Builders/Builders.Redis.fs
@@ -6,12 +6,13 @@ open Farmer.CoreTypes
 open Farmer.Redis
 open Farmer.Arm.Cache
 
-let internal buildRedisKey (ResourceName name) =
-    sprintf
-        "concat('%s.redis.cache.windows.net,abortConnect=false,ssl=true,password=', listKeys('%s', '2015-08-01').primaryKey)"
-            name
-            name
-    |> ArmExpression.create
+let internal buildRedisKey (name:ResourceName) =
+    let expr =
+        sprintf
+            "concat('%s.redis.cache.windows.net,abortConnect=false,ssl=true,password=', listKeys('%s', '2015-08-01').primaryKey)"
+                name.Value
+                name.Value
+    ArmExpression.create(expr, name)
 
 type RedisConfig =
     { Name : ResourceName
@@ -91,8 +92,8 @@ type RedisBuilder() =
     [<CustomOperation "minimum_tls_version">]
     member __.MinimumTlsVersion(state:RedisConfig, tlsVersion) = { state with MinimumTlsVersion = Some tlsVersion }
     [<CustomOperation "add_tags">]
-    member _.Tags(state:RedisConfig, pairs) = 
-        { state with 
+    member _.Tags(state:RedisConfig, pairs) =
+        { state with
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
     [<CustomOperation "add_tag">]
     member this.Tag(state:RedisConfig, key, value) = this.Tags(state, [ (key,value) ])

--- a/src/Farmer/Builders/Builders.Search.fs
+++ b/src/Farmer/Builders/Builders.Search.fs
@@ -15,12 +15,12 @@ type SearchConfig =
       Tags: Map<string,string>  }
     /// Gets an ARM expression for the admin key of the search instance.
     member this.AdminKey =
-        sprintf "listAdminKeys('Microsoft.Search/searchServices/%s', '2015-08-19').primaryKey" this.Name.Value
-        |> ArmExpression.create
+        let expr = sprintf "listAdminKeys('Microsoft.Search/searchServices/%s', '2015-08-19').primaryKey" this.Name.Value
+        ArmExpression.create(expr, this.Name)
     /// Gets an ARM expression for the query key of the search instance.
     member this.QueryKey =
-        sprintf "listQueryKeys('Microsoft.Search/searchServices/%s', '2015-08-19').value[0].key" this.Name.Value
-        |> ArmExpression.create
+        let expr = sprintf "listQueryKeys('Microsoft.Search/searchServices/%s', '2015-08-19').value[0].key" this.Name.Value
+        ArmExpression.create(expr, this.Name)
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [
@@ -55,8 +55,8 @@ type SearchBuilder() =
     [<CustomOperation "partitions">]
     member __.PartitionCount(state:SearchConfig, partitions:int) = { state with Partitions = partitions }
     [<CustomOperation "add_tags">]
-    member _.Tags(state:SearchConfig, pairs) = 
-        { state with 
+    member _.Tags(state:SearchConfig, pairs) =
+        { state with
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
     [<CustomOperation "add_tag">]
     member this.Tag(state:SearchConfig, key, value) = this.Tags(state, [ (key,value) ])

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -140,14 +140,15 @@ type ServiceBusConfig =
       Queues : Map<ResourceName, ServiceBusQueueConfig>
       Topics : Map<ResourceName, ServiceBusTopicConfig>
       Tags: Map<string,string>  }
-    member private _.GetKeyPath sbNsName property =
-        sprintf
-            "listkeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '%s', 'RootManageSharedAccessKey'), '2017-04-01').%s"
-            sbNsName
-            property
-        |> ArmExpression.create
-    member this.NamespaceDefaultConnectionString = this.GetKeyPath this.Name.Value "primaryConnectionString"
-    member this.DefaultSharedAccessPolicyPrimaryKey = this.GetKeyPath this.Name.Value "primaryKey"
+    member private this.GetKeyPath property =
+        let expr =
+            sprintf
+                "listkeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '%s', 'RootManageSharedAccessKey'), '2017-04-01').%s"
+                this.Name.Value
+                property
+        ArmExpression.create(expr, this.Name)
+    member this.NamespaceDefaultConnectionString = this.GetKeyPath "primaryConnectionString"
+    member this.DefaultSharedAccessPolicyPrimaryKey = this.GetKeyPath "primaryKey"
     interface IBuilder with
         member this.DependencyName = this.Name
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.SignalR.fs
+++ b/src/Farmer/Builders/Builders.SignalR.fs
@@ -24,8 +24,8 @@ type SignalRConfig =
               Tags = this.Tags  }
         ]
     member this.Key =
-        sprintf "listKeys(resourceId('Microsoft.SignalRService/SignalR', '%s'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).primaryConnectionString" this.Name.Value
-        |> ArmExpression.create
+        let expr = sprintf "listKeys(resourceId('Microsoft.SignalRService/SignalR', '%s'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).primaryConnectionString" this.Name.Value
+        ArmExpression.create(expr, this.Name)
 
 type SignalRBuilder() =
     member _.Yield _ =
@@ -51,8 +51,8 @@ type SignalRBuilder() =
     [<CustomOperation("allowed_origins")>]
     member _.AllowedOrigins(state:SignalRConfig, allowedOrigins) = { state with AllowedOrigins = allowedOrigins}
     [<CustomOperation "add_tags">]
-    member _.Tags(state:SignalRConfig, pairs) = 
-        { state with 
+    member _.Tags(state:SignalRConfig, pairs) =
+        { state with
             Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
     [<CustomOperation "add_tag">]
     member this.Tag(state:SignalRConfig, key, value) = this.Tags(state, [ (key,value) ])

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -29,15 +29,17 @@ type SqlAzureConfig =
       Tags: Map<string,string>  }
     /// Gets a basic .NET connection string using the administrator username / password.
     member this.ConnectionString (database:SqlAzureDbConfig) =
-        concat [
-            literal
-                (sprintf "Server=tcp:%s.database.windows.net,1433;Initial Catalog=%s;Persist Security Info=False;User ID=%s;Password="
-                    this.Name.Value
-                    database.Name.Value
-                    this.AdministratorCredentials.UserName)
-            this.AdministratorCredentials.Password.AsArmRef
-            literal ";MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
-        ]
+        let expr =
+            concat [
+                literal
+                    (sprintf "Server=tcp:%s.database.windows.net,1433;Initial Catalog=%s;Persist Security Info=False;User ID=%s;Password="
+                        this.Name.Value
+                        database.Name.Value
+                        this.AdministratorCredentials.UserName)
+                this.AdministratorCredentials.Password.AsArmRef
+                literal ";MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+            ]
+        expr.WithOwner database.Name
     member this.ConnectionString databaseName =
         this.Databases
         |> List.tryFind(fun db -> db.Name = databaseName)

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -12,11 +12,12 @@ type StorageAccount =
     /// Gets an ARM Expression connection string for any Storage Account.
     static member getConnectionString (name:StorageAccountName, ?resourceGroup:string) =
         let resourcePath = ArmExpression.resourceId(storageAccounts, name.ResourceName, ?group = resourceGroup).Value
-        sprintf
-            "concat('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=', listKeys(%s, '2017-10-01').keys[0].value)"
-            name.ResourceName.Value
-            resourcePath
-        |> ArmExpression.create
+        let expr =
+            sprintf
+                "concat('DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=', listKeys(%s, '2017-10-01').keys[0].value)"
+                name.ResourceName.Value
+                resourcePath
+        ArmExpression.create(expr, name.ResourceName)
     /// Gets an ARM Expression connection string for any Storage Account.
     static member getConnectionString (name, ?resourceGroup) =
         StorageAccount.getConnectionString(StorageAccountName.Create(ResourceName name).OkValue, ?resourceGroup = resourceGroup)

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -398,7 +398,7 @@ type WebAppBuilder() =
     member _.AddConnectionString(state:WebAppConfig, key) =
         { state with ConnectionStrings = state.ConnectionStrings.Add(key, (ParameterSetting (SecureParameter key), Custom)) }
     member _.AddConnectionString(state:WebAppConfig, (key, value:ArmExpression)) =
-        { state with ConnectionStrings = state.ConnectionStrings.Add(key, (LiteralSetting (value.Eval()), Custom)) }
+        { state with ConnectionStrings = state.ConnectionStrings.Add(key, (ExpressionSetting value, Custom)) }
     /// Creates a set of connection strings of the web app whose values will be supplied as secret parameters.
     [<CustomOperation "connection_strings">]
     member this.AddConnectionStrings(state:WebAppConfig, connectionStrings) =

--- a/src/Tests/KeyVault.fs
+++ b/src/Tests/KeyVault.fs
@@ -10,12 +10,14 @@ let tests = testList "KeyVault" [
     test "Can create secrets without popping" {
         secret { name "test" } |> ignore
     }
-    test "Can create quick secret" {
-        keyVault {
-            name "test"
-            add_secret "test1"
-            add_secret (secret { name "test2" })
-        } |> ignore
+    test "Can create quick secrets" {
+        let vault =
+            keyVault {
+                name "test"
+                add_secret "test1"
+                add_secret (secret { name "test2" })
+            }
+        Expect.hasLength vault.Secrets 2 "Bad secrets"
     }
     test "Throws on empty inline secret" {
         Expect.throws(fun () ->
@@ -33,5 +35,17 @@ let tests = testList "KeyVault" [
     test "Default access policy settings is GET and LIST" {
         let p = AccessPolicy.create (ObjectId Guid.Empty)
         Expect.equal (set [ Secret.Get; Secret.List ]) p.Permissions.Secrets "Incorrect default secrets"
+    }
+    test "Creates key vault secrets correctly" {
+        let parameterSecret = SecretConfig.create "test"
+        Expect.equal parameterSecret.Key "test" "Invalid name of simple secret"
+        Expect.equal parameterSecret.Value (ParameterSecret (SecureParameter "test")) "Invalid value of parameter secret"
+
+        let sa = storageAccount { name "storage" }
+        let expressionSecret = SecretConfig.create("test", sa.Key)
+        Expect.equal expressionSecret.Value (ExpressionSecret sa.Key) "Invalid value of expression secret"
+        Expect.sequenceEqual expressionSecret.Dependencies [ sa.Name.ResourceName ] "Missing storage account dependency"
+
+        Expect.throws (fun _ -> SecretConfig.create("bad", (literal "foo")) |> ignore) "Should throw exception on expression with no owner"
     }
 ]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -61,13 +61,14 @@ let tests = testList "Web App Tests" [
         Expect.equal 3 (wa.Tags|> Map.count) "Should not contain additional tags"
     }
     test "Web App correctly adds connection strings" {
+        let sa = storageAccount { name "foo" }
         let wa =
-            let resources = webApp { name "test"; connection_string "a"; connection_string ("b", literal "value") } |> getResources
+            let resources = webApp { name "test"; connection_string "a"; connection_string ("b", sa.Key) } |> getResources
             resources |> getResource<Web.Site> |> List.head
 
         let expected = [
-            "a", ((ParameterSetting(SecureParameter "a")), Custom)
-            "b", ((LiteralSetting "['value']"), Custom)
+            "a", (ParameterSetting(SecureParameter "a"), Custom)
+            "b", (ExpressionSetting sa.Key, Custom)
         ]
         let parameters = wa :> IParameters
 
@@ -102,9 +103,8 @@ let tests = testList "Web App Tests" [
     }
 
     test "CORS without credentials does not crash" {
-        let _ = webApp { name "test"; enable_cors AllOrigins }
-        let _ = webApp { name "test"; enable_cors [ "https://bbc.co.uk" ] }
-        ()
+        webApp { name "test"; enable_cors AllOrigins } |> ignore
+        webApp { name "test"; enable_cors [ "https://bbc.co.uk" ] } |> ignore
     }
 
     test "If CORS is not enabled, ignores enable credentials" {
@@ -126,5 +126,12 @@ let tests = testList "Web App Tests" [
 
         Expect.contains wa.Dependencies sa.Name.ResourceName "Storage Account is missing"
         Expect.contains wa.Dependencies (ResourceName "thedb") "Database is missing"
+    }
+
+    test "Implicitly adds a dependency when adding a connection string" {
+        let sa = storageAccount { name "teststorage" }
+        let wa = webApp { name "testweb"; setting "storage" sa.Key }
+        let wa = wa |> getResources |> getResource<Web.Site> |> List.head
+        Expect.contains wa.Dependencies sa.Name.ResourceName "Storage Account is missing"
     }
 ]


### PR DESCRIPTION
This PR closes issue #382.

The changes in this PR are as follows:

* ArmExpression can now store an optional ResourceName, which represents the owning resource of the expression.
* All identified ArmExpressions that are used publicly e.g. Key, ConnectionString etc. now provide their containing resource.
* WebApp and Functions `setting` and KeyVault `add_secret` keywords are now aware of this.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the contributions guide and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Draft PR
