### PR TITLE
Yield resources/For overloads

### DIFF
--- a/samples/scripts/eventhubs.fsx
+++ b/samples/scripts/eventhubs.fsx
@@ -5,32 +5,30 @@ open Farmer
 open Farmer.Builders
 open Farmer.EventHub
 
-let myEh = eventHub {
-    name "first-hub"
-    namespace_name "allmyevents"
-
-    sku Standard
-    enable_zone_redundant
-    enable_auto_inflate 3
-    add_authorization_rule "FirstRule" [ Listen; Send ]
-    add_authorization_rule "SecondRule" AllAuthorizationRights
-
-    partitions 2
-    message_retention_days 3
-    add_consumer_group "myGroup"
-}
-
-let secondHub = eventHub {
-    name "second-hub"
-    link_to_namespace "allmyevents"
-    partitions 1
-    message_retention_days 1
-}
-
 let deployment = arm {
     location Location.NorthEurope
-    add_resource myEh
-    add_resource secondHub
+        
+    eventHub {
+        name "first-hub"
+        namespace_name "allmyevents"
+    
+        sku Standard
+        enable_zone_redundant
+        enable_auto_inflate 3
+        add_authorization_rule "FirstRule" [ Listen; Send ]
+        add_authorization_rule "SecondRule" AllAuthorizationRights
+    
+        partitions 2
+        message_retention_days 3
+        add_consumer_group "myGroup"
+    }
+
+    eventHub {
+        name "second-hub"
+        link_to_namespace "allmyevents"
+        partitions 1
+        message_retention_days 1
+    }
 }
 
 // Generate the ARM template here...

--- a/src/Farmer/ArmBuilder.fs
+++ b/src/Farmer/ArmBuilder.fs
@@ -74,6 +74,11 @@ module ArmBuilder =
               Location = state1.Location }
 
         member this.For (state: ArmConfig, f: unit -> ArmConfig) = this.Combine(state, f())
+        member this.For (xs: seq<'T>, f: 'T -> ArmConfig) =
+            xs
+            |> Seq.fold (fun xs x -> 
+                this.Combine(xs, f x)
+            ) ArmConfig.empty
         
         member _.Run (state:ArmConfig) =
             let resources = 
@@ -128,7 +133,6 @@ module ArmBuilder =
 
         [<CustomOperation "add_resources">]
         member _.AddResources(state:ArmConfig, input:IBuilder list) =
-            //let resources = input |> List.collect(fun i -> i.BuildResources state.Location)
             input 
             |> List.map (fun b -> b.BuildResources)
             |> ArmConfig.addResources state

--- a/src/Farmer/ArmBuilder.fs
+++ b/src/Farmer/ArmBuilder.fs
@@ -41,17 +41,12 @@ module ArmBuilder =
 
         let addResource (state: ArmConfig) (resource: Builder) =
             { state with Resources = resource::state.Resources }
-        
-            // |> List.distinctBy(fun r -> r.ResourceName, r.GetType().Name)
 
     type ArmBuilder() =
         member _.Yield (x: unit) = ArmConfig.empty
