### PR TITLE
Fix broken table in containerGroup documentation.

### DIFF
--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -12,7 +12,7 @@ The Container Group builder is used to create Azure Container Group instances.
 
 #### Builder Keywords
 | Applies To | Keyword | Purpose |
-|-|-|
+|-|-|-|
 | containerInstance | name | Sets the name of the Container Group instance. |
 | containerInstance | image | Sets the container image. |
 | containerInstance | add_ports | Sets the ports the container exposes. |

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -21,7 +21,7 @@ The Container Group builder is used to create Azure Container Group instances.
 | containerInstance | env_vars | Sets a list of environment variables for the container. |
 | containerInstance | add_volume_mount | Adds a volume mount on a container from a volume in the container group. |
 | containerGroup | add_instances | Adds container instances to the group. |
-| containerGroup | os_type | Sets the OS type (default Linux). |
+| containerGroup | operating_system | Sets the OS type (default Linux). |
 | containerGroup | restart_policy | Sets the restart policy (default Always) |
 | containerGroup | public_dns | Sets the DNS host label when using a public IP. |
 | containerGroup | private_ip | Indicates the container should use a system-assigned private IP address for use in a virtual network. |


### PR DESCRIPTION
This is a tiny documentation fix for the ContainerGroup page where the Builder Keywords table was broken and did not render correctly due to a missing column.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
No code changes, just docs 😉