### PR TITLE
Fix 441

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,13 @@
 Release Notes
 =============
-## 1.3.0
+## 1.3.0-beta1
 * Container Instance: Support for command line arguments
 * Key Vault: Support for setting tags on key vault secrets
+
 * Storage Account: Support for the full set of Storage Account Kind and SKUs (minor breaking change).
+* Storage Account: Improved integration with CDN.
+
+* CDN has improved integration with Storage Accounts.
 
 ## 1.2.0
 * Log Analytics: Initial release.

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -38,7 +38,8 @@ The Storage Account builder creates storage accounts and their associated contai
 | Member | Purpose |
 |-|-|
 | Key | Returns an ARM expression to retrieve the storage account's primary connection string. Useful for e.g. supplying the connection string to another resource e.g. KeyVault or an app setting in the App Service. |
-| WebsitePrimaryEndpoint | Returns the Primary endpoint for static website (if enabled). |
+| WebsitePrimaryEndpoint | Returns an ARM Expression for the Primary endpoint for static website (if enabled). |
+| WebsitePrimaryEndpointHost | Returns an ARM Expression for the Host of the Primary endpoint for static website (if enabled). Use this for e.g. Azure CDN integration. |
 
 #### Helpers
 The `StorageAccount` type contains helper methods to quickly create ARM expressions for Storage Account connection strings.

--- a/src/Farmer/Arm/Cdn.fs
+++ b/src/Farmer/Arm/Cdn.fs
@@ -32,15 +32,20 @@ module Profiles =
           Http : FeatureFlag
           Https : FeatureFlag
           Compression : FeatureFlag
-          Origin : string
+          Origin : ArmExpression
           OptimizationType : OptimizationType
-          Tags: Map<string,string>  }
+          Tags: Map<string,string> }
         interface IArmResource with
-            member this.ResourceName: ResourceName = this.Name
+            member this.ResourceName = this.Profile/this.Name
             member this.JsonModel =
