### PR TITLE
More flexible service bus TTL settings, doc additions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 ## 1.2.0-beta1
 * Bastion Hosts: Create bastion hosts for accessing resources on a virtual network.
 * Gateway: Add VPN Client configuration
+* Service Bus: Set message TTL 
 
 ## 1.1.0
 * AKS: Basic AKS support

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -22,6 +22,24 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Queue | enable_dead_letter_on_message_expiration | Enables dead lettering of messages that expire. |
 | Queue | enable_partition | Enables partition support on the queue. |
 | Queue | link_to_namespace | Link this queue to an existing namespace instead of creating a new one. |
+| Queue | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes. |
+| Queue | message_ttl_days | Time To Live (TTL) value for messages in days. |
+| Subscription | name | The name of the subscription. |
+| Subscription | lock_duration_minutes | The length of time that a lock can be held on a message. |
+| Subscription | max_delivery_count | The maximum number of times a message can be delivered before dead lettering. |
+| Subscription | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for. |
+| Subscription | enable_session | Enables session support. |
+| Subscription | enable_dead_letter_on_message_expiration | Enables dead lettering of messages that expire. |
+| Subscription | enable_partition | Enables partition support on the queue. |
+| Subscription | link_to_namespace | Link this queue to an existing namespace instead of creating a new one. |
+| Subscription | add_filters | Adds multiple filters to a subscription |
+| Subscription | add_sql_filter | Adds a filter to a subscription using SQL syntax. |
+| Subscription | add_correlation_filter | Adds a filter to a subscription using header value correlation. |
+| Topic | name | The name of the topic. |
+| Topic | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for. |
+| Topic | enable_partition | Enables partition support on the topic. |
+| Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes. |
+| Topic | message_ttl_days | Time To Live (TTL) value for messages in days. |
 | Namespace | sku | The ServiceBusNamespaceSku e.g. Standard |
 | Namespace | namespace_name | The name of the namespace that holds the queue. |
 | Namespace | depends_on | Sets dependencies on the service bus namespace. |

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -38,8 +38,7 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Topic | name | The name of the topic. |
 | Topic | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for. |
 | Topic | enable_partition | Enables partition support on the topic. |
-| Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes. |
-| Topic | message_ttl_days | Time To Live (TTL) value for messages in days. |
+| Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes, or as an integer days e.g. `4<Days>`. |
 | Namespace | sku | The ServiceBusNamespaceSku e.g. Standard |
 | Namespace | namespace_name | The name of the namespace that holds the queue. |
 | Namespace | depends_on | Sets dependencies on the service bus namespace. |

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -36,10 +36,11 @@ type ServiceBusQueueBuilder() =
     [<CustomOperation "lock_duration_minutes">] member _.LockDurationMinutes(state:ServiceBusQueueConfig, duration) = { state with LockDuration = Some (TimeSpan.FromMinutes (float duration)) }
     /// The maximum number of times a message can be delivered before dead lettering.
     [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
-    /// The default time-to-live for messages in days. If not specified, the maximum TTL will be set for the SKU.
-    [<CustomOperation "message_ttl_days">] member _.MessageTtlDays(state:ServiceBusQueueConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
     /// The default time-to-live for messages in a timespan string (e.g. '00:05:00'). If not specified, the maximum TTL will be set for the SKU.
-    [<CustomOperation "message_ttl">] member _.MessageTtl(state:ServiceBusQueueConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.Parse ttl) }
+    [<CustomOperation "message_ttl">]
+    member _.MessageTtl(state:ServiceBusQueueConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.Parse ttl) }
+    /// The default time-to-live for messages in days. If not specified, the maximum TTL will be set for the SKU.
+    member _.MessageTtl(state:ServiceBusQueueConfig, ttl:int<Days>) = { state with DefaultMessageTimeToLive = ttl / 1<Days> |> float |> TimeSpan.FromDays |> Some }
     /// Enables session support.
     [<CustomOperation "max_delivery_count">] member _.MaxDeliveryCount(state:ServiceBusQueueConfig, count) = { state with MaxDeliveryCount = Some count }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
@@ -120,10 +121,11 @@ type ServiceBusTopicBuilder() =
     [<CustomOperation "name">] member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = ResourceName name }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
