### PR TITLE
Add support for executing command line arguments in container instance.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,7 @@
 Release Notes
 =============
-## 1.3.1
-* Container Instance: Support for command line arguments
-
 ## 1.3.0
+* Container Instance: Support for command line arguments
 * Storage Account: Support for the full set of Storage Account Kind and SKUs (minor breaking change).
 
 ## 1.2.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.3.1
+* Container Instance: Support for command line arguments
+
 ## 1.3.0
 * Storage Account: Support for the full set of Storage Account Kind and SKUs (minor breaking change).
 

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -15,6 +15,7 @@ The Container Group builder is used to create Azure Container Group instances.
 |-|-|-|
 | containerInstance | name | Sets the name of the Container Group instance. |
 | containerInstance | image | Sets the container image. |
+| containerInstance | command | Sets the commands to execute within the container instance in exec form. |
 | containerInstance | add_ports | Sets the ports the container exposes. |
 | containerInstance | cpu_cores | Sets the maximum CPU cores the container may use. |
 | containerInstance | memory | Sets the maximum gigabytes of memory the container may use. |
@@ -123,3 +124,33 @@ let group = containerGroup {
     private_ip [TCP, 80us]
 }
 ```
+
+#### Execute container command example
+
+Modified from azure-cli example here: https://docs.microsoft.com/en-us/azure/container-instances/container-instances-start-command
+
+```fsharp
+open Farmer
+open Farmer.Builders
+open Farmer.ContainerGroup
+
+let wordcount = containerInstance {
+    name "mycontainer1"
+    image "mcr.microsoft.com/azuredocs/aci-wordcount:latest"
+    memory 0.5<Gb>
+    cpu_cores 1
+    env_vars [
+        env_var "NumWords" "3"
+        env_var "MinLength" "5"
+    ]
+    command_line [ "python"; "wordcount.py"; "http://shakespeare.mit.edu/romeo_juliet/full.html" ]
+}
+
+let group = containerGroup {
+    name "wordcount"
+    operating_system Linux
+    restart_policy RestartOnFailure
+    add_instances [ wordcount ]
+}
+```
+

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -28,6 +28,7 @@ type ContainerGroup =
       ContainerInstances :
         {| Name : ResourceName
            Image : string
+           Command : string list
            Ports : uint16 Set
            Cpu : float
            Memory : float<Gb>
@@ -73,6 +74,7 @@ type ContainerGroup =
                                {| name = container.Name.Value.ToLowerInvariant ()
                                   properties =
                                    {| image = container.Image
+                                      command = container.Command
                                       ports = container.Ports |> Set.map (fun port -> {| port = port |})
                                       environmentVariables = [
                                           for (key, value) in Map.toSeq container.EnvironmentVariables do

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -32,6 +32,8 @@ type ContainerInstanceConfig =
       Name : ResourceName
       /// The container instance image
       Image : string
+      /// The commands to execute within the container instance in exec form
+      Command : string list
       /// List of ports the container instance listens on
       Ports : Map<uint16, PortAccess>
       /// Max number of CPU cores the container instance may use
@@ -74,6 +76,7 @@ type ContainerGroupConfig =
                 for instance in this.Instances do
                     {| Name = instance.Name
                        Image = instance.Image
+                       Command = instance.Command
                        Ports = instance.Ports |> Map.toSeq |> Seq.map fst |> Set
                        Cpu = instance.Cpu
                        Memory = instance.Memory
@@ -183,6 +186,7 @@ type ContainerInstanceBuilder() =
     member __.Yield _ =
         { Name = ResourceName.Empty
           Image = ""
+          Command = List.empty
           Ports = Map.empty
           Cpu = 1.0
           Memory = 1.5<Gb>
@@ -223,6 +227,10 @@ type ContainerInstanceBuilder() =
     [<CustomOperation "add_volume_mount">]
     member __.AddVolumeMount (state:ContainerInstanceConfig, volumeName, mountPath) =
         { state with VolumeMounts = state.VolumeMounts |> Map.add volumeName mountPath }
+    /// Adds commands to execute within the container instance
+    [<CustomOperation "command_line">]
+    member __.CommandLine (state:ContainerInstanceConfig, command) =
+        { state with Command = state.Command @ command }
 
 let env_var (name:string) (value:string) = name, EnvValue value
 let secure_env_var (name:string) (value:string) = name, EnvSecureValue value

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -81,6 +81,18 @@ let tests = testList "Container Group" [
         Expect.isNone group.IpAddress "IpAddresses should be none"
     }
 
+    test "Container with command line arguments" {
+        let containerInstance = containerInstance {
+            name "appWithCommand"
+            image "myapp:1.7.2"
+            memory 1.5<Gb>
+            cpu_cores 2
+            command_line [ "echo"; "hello world" ]
+        }
+
+        Expect.equal containerInstance.Command [ "echo"; "hello world" ] "Incorrect container command line arguments"
+    }
+
     test "Multiple containers are correctly added" {
         let group = containerGroup { add_instances [ nginx; fsharpApp ] } |> asAzureResource
 


### PR DESCRIPTION
This PR closes #402 

The changes in this PR are as follows:

* Add support for command line arguments for container instances in a container group

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