-                {| endpoints.Create(this.Profile/this.Name, Location.Global, ResourceId.create this.Profile :: this.Dependencies, this.Tags) with
+                let dependencies = [
+                    ResourceId.create this.Profile
+                    yield! this.Origin.Owner |> Option.toList
+                    yield! this.Dependencies
+                ]
+                {| endpoints.Create(this.Profile/this.Name, Location.Global, dependencies, this.Tags) with
                        properties =
-                            {| originHostHeader = this.Origin
+                            {| originHostHeader = this.Origin.Eval()
                                queryStringCachingBehavior = string this.QueryStringCachingBehaviour
                                optimizationType = string this.OptimizationType
                                isHttpAllowed = this.Http.AsBoolean
@@ -49,7 +54,7 @@ module Profiles =
                                contentTypesToCompress = this.CompressedContentTypes
                                origins = [
                                    {| name = "origin"
-                                      properties = {| hostName = this.Origin |}
+                                      properties = {| hostName = this.Origin.Eval() |}
                                    |}
                                ]
                             |}
@@ -58,11 +63,12 @@ module Profiles =
     module Endpoints =
         type CustomDomain =
             { Name : ResourceName
+              Profile : ResourceName
               Endpoint : ResourceName
               Hostname : Uri }
             interface IArmResource with
-                member this.ResourceName = this.Name
+                member this.ResourceName = this.Profile/this.Endpoint/this.Name
                 member this.JsonModel =
-                    {| customDomains.Create (this.Endpoint/this.Name, dependsOn = [ ResourceId.create this.Endpoint ]) with
+                    {| customDomains.Create (this.Profile/this.Endpoint/this.Name, dependsOn = [ ResourceId.create this.Endpoint ]) with
                         properties = {| hostName = string this.Hostname |}
                     |} :> _

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -56,6 +56,9 @@ type StorageAccountConfig =
         ArmExpression
             .reference(storageAccounts, ResourceId.create(storageAccounts, this.Name.ResourceName))
             .Map(sprintf "%s.primaryEndpoints.web")
+    member this.WebsitePrimaryEndpointHost =
+        this.WebsitePrimaryEndpoint
+            .Map(fun uri -> sprintf "replace(replace(%s, 'https://', ''), '/', '')" uri)
     member this.Endpoint = sprintf "%s.blob.core.windows.net" this.Name.ResourceName.Value
     interface IBuilder with
         member this.DependencyName = this.Name.ResourceName
@@ -100,7 +103,7 @@ type StorageAccountConfig =
 type StorageAccountBuilder() =
     member _.Yield _ = {
         Name = StorageAccountName.Create("default").OkValue
-        Sku = Sku.Premium_LRS
+        Sku = Sku.Standard_LRS
         EnableDataLake = None
         Containers = []
         FileShares = []

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -79,8 +79,10 @@ type ArmExpression =
     member this.Map mapper = match this with ArmExpression (e, r) -> ArmExpression(mapper e, r)
     /// Evaluates the expression for emitting into an ARM template. That is, wraps it in [].
     member this.Eval() =
-        if System.Text.RegularExpressions.Regex.IsMatch(this.Value, @"string\(\'[^\']*\'\)") then this.Value.Substring(8, this.Value.Length - 10)
-        else sprintf "[%s]" this.Value
+        let specialCases = [ @"string\(\'[^\']*\'\)", 8, 10; @"^'\w*'$", 1, 2 ]
+        match specialCases |> List.tryFind(fun (case, _, _) -> System.Text.RegularExpressions.Regex.IsMatch(this.Value, case)) with
+        | Some (_, start, finish) -> this.Value.Substring(start, this.Value.Length - finish)
+        | None -> sprintf "[%s]" this.Value
     /// Sets the owning resource on this ARM Expression.
     member this.WithOwner(owner:ResourceId) = match this with ArmExpression (e, _) -> ArmExpression(e, Some owner)
     /// Sets the owning resource on this ARM Expression.

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -18,6 +18,20 @@ let tests = testList "Storage Tests" [
         let resource =
             let account = storageAccount {
                 name "mystorage123"
+            }
+            arm { add_resource account }
+            |> getStorageResource
+
+        resource.Validate()
+        Expect.equal resource.Name "mystorage123" "Account name is wrong"
+        Expect.equal resource.Sku.Name "Standard_LRS" "SKU is wrong"
+        Expect.equal resource.Kind "StorageV2" "Kind"
+        Expect.equal resource.IsHnsEnabled (Nullable<bool>()) "Hierarchical namespace shouldn't be included"
+    }
+    test "Data lake is not enabled by default" {
+        let resource =
+            let account = storageAccount {
+                name "mystorage123"
                 sku Sku.Premium_LRS
                 enable_data_lake true
             }
@@ -25,35 +39,20 @@ let tests = testList "Storage Tests" [
             |> getStorageResource
 
         resource.Validate()
-        Expect.equal resource.Name "mystorage123" "Account name is wrong"
         Expect.equal resource.Sku.Name "Premium_LRS" "SKU is wrong"
-        Expect.equal resource.Kind "StorageV2" "Kind"
         Expect.isTrue resource.IsHnsEnabled.Value "Hierarchical namespace not enabled"
     }
-    test "When data lake is not enabled" {
+    test "When data lake can be disabled" {
         let resource =
             let account = storageAccount {
                 name "mystorage123"
-                sku Sku.Premium_LRS
                 enable_data_lake false
             }
             arm { add_resource account }
             |> getStorageResource
 
         resource.Validate()
-        Expect.isFalse resource.IsHnsEnabled.Value "Hierarchical namespace shouldn't be included"
-    }
-    test "When data lake is not enabled by default" {
-        let resource =
-            let account = storageAccount {
-                name "mystorage123"
-                sku Sku.Premium_LRS
-            }
-            arm { add_resource account }
-            |> getStorageResource
-
-        resource.Validate()
-        Expect.equal resource.IsHnsEnabled (Nullable<bool>()) "Hierarchical namespace shouldn't be included"
+        Expect.isFalse resource.IsHnsEnabled.Value "Hierarchical namespace should be false"
     }
     test "Creates containers correctly" {
         let resources : BlobContainer list =
@@ -161,26 +160,26 @@ let tests = testList "Storage Tests" [
         let resource = arm { add_resource account } |> getStorageResource
         Expect.equal resource.Kind "BlobStorage" "Kind"
         Expect.equal resource.AccessTier (Nullable AccessTier.Cool) "Access Tier"
-        Expect.equal resource.Sku.Name "Standard_LRS" "Sku Name"       
+        Expect.equal resource.Sku.Name "Standard_LRS" "Sku Name"
 
         let account = storageAccount { sku (Files BasicReplication.ZRS) }
         let resource = arm { add_resource account } |> getStorageResource
         Expect.equal resource.Kind "FileStorage" "Kind"
-        Expect.equal resource.Sku.Name "Premium_ZRS" "Sku Name"       
+        Expect.equal resource.Sku.Name "Premium_ZRS" "Sku Name"
 
         let account = storageAccount { sku (BlockBlobs BasicReplication.LRS) }
         let resource = arm { add_resource account } |> getStorageResource
         Expect.equal resource.Kind "BlockBlobStorage" "Kind"
-        Expect.equal resource.Sku.Name "Premium_LRS" "Sku Name"       
+        Expect.equal resource.Sku.Name "Premium_LRS" "Sku Name"
 
         let account = storageAccount { sku (GeneralPurpose (V1 V1Replication.RAGRS)) }
         let resource = arm { add_resource account } |> getStorageResource
         Expect.equal resource.Kind "Storage" "Kind"
-        Expect.equal resource.Sku.Name "Standard_RAGRS" "Sku Name"       
+        Expect.equal resource.Sku.Name "Standard_RAGRS" "Sku Name"
 
         let account = storageAccount { sku (GeneralPurpose (V2 (V2Replication.LRS Premium))) }
         let resource = arm { add_resource account } |> getStorageResource
         Expect.equal resource.Kind "StorageV2" "Kind"
-        Expect.equal resource.Sku.Name "Premium_LRS" "Sku Name"       
+        Expect.equal resource.Sku.Name "Premium_LRS" "Sku Name"
     }
 ]

--- a/src/Tests/Template.fs
+++ b/src/Tests/Template.fs
@@ -184,11 +184,15 @@ let tests = testList "Template" [
     }
 
     test "Fails if ARM expression is already quoted" {
-        Expect.throws(fun () -> ArmExpression.create "[test]" |> ignore ) "Should fail on quoted ARM expression"
+        Expect.throws(fun () -> ArmExpression.create "[test]" |> ignore ) ""
+    }
+
+    test "Correctly strips a literal expression" {
+        Expect.equal ((ArmExpression.literal "test").Eval()) "test" ""
     }
 
     test "Does not fail if ARM expression contains an inner quote" {
-        Expect.equal "[foo[test]]" ((ArmExpression.create "foo[test]").Eval()) "Failed on quoted ARM expression"
+        Expect.equal "[foo[test]]" ((ArmExpression.create "foo[test]").Eval()) ""
     }
     test "Does not create empty nodes for core resource fields when nothing is supplied" {
         let createdResource = ResourceType("Test", "2017-01-01").Create(ResourceName "Name")


### PR DESCRIPTION
This PR closes #441 

The changes in this PR are as follows:

* Add support for CDN to accept an ARM expression as the `origin` - this allows passing the storage account Web Endpoint.
* Storage Account config now has a `WebEndpointHost` member.
* Better support in `ArmExpression.Eval()` for emitting literals.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
