### PR TITLE
Correct SQL Owner path

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 Release Notes
 =============
 ## 1.2.0
-* Fix an issue whereby the Owner of a SQL connection string did not have the correct path.
+* SQL Azure: Connection string owner now has the correct path.
+* Functions: Ability to override the auto-generated storage account name.
 
 ## 1.2.0-beta2
 * Log Analytics: Initial release.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 Release Notes
 =============
 ## 1.2.0
+* Fix an issue whereby the Owner of a SQL connection string did not have the correct path.
 
 ## 1.2.0-beta2
 * Log Analytics: Initial release.

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -191,6 +191,9 @@ type FunctionsBuilder() =
     [<CustomOperation "link_to_storage_account">]
     member _.LinkToStorageAccount(state:FunctionsConfig, name) = { state with StorageAccount = External (Managed name) }
     member this.LinkToStorageAccount(state:FunctionsConfig, name) = this.LinkToStorageAccount(state, ResourceName name)
+    /// Set the name of the storage account instead of using an auto-generated one based on the function instance name.
+    [<CustomOperation "storage_account_name">]
+    member _.StorageAccountName(state:FunctionsConfig, name) = { state with StorageAccount = AutoCreate (Named (ResourceName name)) }
     /// Sets the name of the automatically-created app insights instance.
     [<CustomOperation "app_insights_name">]
     member _.AppInsightsName(state:FunctionsConfig, name) = { state with AppInsights = Some (AutoCreate (Named name)) }

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -39,7 +39,7 @@ type SqlAzureConfig =
                 this.AdministratorCredentials.Password.ArmExpression
                 ArmExpression.literal ";MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
             ]
-        expr.WithOwner (ResourceId.create(databases, database.Name))
+        expr.WithOwner (ResourceId.create(databases, this.Name, database.Name))
     member this.ConnectionString databaseName =
         this.Databases
         |> List.tryFind(fun db -> db.Name = databaseName)

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -33,6 +33,7 @@ let allTests =
                 Sql.tests
                 EventGrid.tests
                 WebApp.tests
+                Functions.tests
                 StaticWebApp.tests
                 VirtualNetworkGateway.tests
             ]

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -1,0 +1,26 @@
+module Functions
+
+open Expecto
+open Farmer
+open Farmer.Builders
+open Farmer.CoreTypes
+open Farmer.WebApp
+open Farmer.Arm
+open Microsoft.Azure.Management.WebSites
+open Microsoft.Azure.Management.WebSites.Models
+open Microsoft.Rest
+open System
+
+let tests = testList "Functions tests" [
+    test "Renames storage account correctly" {
+        let f = functions { name "test"; storage_account_name "foo" }
+        Expect.equal f.StorageAccountName.ResourceName.Value "foo" "Incorrect storage name"
+    }
+    test "Implicitly sets dependency on connection string" {
+        let db = sqlDb { name "mySql" }
+        let sql = sqlServer { name "test2"; admin_username "isaac"; add_databases [ db ] }
+        let f = functions { name "test"; storage_account_name "foo"; setting "db" (sql.ConnectionString db) } :> IBuilder
+        let site = f.BuildResources Location.NorthEurope |> List.head :?> Web.Site
+        Expect.contains site.Dependencies (ResourceId.create (Sql.databases, ResourceName "test2", ResourceName "mySql")) "Missing dependency"
+    }
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="Helpers.fs" />
     <Compile Include="AppInsights.fs" />
     <Compile Include="Common.fs" />
+    <Compile Include="Functions.fs" />
     <Compile Include="LogAnalytics.fs" />
     <Compile Include="Bastion.fs" />
     <Compile Include="Cdn.fs" />

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -126,7 +126,7 @@ let tests = testList "Web App Tests" [
         let wa = wa |> getResources |> getResource<Web.Site> |> List.head
 
         Expect.contains wa.Dependencies (ResourceId.create(storageAccounts, sa.Name.ResourceName)) "Storage Account is missing"
-        Expect.contains wa.Dependencies (ResourceId.create(Sql.databases, ResourceName "thedb")) "Database is missing"
+        Expect.contains wa.Dependencies (ResourceId.create(Sql.databases, ResourceName "test", ResourceName "thedb")) "Database is missing"
     }
 
     test "Implicitly adds a dependency when adding a connection string" {


### PR DESCRIPTION
This PR closes #423 

The changes in this PR are as follows:

* Fix connection string member to contain correct path for owner resource.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.