### PR TITLE
Remodel DNS Zone types

### DIFF
--- a/dns-example.json
+++ b/dns-example.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "outputs": {},
+  "parameters": {},
+  "resources": [
+    {
+      "apiVersion": "2018-05-01",
+      "location": "global",
+      "name": "farmer.com",
+      "properties": {
+        "zoneType": "Public"
+      },
+      "type": "Microsoft.Network/dnsZones"
+    },
+    {
+      "apiVersion": "2018-05-01",
+      "dependsOn": [
+        "farmer.com"
+      ],
+      "name": "farmer.com/www2",
+      "properties": {
+        "CNAMERecord": {
+          "cname": "farmer.github.com"
+        },
+        "TTL": 3600
+      },
+      "type": "Microsoft.Network/dnsZones/CNAME"
+    },
+    {
+      "apiVersion": "2018-05-01",
+      "dependsOn": [
+        "farmer.com"
+      ],
+      "name": "farmer.com/@",
+      "properties": {
+        "ARecords": [
+          {
+            "ipv4Address": "192.168.0.1"
+          },
+          {
+            "ipv4Address": "192.168.0.2"
+          }
+        ],
+        "TTL": 7200
+      },
+      "type": "Microsoft.Network/dnsZones/A"
+    }
+  ]
+}

--- a/docs/content/api-overview/resources/dns.md
+++ b/docs/content/api-overview/resources/dns.md
@@ -32,15 +32,21 @@ The following items are currently unsupported:
 |-|-|
 | name | Sets the name of the domain. |
 | zone_type | Sets the zone type. |
-| add_records | Adds DNS Zone records. |
+| add_records | Adds DNS Zone records (see below). |
 
-
-#### A Record Builder Keywords
+Each Record type has its own custom builder. All builders share the following common keywords:
 
 | Keyword | Purpose |
 |-|-|
 | name | Sets the name of the record set (default to `@`). |
 | ttl | Sets the time-to-live of the record set. |
+
+In addition, each record builder has its own custom keywords:
+
+#### A Record Builder Keywords
+
+| Keyword | Purpose |
+|-|-|
 | add_ipv4_addresses | Add IPv4 addresses to this record set. |
 | target_resource | A reference to an azure resource from where the dns resource value is taken. |
 
@@ -48,8 +54,6 @@ The following items are currently unsupported:
 
 | Keyword | Purpose |
 |-|-|
-| name | Sets the name of the record set. (default to `@`) |
-| ttl | Sets the time-to-live of the record set. |
 | add_ipv6_addresses | Add IPv6 addresses to this record set. |
 | target_resource | A reference to an azure resource from where the dns resource value is taken. |
 
@@ -57,8 +61,6 @@ The following items are currently unsupported:
 
 | Keyword | Purpose |
 |-|-|
-| name | Sets the name of the record set. |
-| ttl | Sets the time-to-live of the record set. |
 | cname | Sets the canonical name for this CNAME record. |
 | target_resource | A reference to an azure resource from where the dns resource value is taken. |
 
@@ -66,43 +68,37 @@ The following items are currently unsupported:
 
 | Keyword | Purpose |
 |-|-|
-| name | Sets the name of the record set. (default to `@`) |
-| ttl | Sets the time-to-live of the record set. |
 | add_values | Add TXT values to this record set. |
 
 #### MX Record Builder Keywords
 
 | Keyword | Purpose |
 |-|-|
-| name | Sets the name of the record set. (default to `@`) |
-| ttl | Sets the time-to-live of the record set. |
 | add_values | Add MX values to the record set. |
 
 #### NS Record Builder Keywords
 
 | Keyword | Purpose |
 |-|-|
-| name | Sets the name of the record set. (default to `@`) |
-| ttl | Sets the time-to-live of the record set. |
 | add_nsd_names | Add NS values to this record set. |
 
 #### PTR Record Builder Keywords
 
 | Keyword | Purpose |
 |-|-|
-| name | Sets the name of the record set. (default to `@`) |
-| ttl | Sets the time-to-live of the record set. |
 | add_ptrd_names | Add PTR names to this record set. |
 
 #### Example
 ```fsharp
+#r @"./libs/Newtonsoft.Json.dll"
+#r @"../../src/Farmer/bin/Debug/netstandard2.0/Farmer.dll"
+
 open Farmer
 open Farmer.Builders
-open Sql
 
 let dns = dnsZone {
     name "farmer.com"
-    zone_type Public
+    zone_type Dns.Public
     add_records [
         cnameRecord {
             name "www2"
@@ -133,13 +129,9 @@ let dns = dnsZone {
 
 let deployment = arm {
     location Location.NorthEurope
-
     add_resource dns
 }
 
-template
+deployment
 |> Writer.quickWrite "dns-example"
-
-template
-|> Deploy.execute "my-resource-group" []
 ```

--- a/samples/scripts/dns.fsx
+++ b/samples/scripts/dns.fsx
@@ -1,0 +1,44 @@
+#r @"./libs/Newtonsoft.Json.dll"
+#r @"../../src/Farmer/bin/Debug/netstandard2.0/Farmer.dll"
+
+open Farmer
+open Farmer.Builders
+
+let dns = dnsZone {
+    name "farmer.com"
+    zone_type Dns.Public
+    add_records [
+        cnameRecord {
+            name "www2"
+            ttl 3600
+            cname "farmer.github.com"
+        }
+        aRecord {
+            ttl 7200
+            add_ipv4_addresses [ "192.168.0.1"; "192.168.0.2" ]
+        }
+        aaaaRecord {
+            ttl 7200
+            add_ipv6_addresses [ "100:100:100:100" ]
+        }
+        txtRecord {
+            ttl 3600
+            add_values [ "v=spf1 include:spf.protection.outlook.com -all" ]
+        }
+        mxRecord {
+            ttl 7200
+            add_values [
+                0, "farmer-com.mail.protection.outlook.com";
+                1, "farmer2-com.mail.protection.outlook.com";
+            ]
+        }
+    ]
+}
+
+let deployment = arm {
+    location Location.NorthEurope
+    add_resource dns
+}
+
+deployment
+|> Writer.quickWrite "dns-example"