-    /// The default time-to-live for messages in days. If not specified, the maximum TTL will be set for the SKU.
-    [<CustomOperation "message_ttl_days">] member _.MessageTtlDays(state:ServiceBusTopicConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
     /// The default time-to-live for messages in a timespan string (e.g. '00:05:00'). If not specified, the maximum TTL will be set for the SKU.
-    [<CustomOperation "message_ttl">] member _.MessageTtl(state:ServiceBusTopicConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.Parse ttl) }
+    [<CustomOperation "message_ttl">]
+    member _.MessageTtl(state:ServiceBusTopicConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.Parse ttl) }
+    /// The default time-to-live for messages in days. If not specified, the maximum TTL will be set for the SKU.
+    member _.MessageTtl(state:ServiceBusTopicConfig, ttl:int<Days>) = { state with DefaultMessageTimeToLive = ttl / 1<Days> |> float |> TimeSpan.FromDays |> Some }
     /// Enables partition support on the queue.
     [<CustomOperation "enable_partition">] member _.EnablePartition(state:ServiceBusTopicConfig) = { state with EnablePartitioning = Some true }
     [<CustomOperation "add_subscriptions">]

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -36,8 +36,10 @@ type ServiceBusQueueBuilder() =
     [<CustomOperation "lock_duration_minutes">] member _.LockDurationMinutes(state:ServiceBusQueueConfig, duration) = { state with LockDuration = Some (TimeSpan.FromMinutes (float duration)) }
     /// The maximum number of times a message can be delivered before dead lettering.
     [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
-    /// The default time-to-live for messages. If not specified, the maximum TTL will be set for the SKU.
-    [<CustomOperation "message_ttl_days">] member _.MessageTtl(state:ServiceBusQueueConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
+    /// The default time-to-live for messages in days. If not specified, the maximum TTL will be set for the SKU.
+    [<CustomOperation "message_ttl_days">] member _.MessageTtlDays(state:ServiceBusQueueConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
+    /// The default time-to-live for messages in a timespan string (e.g. '00:05:00'). If not specified, the maximum TTL will be set for the SKU.
+    [<CustomOperation "message_ttl">] member _.MessageTtl(state:ServiceBusQueueConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.Parse ttl) }
     /// Enables session support.
     [<CustomOperation "max_delivery_count">] member _.MaxDeliveryCount(state:ServiceBusQueueConfig, count) = { state with MaxDeliveryCount = Some count }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
@@ -79,9 +81,6 @@ type ServiceBusSubscriptionBuilder() =
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection_minutes">]
      member _.DuplicateDetection(state:ServiceBusSubscriptionConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
-    /// The default time-to-live for messages. If not specified, the maximum TTL will be set for the SKU.
-    [<CustomOperation "message_ttl_days">]
-     member _.MessageTtl(state:ServiceBusSubscriptionConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
     /// Enables session support.
     [<CustomOperation "max_delivery_count">]
      member _.MaxDeliveryCount(state:ServiceBusSubscriptionConfig, count) = { state with MaxDeliveryCount = Some count }
@@ -121,8 +120,10 @@ type ServiceBusTopicBuilder() =
     [<CustomOperation "name">] member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = ResourceName name }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
-    /// The default time-to-live for messages. If not specified, the maximum TTL will be set for the SKU.
-    [<CustomOperation "message_ttl_days">] member _.MessageTtl(state:ServiceBusTopicConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
+    /// The default time-to-live for messages in days. If not specified, the maximum TTL will be set for the SKU.
+    [<CustomOperation "message_ttl_days">] member _.MessageTtlDays(state:ServiceBusTopicConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.FromDays (float ttl)) }
+    /// The default time-to-live for messages in a timespan string (e.g. '00:05:00'). If not specified, the maximum TTL will be set for the SKU.
+    [<CustomOperation "message_ttl">] member _.MessageTtl(state:ServiceBusTopicConfig, ttl) = { state with DefaultMessageTimeToLive = Some (TimeSpan.Parse ttl) }
     /// Enables partition support on the queue.
     [<CustomOperation "enable_partition">] member _.EnablePartition(state:ServiceBusTopicConfig) = { state with EnablePartitioning = Some true }
     [<CustomOperation "add_subscriptions">]

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -54,7 +54,7 @@ let tests = testList "Service Bus Tests" [
                             enable_session
                             lock_duration_minutes 5
                             max_delivery_count 3
-                            message_ttl_days 10
+                            message_ttl 10<Days>
                         }
                     ]
                 }
@@ -156,7 +156,7 @@ let tests = testList "Service Bus Tests" [
                         topic {
                             name "my-topic"
                             duplicate_detection_minutes 3
-                            message_ttl_days 2
+                            message_ttl 2<Days>
                             enable_partition
                         }
                     ]

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -106,6 +106,21 @@ let tests = testList "Service Bus Tests" [
 
             Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalDays 14. "Default TTL should be 14 days"
         }
+        
+        test "Set TTL by timespan for Basic queue" {
+            let queue:SBQueue =
+                serviceBus {
+                    name "serviceBus"
+                    add_queues [
+                        queue {
+                            name "my-queue"
+                            message_ttl "00:05:00"
+                        }
+                    ]
+                } |> getResourceAtIndex 1
+
+            Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalMinutes 5. "TTL from TimeSpan should be 5 minutes"
+        }
 
         test "Default TTL set for Standard queue" {
             let queue:SBQueue =


### PR DESCRIPTION
This PR closes issue #

The changes in this PR are as follows:

* Enables service bus topic and queue message TTL's to be specified in TimeSpan strings like '1:30:00'.
* Adds missing service bus builder options to docs.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the contributions guide and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
