### PR TITLE
#404 do not create ip address field if not needed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,7 @@
 Release Notes
 =============
-## 1.2.0
-* Container Groups: Support for creating group without public IP Address.
-
 ## 1.2.0-beta2
+* Container Groups: Support for creating group without public IP Address.
 * Container Groups: Support for image registry credentials for private registries.
 * Container Groups: Support for partial CPU cores.
 * Log Analytics: Initial support.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.2.0
+* Container Groups: Support for creating group without public IP Address.
+
 ## 1.2.0-beta2
 * Container Groups: Support for image registry credentials for private registries.
 * Container Groups: Support for partial CPU cores.

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -111,24 +111,24 @@ type ContainerGroupBuilder() =
           Instances = []
           Volumes = Map.empty
           Tags = Map.empty }
-    member _.Run (state:ContainerGroupConfig) =
+    member this.Run (state:ContainerGroupConfig) =
         // Automatically apply all public-facing ports to the container group itself.
         state.Instances
         |> Seq.collect(fun i -> i.Ports |> Map.toSeq |> Seq.choose(function (port, PublicPort) -> Some port | _, InternalPort -> None))
         |> Seq.fold (fun (state:ContainerGroupConfig) port -> this.AddPort (state, TCP, port)) state
 
-    member __.AddTcpPort(state:ContainerGroupConfig, port) = __.AddPort (state, TCP, port)
+    member this.AddTcpPort(state:ContainerGroupConfig, port) = this.AddPort (state, TCP, port)
 
     [<CustomOperation "name">]
     /// Sets the name of the container group.
-    member __.Name(state:ContainerGroupConfig, name) = { state with Name = name }
+    member _.Name(state:ContainerGroupConfig, name) = { state with Name = name }
     member this.Name(state:ContainerGroupConfig, name) = this.Name(state, ResourceName name)
     /// Sets the OS type (default Linux)
     [<CustomOperation "operating_system">]
-    member __.OsType(state:ContainerGroupConfig, os) = { state with OperatingSystem = os }
+    member _.OsType(state:ContainerGroupConfig, os) = { state with OperatingSystem = os }
     /// Sets the restart policy (default Always)
     [<CustomOperation "restart_policy">]
-    member __.RestartPolicy(state:ContainerGroupConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
+    member _.RestartPolicy(state:ContainerGroupConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
     member private _.SetIpAddress(state:ContainerGroupConfig, ipAddressType, ports) =
         { state with
             IpAddress =

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -25,7 +25,7 @@ let fsharpApp = containerInstance {
     cpu_cores 2
 }
 let appWithoutPorts = containerInstance {
-    name "fsharpApp"
+    name "appWithoutPorts"
     image "myapp:1.7.2"
     memory 1.5<Gb>
     cpu_cores 2

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -24,6 +24,12 @@ let fsharpApp = containerInstance {
     memory 1.5<Gb>
     cpu_cores 2
 }
+let appWithoutPorts = containerInstance {
+    name "fsharpApp"
+    image "myapp:1.7.2"
+    memory 1.5<Gb>
+    cpu_cores 2
+}
 
 /// Client instance needed to get the serializer settings.
 let dummyClient = new ContainerInstanceManagementClient (Uri "http://management.azure.com", TokenCredentials "NotNullOrWhiteSpace")
@@ -62,6 +68,17 @@ let tests = testList "Container Group" [
         Expect.equal ports [ 80; 443; 9090 ] "Incorrect ports on container"
     }
 
+    test "Group without public ip" {
+        let group = containerGroup {
+            name "myGroup"
+            operating_system Linux
+            restart_policy RestartOnFailure
+            add_instances [ appWithoutPorts ]
+        }
+
+        Expect.isNone group.IpAddress "IpAddresses should be none"
+    }
+
     test "Multiple containers are correctly added" {
         let group = containerGroup { add_instances [ nginx; fsharpApp ] } |> asAzureResource
 
@@ -92,7 +109,7 @@ let tests = testList "Container Group" [
                 ]
             } |> asAzureResource
 
-        Expect.isEmpty group.IpAddress.Ports "Should not be any public ports"
+        Expect.equal group.IpAddress null "Should not be any public ports"
         Expect.equal group.Containers.[0].Ports.[0].Port 123 "Incorrect private port"
         Expect.hasLength group.Containers.[0].Ports 1 "Should only be one port"
     }


### PR DESCRIPTION
This PR closes #404

The changes in this PR are as follows:

* mark IpAddress in ContainerInstance as option
* when ipAddress is not specified mark it as None and not generate an IpAddress section in ARM template

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

- Documentation don't need to be updated,
- I don't test my code on Azure but check if the generated example looks the same if we specify ports and if it looks okay if we don't specify them,
- I would update Release_notes.md when the code changes would be approved.

CC: @isaacabraham 