--- a/src/Farmer/Arm/Dns.fs
+++ b/src/Farmer/Arm/Dns.fs
@@ -48,43 +48,25 @@ module DnsRecords =
             member this.ResourceName = this.Name
             member this.JsonModel =
                 {| this.Type.ResourceType.Create(this.Zone + this.Name, dependsOn = [ this.Zone ]) with
-                    properties =
-                        {| TTL = this.TTL
-                           targetResource =
-                            match this.Type with
-                            | A (Some targetResource, _)
-                            | CName (Some targetResource, _)
-                            | AAAA (Some targetResource, _)  ->
-                                box {| id = targetResource.Value |}
-                            | _ ->
-                                null
-                           CNAMERecord =
-                            match this.Type with
-                            | CName (_, Some cnameRecord) -> box {| cname = cnameRecord |}
-                            | _ -> null
-                           MXRecords =
-                            match this.Type with
-                            | MX records -> records |> List.map (fun mx -> {| preference = mx.Preference; exchange = mx.Exchange |}) |> box
-                            | _ -> null
-                           NSRecords =
-                            match this.Type with
-                            | NS records -> records |> List.map (fun ns -> {| nsdname = ns |}) |> box
-                            | _ -> null
-                           TXTRecords =
-                            match this.Type with
-                            | TXT records -> records |> List.map (fun txt -> {| value = [ txt ] |}) |> box
-                            | _ -> null
-                           PTRRecords =
-                            match this.Type with
-                            | PTR records -> records |> List.map (fun ptr -> {| ptrdname = ptr |}) |> box
-                            | _ -> null
-                           ARecords =
-                            match this.Type with
-                            | A (_, records) -> records |> List.map (fun a -> {| ipv4Address = a |}) |> box
-                            | _ -> null
-                           AAAARecords =
-                            match this.Type with
-                            | AAAA (_, records) -> records |> List.map (fun aaaa -> {| ipv6Address = aaaa |}) |> box
-                            | _ -> null
-                        |}
+                    properties = [
+                        "TTL", box this.TTL
+
+                        match this.Type with
+                        | A (Some targetResource, _)
+                        | CName (Some targetResource, _)
+                        | AAAA (Some targetResource, _)  ->
+                            "targetResource", box {| id = targetResource.Value |}
+                        | _ ->
+                            ()
+
+                        match this.Type with
+                        | CName (_, Some cnameRecord) -> "CNAMERecord", box {| cname = cnameRecord |}
+                        | MX records -> "MXRecords", records |> List.map (fun mx -> {| preference = mx.Preference; exchange = mx.Exchange |}) |> box
+                        | NS records -> "NSRecords", records |> List.map (fun ns -> {| nsdname = ns |}) |> box
+                        | TXT records -> "TXTRecords", records |> List.map (fun txt -> {| value = [ txt ] |}) |> box
+                        | PTR records -> "PTRRecords", records |> List.map (fun ptr -> {| ptrdname = ptr |}) |> box
+                        | A (_, records) -> "ARecords", records |> List.map (fun a -> {| ipv4Address = a |}) |> box
+                        | AAAA (_, records) -> "AAAARecords", records |> List.map (fun aaaa -> {| ipv6Address = aaaa |}) |> box
+                        | CName (_, None) -> ()
+                    ] |> Map
                 |} :> _

--- a/src/Farmer/Builders/Builders.Dns.fs
+++ b/src/Farmer/Builders/Builders.Dns.fs
@@ -6,7 +6,6 @@ open Farmer.Dns
 open Farmer.Arm.Dns
 open DnsRecords
 
-type DnsZoneType = Public | Private
 type DnsZoneRecordConfig =
     { Name : ResourceName
       Type : DnsRecordType

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1002,4 +1002,11 @@ module Roles =
         let TrafficManagerContributor = RoleID "a4b10055-b0c7-44c2-b00f-c7b5b3550cf7"
 
 module Dns =
-    type DnsRecordType = A | AAAA | CName | NS | PTR | TXT | MX
+    type DnsRecordType =
+        | A of TargetResource : ResourceName option * ARecords : string list
+        | AAAA of TargetResource : ResourceName option * AaaaRecords : string list
+        | CName of TargetResource : ResourceName option * CNameRecord : string option
+        | NS of NsRecords : string list
+        | PTR of PtrRecords : string list
+        | TXT of TxtRecords : string list
+        | MX of {| Preference : int; Exchange : string |} list

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1002,6 +1002,7 @@ module Roles =
         let TrafficManagerContributor = RoleID "a4b10055-b0c7-44c2-b00f-c7b5b3550cf7"
 
 module Dns =
+    type DnsZoneType = Public | Private
     type DnsRecordType =
         | A of TargetResource : ResourceName option * ARecords : string list
         | AAAA of TargetResource : ResourceName option * AaaaRecords : string list


### PR DESCRIPTION
@raymens when you get ten minutes, could you review this? I've slightly reworked the way that data is modelled for DNS Config:

* Uses the DU cases to store the metadata against each one
* No longer requires option for the type of record

This has the following impacts:
* Can use a single record to model all record types (great here because most fields are the same across all types)
* Less code on builder
* Ability to share validation logic
* Less code in ARM

What do you think?