-        member this.Yield (appInsight: #IBuilder) =
-            this.Yield(appInsight)
-
         member _.Yield (location: Location) = 
             ArmConfig.create location
-        member _.Yield (input: IBuilder) =
+        member _.Yield (input: #IBuilder) =
             ArmConfig.addResource ArmConfig.empty input.BuildResources
         member _.Yield (input: Builder) =
             ArmConfig.addResource ArmConfig.empty input

--- a/src/Farmer/ArmBuilder.fs
+++ b/src/Farmer/ArmBuilder.fs
@@ -1,97 +1,136 @@
+namespace Farmer
+
 [<AutoOpen>]
-module Farmer.ArmBuilder
+module ArmBuilder =
 
-open Farmer.CoreTypes
-open Farmer
+    open Farmer.CoreTypes
+    open Farmer
 
-module Resource =
-    /// Creates a unique IArmResource from an arbitrary object.
-    let ofObj armObject =
-        { new IArmResource with
-             member _.ResourceName = ResourceName (System.Guid.NewGuid().ToString())
-             member _.JsonModel = armObject }
+    [<RequireQualifiedAccess>]
+    module Builder =
+        let lift (armResource: IArmResource) : Builder = fun _ -> [ armResource ]
 
-    /// Creates a unique IArmResource from a JSON string containing the output you want.
-    let ofJson json = json |> Newtonsoft.Json.Linq.JObject.Parse |> ofObj
+    [<RequireQualifiedAccess>]
+    module List =
+        let collectF (x: 'T) (xs: ('T -> 'U list) list) =
+            xs |> List.collect (fun f -> f x)
 
-module Json =
-    /// Creates a unique IArmResource from a JSON string containing the output you want.
-    let toIArmResource = Resource.ofJson
+    /// Represents all configuration information to generate an ARM template.
+    type ArmConfig =
+        { Parameters : string Set
+          Outputs : Map<string, string>
+          Location : Location
+          Resources : Builder list }
 
-module Subscription =
-    /// Gets an ARM expression pointing to the tenant id of the current subscription.
-    let TenantId = ArmExpression.create "subscription().tenantid"
+    [<RequireQualifiedAccess>]
+    module ArmConfig =
+        let empty = 
+            { Parameters = Set.empty
+              Outputs = Map.empty
+              Resources = List.empty
+              Location = Location.WestEurope }
 
-/// Represents all configuration information to generate an ARM template.
-type ArmConfig =
-    { Parameters : string Set
-      Outputs : Map<string, string>
-      Location : Location
-      Resources : IArmResource list }
+        let create location =
+            { Parameters = Set.empty
+              Outputs = Map.empty
+              Resources = List.empty
+              Location = location }
 
-type ArmBuilder() =
-    member __.Yield _ =
-        { Parameters = Set.empty
-          Outputs = Map.empty
-          Resources = List.empty
-          Location = Location.WestEurope }
+        let addResources (state: ArmConfig) (resources: Builder list) =
+            { state with Resources = state.Resources @ resources }
 
-    member __.Run (state:ArmConfig) =
-        let template =
-            { Parameters = [
-                for resource in state.Resources do
-                    match resource with
-                    | :? IParameters as p -> yield! p.SecureParameters
-                    | _ -> ()
-              ] |> List.distinct
-              Outputs = state.Outputs |> Map.toList
-              Resources = state.Resources }
+        let addResource (state: ArmConfig) (resource: Builder) =
+            { state with Resources = resource::state.Resources }
+        
+            // |> List.distinctBy(fun r -> r.ResourceName, r.GetType().Name)
 
-        let postDeployTasks = [
-            for resource in state.Resources do
-                match resource with
-                | :? IPostDeploy as pd -> pd
-                | _ -> ()
-            ]
+    type ArmBuilder() =
+        member _.Yield (x: unit) = ArmConfig.empty
+        member this.Yield (appInsight: #IBuilder) =
+            this.Yield(appInsight)
 
-        { Location = state.Location
-          Template = template
-          PostDeployTasks = postDeployTasks }
+        member _.Yield (location: Location) = 
+            ArmConfig.create location
+        member _.Yield (input: IBuilder) =
+            ArmConfig.addResource ArmConfig.empty input.BuildResources
+        member _.Yield (input: Builder) =
+            ArmConfig.addResource ArmConfig.empty input
+        member _.Yield (input: IArmResource) =
+            Builder.lift input
+            |> ArmConfig.addResource ArmConfig.empty
 
-    /// Creates an output value that will be returned by the ARM template.
-    [<CustomOperation "output">]
-    member __.Output (state, outputName, outputValue) : ArmConfig = { state with Outputs = state.Outputs.Add(outputName, outputValue) }
-    member this.Output (state:ArmConfig, outputName:string, (ResourceName outputValue)) = this.Output(state, outputName, outputValue)
-    member this.Output (state:ArmConfig, outputName:string, outputValue:ArmExpression) = this.Output(state, outputName, outputValue.Eval())
-    member this.Output (state:ArmConfig, outputName:string, outputValue:string option) =
-        match outputValue with
-        | Some outputValue -> this.Output(state, outputName, outputValue)
-        | None -> state
-    member this.Output (state:ArmConfig, outputName:string, outputValue:ArmExpression option) =
-        match outputValue with
-        | Some outputValue -> this.Output(state, outputName, outputValue)
-        | None -> state
+        member _.Zero () = ArmConfig.empty
+        member _.Delay f = f()
 
-    /// Sets the default location of all resources.
-    [<CustomOperation "location">]
-    member __.Location (state, location) : ArmConfig = { state with Location = location }
+        member _.Combine (state1: ArmConfig, state2: ArmConfig) =
+            { Parameters = Set.union state1.Parameters state2.Parameters
+              Outputs = 
+                  state2.Outputs
+                  |> List.ofSeq
+                  |> List.fold (fun m kvPair -> 
+                      Map.add kvPair.Key kvPair.Value m
+                  ) state1.Outputs 
+              Resources = state1.Resources @ state2.Resources 
+              Location = state1.Location }
 
-    static member private AddResources(state:ArmConfig, resources:IArmResource list) =
-        { state with
-            Resources =
+        member this.For (state: ArmConfig, f: unit -> ArmConfig) = this.Combine(state, f())
+        
+        member _.Run (state:ArmConfig) =
+            let resources = 
                 state.Resources
-                @ resources
-                |> List.distinctBy(fun r -> r.ResourceName, r.GetType().Name) }
+                |> List.collectF state.Location
+                |> List.distinctBy(fun r -> r.ResourceName, r.GetType().Name)
 
-    /// Adds a builder's ARM resources to the ARM template.
-    [<CustomOperation "add_resource">]
-    member _.AddResource (state:ArmConfig, input:IBuilder) = ArmBuilder.AddResources(state, input.BuildResources state.Location)
-    member _.AddResource (state:ArmConfig, input:Builder) = ArmBuilder.AddResources(state, input state.Location)
-    member _.AddResource (state:ArmConfig, input:IArmResource) = ArmBuilder.AddResources(state, [ input ])
+            let template =
+                { Parameters = [
+                    for resource in resources do
+                        match resource with
+                        | :? IParameters as p -> yield! p.SecureParameters
+                        | _ -> ()
+                  ] |> List.distinct
+                  Outputs = state.Outputs |> Map.toList
+                  Resources = resources }
 
-    [<CustomOperation "add_resources">]
-    member this.AddResources(state:ArmConfig, input:IBuilder list) =
-        let resources = input |> List.collect(fun i -> i.BuildResources state.Location)
-        ArmBuilder.AddResources(state, resources)
+            let postDeployTasks = [
+                for resource in resources do
+                    match resource with
+                    | :? IPostDeploy as pd -> pd
+                    | _ -> ()
+                ]
 
-let arm = ArmBuilder()
+            { Location = state.Location
+              Template = template
+              PostDeployTasks = postDeployTasks }
+
+        /// Creates an output value that will be returned by the ARM template.
+        [<CustomOperation "output">]
+        member _.Output (state, outputName, outputValue) : ArmConfig = { state with Outputs = state.Outputs.Add(outputName, outputValue) }
+        member this.Output (state:ArmConfig, outputName:string, (ResourceName outputValue)) = this.Output(state, outputName, outputValue)
+        member this.Output (state:ArmConfig, outputName:string, outputValue:ArmExpression) = this.Output(state, outputName, outputValue.Eval())
+        member this.Output (state:ArmConfig, outputName:string, outputValue:string option) =
+            match outputValue with
+            | Some outputValue -> this.Output(state, outputName, outputValue)
+            | None -> state
+        member this.Output (state:ArmConfig, outputName:string, outputValue:ArmExpression option) =
+            match outputValue with
+            | Some outputValue -> this.Output(state, outputName, outputValue)
+            | None -> state
+
+        /// Sets the default location of all resources.
+        [<CustomOperation "location">]
+        member _.Location (state:ArmConfig, location: Location) = { state with Location = location }
+
+        /// Adds a builder's ARM resources to the ARM template.
+        [<CustomOperation "add_resource">]
+        member _.AddResource (state:ArmConfig, input:IBuilder) = ArmConfig.addResource state input.BuildResources
+        member _.AddResource (state:ArmConfig, input:Builder) = ArmConfig.addResource state input
+        member _.AddResource (state:ArmConfig, input:IArmResource) = Builder.lift input |> ArmConfig.addResource state
+
+        [<CustomOperation "add_resources">]
+        member _.AddResources(state:ArmConfig, input:IBuilder list) =
+            //let resources = input |> List.collect(fun i -> i.BuildResources state.Location)
+            input 
+            |> List.map (fun b -> b.BuildResources)
+            |> ArmConfig.addResources state
+
+    let arm = ArmBuilder()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -46,7 +46,6 @@
     <Compile Include="Result.fs" />
     <Compile Include="Types.fs" />
     <Compile Include="Common.fs" />
-    <Compile Include="ArmBuilder.fs" />
 
     <Compile Include="Writer.fs" />
     <Compile Include="Deploy.fs" />
@@ -116,5 +115,6 @@
     <Compile Include="Builders/Builders.EventGrid.fs" />
     <Compile Include="Builders/Builders.StaticWebApp.fs" />
     <Compile Include="Builders\Builders.NetworkSecurityGroup.fs" />
+    <Compile Include="ArmBuilder.fs" />
   </ItemGroup>
 </Project>

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -286,3 +286,21 @@ module internal DeterministicGuid =
 
         swapByteOrder newGuid
         Guid newGuid
+
+module Resource =
+    /// Creates a unique IArmResource from an arbitrary object.
+    let ofObj armObject =
+        { new IArmResource with
+             member _.ResourceName = ResourceName (System.Guid.NewGuid().ToString())
+             member _.JsonModel = armObject }
+
+    /// Creates a unique IArmResource from a JSON string containing the output you want.
+    let ofJson json = json |> Newtonsoft.Json.Linq.JObject.Parse |> ofObj
+
+module Json =
+    /// Creates a unique IArmResource from a JSON string containing the output you want.
+    let toIArmResource = Resource.ofJson
+
+module Subscription =
+    /// Gets an ARM expression pointing to the tenant id of the current subscription.
+    let TenantId = ArmExpression.create "subscription().tenantid"


### PR DESCRIPTION
As per our Twitter convo here's a few (non-breaking it looks like) changes that can potentially improve the syntax. You'll want to look at how the merging is done because you might want to change that behavior.

Goes from:
```fsharp
let myEh = eventHub {
    name "first-hub"
    namespace_name "allmyevents"

    sku Standard
    enable_zone_redundant
    enable_auto_inflate 3
    add_authorization_rule "FirstRule" [ Listen; Send ]
    add_authorization_rule "SecondRule" AllAuthorizationRights

    partitions 2
    message_retention_days 3
    add_consumer_group "myGroup"
}

let secondHub = eventHub {
    name "second-hub"
    link_to_namespace "allmyevents"
    partitions 1
    message_retention_days 1
}

let deployment = arm {
    location Location.NorthEurope
    add_resource myEh
    add_resource secondHub
}
```

into this:

```fsharp
let deployment = arm {
    location Location.NorthEurope
        
    eventHub {
        name "first-hub"
        namespace_name "allmyevents"
    
        sku Standard
        enable_zone_redundant
        enable_auto_inflate 3
        add_authorization_rule "FirstRule" [ Listen; Send ]
        add_authorization_rule "SecondRule" AllAuthorizationRights
    
        partitions 2
        message_retention_days 3
        add_consumer_group "myGroup"
    }

    eventHub {
        name "second-hub"
        link_to_namespace "allmyevents"
        partitions 1
        message_retention_days 1
    }
}
```

It also enables `for x in xs do` syntax like requested in #99

```fsharp
let deployment = arm {
    location Location.NorthEurope
        
    for i in [ 1 .. 2 ] do
        eventHub {
            name (sprintf "hub-%i" i)
            link_to_namespace "allmyevents"
            partitions 1
            message_retention_days 1
        }
}
```