### PR TITLE
#381 add account name validation for cosmos db

### DIFF
--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -148,7 +148,7 @@ type CosmosDbBuilder() =
                 let dbName = config.DbName.Value.ToLower()
                 if config.DbName.Value.Length > maxLength then dbName.Substring maxLength
                 else dbName
-            ResourceName (sprintf "%s-account" dbNamePart))
+            CosmosDbValidation.CosmosDbName.Create(sprintf "%s-account" dbNamePart).OkValue.ResourceName)
           AccountConsistencyPolicy = Eventual
           AccountFailoverPolicy = NoFailover
           DbThroughput = 400<RU>
@@ -160,7 +160,7 @@ type CosmosDbBuilder() =
     /// Sets the name of the CosmosDB server.
     [<CustomOperation "account_name">]
     member __.AccountName(state:CosmosDbConfig, serverName) = { state with AccountName = AutoCreate (Named serverName) }
-    member this.AccountName(state:CosmosDbConfig, serverName) = this.AccountName(state, ResourceName serverName)
+    member this.AccountName(state:CosmosDbConfig, serverName: string) = this.AccountName(state, CosmosDbValidation.CosmosDbName.Create(serverName).OkValue.ResourceName)
     /// Links the database to an existing server
     [<CustomOperation "link_to_account">]
     member __.LinkToAccount(state:CosmosDbConfig, server:CosmosDbConfig) = { state with AccountName = External(Managed(server.AccountName.CreateResourceId(server).Name)) }

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -299,6 +299,21 @@ module internal Validation =
         |> Seq.tryHead
         |> Option.defaultValue (Ok text)
 
+module CosmosDbValidation =
+    open Validation
+    type CosmosDbName =
+        private | CosmosDbName of ResourceName
+        static member Create name =
+            [ isNonEmpty
+              lengthBetween 3 44
+              containsOnly "lowercase letters" lowercaseOnly
+              containsOnly "alphanumeric characters or dash" (fun x -> Char.IsLetterOrDigit x || x = '-') ]
+            |> validate "CosmosDb account names" name
+            |> Result.map (ResourceName >> CosmosDbName)
+
+        static member Create (ResourceName name) = CosmosDbName.Create name
+        member this.ResourceName = match this with CosmosDbName name -> name
+
 module Storage =
     open Validation
     type StorageAccountName =

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -10,44 +10,70 @@ open Microsoft.Rest
 open System
 open Farmer.CoreTypes
 
