### PR TITLE
Update quickstart-2.md

### DIFF
--- a/docs/content/quickstarts/quickstart-2.md
+++ b/docs/content/quickstarts/quickstart-2.md
@@ -32,7 +32,7 @@ Add the storage account's connection key to the webapp as an app setting.
 ```fsharp
 let myWebApp = webApp {
     ...
-    setting "STORAGE_CONNECTION" myStorage.Key
+    setting "storageKey" myStorage.Key
 }
 ```
 


### PR DESCRIPTION
The storage account connection key defined in the `WebAppBuilder` isn't the same as the key used in the rest of the document. This commit fixes that