-let tests = testList "Cosmos" [
-    test "Cosmos container should ignore duplicate unique keys" {
+let tests =
+    let invalidAccountNameCases =
+        [
+            "", "cannot be empty", "Name too short"
+            "zz", "min length is 3, but here is 2 ('zz')", "Name too short"
+            "abcdefghij1234567890abcde12345678901234567890", "max length is 44, but here is 45 ('abcdefghij1234567890abcde12345678901234567890')", "Name too long"
+            "zzzT", "can only contain lowercase letters ('zzzT')", "Upper case character allowed"
+            "zzz!", "can only contain alphanumeric characters or dash ('zzz!')", "Non alpha numeric (except dash) character allowed"
+        ]
+    let validAccountNameCases =
+        [
+            "abcdefghij1234567890abcd", "Should have created a valid CosmosDb account name"
+            "a-b-c-d-e-12-3-4", "Should have created a valid CosmosDb account name"
+        ]
+    testList "Cosmos" [
+        test "Cosmos container should ignore duplicate unique keys" {
 
-        let container =
-            cosmosContainer {
-                name "people"
-                partition_key [ "/id" ] CosmosDb.Hash
-                add_unique_key [ "/FirstName" ]
-                add_unique_key [ "/LastName" ]
-                add_unique_key [ "/LastName" ]
-            }
+            let container =
+                cosmosContainer {
+                    name "people"
+                    partition_key [ "/id" ] CosmosDb.Hash
+                    add_unique_key [ "/FirstName" ]
+                    add_unique_key [ "/LastName" ]
+                    add_unique_key [ "/LastName" ]
+                }
 
-        Expect.equal container.UniqueKeys.Count 2 "There should be 2 unique keys."
-        Expect.contains container.UniqueKeys ["/FirstName"] "UniqueKeys should contain /FirstName"
-        Expect.contains container.UniqueKeys ["/LastName"] "UniqueKeys should contain /LastName"
-    }
-    test "DB properties are correctly evaluated" {
-        let db = cosmosDb { name "test" }
-        Expect.equal "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2020-03-01').documentEndpoint]" (db.Endpoint.Eval()) "Endpoint is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" (db.PrimaryKey.Eval()) "Primary Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryMasterKey]" (db.SecondaryKey.Eval()) "Secondary Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryreadonlyMasterKey]" (db.PrimaryReadonlyKey.Eval()) "Primary Readonly Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryreadonlyMasterKey]" (db.SecondaryReadonlyKey.Eval()) "Secondary Readonly Key is incorrect"
-        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" (db.PrimaryConnectionString.Eval()) "Primary Connection String is incorrect"
-        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" (db.SecondaryConnectionString.Eval()) "Secondary Connection String is incorrect"
-    }
-    test "Correctly serializes to JSON" {
-        let t = arm { add_resource (cosmosDb { name "test" }) }
+            Expect.equal container.UniqueKeys.Count 2 "There should be 2 unique keys."
+            Expect.contains container.UniqueKeys ["/FirstName"] "UniqueKeys should contain /FirstName"
+            Expect.contains container.UniqueKeys ["/LastName"] "UniqueKeys should contain /LastName"
+        }
+        test "DB properties are correctly evaluated" {
+            let db = cosmosDb { name "test" }
+            Expect.equal "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2020-03-01').documentEndpoint]" (db.Endpoint.Eval()) "Endpoint is incorrect"
+            Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" (db.PrimaryKey.Eval()) "Primary Key is incorrect"
+            Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryMasterKey]" (db.SecondaryKey.Eval()) "Secondary Key is incorrect"
+            Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryreadonlyMasterKey]" (db.PrimaryReadonlyKey.Eval()) "Primary Readonly Key is incorrect"
+            Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryreadonlyMasterKey]" (db.SecondaryReadonlyKey.Eval()) "Secondary Readonly Key is incorrect"
+            Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" (db.PrimaryConnectionString.Eval()) "Primary Connection String is incorrect"
+            Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" (db.SecondaryConnectionString.Eval()) "Secondary Connection String is incorrect"
+        }
+        test "Correctly serializes to JSON" {
+            let t = arm { add_resource (cosmosDb { name "test" }) }
 
-        t.Template
-        |> Writer.toJson
-        |> ignore
-    }
-    test "Creates connection string and keys with resource groups" {
-        let conn = CosmosDb.getConnectionString(ResourceId.create("db", "group"), PrimaryConnectionString).Eval()
-        let key = CosmosDb.getKey(ResourceId.create("db", "group"), PrimaryKey, ReadWrite).Eval()
+            t.Template
+            |> Writer.toJson
+            |> ignore
+        }
+        test "Creates connection string and keys with resource groups" {
+            let conn = CosmosDb.getConnectionString(ResourceId.create("db", "group"), PrimaryConnectionString).Eval()
+            let key = CosmosDb.getKey(ResourceId.create("db", "group"), PrimaryKey, ReadWrite).Eval()
 
-        Expect.equal key "[listKeys(resourceId('group', 'Microsoft.DocumentDb/databaseAccounts', 'db'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" "Primary Key is incorrect"
-        Expect.equal conn "[listConnectionStrings(resourceId('group', 'Microsoft.DocumentDb/databaseAccounts', 'db'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" "Primary Connection String is incorrect"
-    }
-]
+            Expect.equal key "[listKeys(resourceId('group', 'Microsoft.DocumentDb/databaseAccounts', 'db'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" "Primary Key is incorrect"
+            Expect.equal conn "[listConnectionStrings(resourceId('group', 'Microsoft.DocumentDb/databaseAccounts', 'db'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" "Primary Connection String is incorrect"
+        }
+        testList "invalid account names" [
+            for name, error, why in invalidAccountNameCases ->
+                test name {
+                    Expect.equal (CosmosDbValidation.CosmosDbName.Create name) (Error ("CosmosDb account names " + error)) why
+                }
+        ]
+        testList "valid account names" [
+            for name, why in validAccountNameCases ->
+                test name {
+                    Expect.equal (StorageResourceName.Create(name).OkValue.ResourceName) (ResourceName name) why
+                }
+        ]
+    ]


### PR DESCRIPTION
This PR closes #381 

The changes in this PR are as follows:

* add account name validation for cosmos DB

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
- Documentation update not needed,
- I test my code locally since it is only related to validation,
- I will update Release notes when PR would be accepted.

btw. I saw in a issue description, that we would need validation in couple of other places. We want to do it within this pr or via separate one?

`Hmmm. Not really - I'm not planning on implementing all validation rules, but rather putting in a pattern and set of types to do it. We'll then need to implement it across all resources as needed` ~Isaac

Because of above I create this PR as a Draft.

CC: @isaacabraham 
