### PR TITLE
Fix service farm

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.3.0-beta2
+* Web App: Unmanaged Server Farm uses Resource Id for fully-qualified path.
+
 ## 1.3.0-beta1
 * Container Instance: Support for command line arguments.
 * Key Vault: Support for setting tags on key vault secrets.

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -113,7 +113,7 @@ module ZipDeploy =
 type Site =
     { Name : ResourceName
       Location : Location
-      ServicePlan : ResourceName
+      ServicePlan : ResourceId
       AppSettings : Map<string, Setting>
       ConnectionStrings : Map<string, (Setting * ConnectionStringKind)>
       AlwaysOn : bool
@@ -166,7 +166,7 @@ type Site =
                  kind = this.Kind
                  identity = this.Identity |> ManagedIdentity.toArmJson
                  properties =
-                    {| serverFarmId = this.ServicePlan.Value
+                    {| serverFarmId = this.ServicePlan.Eval()
                        httpsOnly = this.HTTPSOnly
                        clientAffinityEnabled = match this.ClientAffinityEnabled with Some v -> box v | None -> null
                        siteConfig =

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -45,8 +45,10 @@ type FunctionsConfig =
     member this.MasterKey =
         sprintf "listkeys(concat(resourceId('Microsoft.Web/sites', '%s'), '/host/default/'),'2016-08-01').masterKey" this.Name.Value
         |> ArmExpression.create
-    /// Gets the Service Plan name for this functions app.
-    member this.ServicePlanName = this.ServicePlan.CreateResourceId(this).Name
+    /// Gets this web app's Server Plan's full resource ID.
+    member this.ServicePlanId = this.ServicePlan.CreateResourceId this
+    /// Gets the Service Plan name for this web app.
+    member this.ServicePlanName = this.ServicePlanId.Name
     /// Gets the App Insights name for this functions app, if it exists.
     member this.AppInsightsName : ResourceName option = this.AppInsights |> Option.map (fun ai -> ai.CreateResourceId(this).Name)
     /// Gets the Storage Account name for this functions app.
@@ -55,7 +57,7 @@ type FunctionsConfig =
         member this.DependencyName = this.ServicePlanName
         member this.BuildResources location = [
             { Name = this.Name
-              ServicePlan = this.ServicePlanName
+              ServicePlan = this.ServicePlanId
               Location = location
               Cors = this.Cors
               Tags = this.Tags

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -108,8 +108,10 @@ type WebAppConfig =
     }
     /// Gets the ARM expression path to the publishing password of this web app.
     member this.PublishingPassword = publishingPassword (this.Name)
+    /// Gets this web app's Server Plan's full resource ID.
+    member this.ServicePlanId = this.ServicePlan.CreateResourceId this
     /// Gets the Service Plan name for this web app.
-    member this.ServicePlanName = this.ServicePlan.CreateResourceId(this).Name
+    member this.ServicePlanName = this.ServicePlanId.Name
     /// Gets the App Insights name for this web app, if it exists.
     member this.AppInsightsName = this.AppInsights |> Option.map (fun ai -> ai.CreateResourceId(this).Name)
     member this.Endpoint = sprintf "%s.azurewebsites.net" this.Name.Value
@@ -169,7 +171,7 @@ type WebAppConfig =
 
             { Name = this.Name
               Location = location
-              ServicePlan = this.ServicePlanName
+              ServicePlan = this.ServicePlanId
               HTTPSOnly = this.HTTPSOnly
               HTTP20Enabled = this.HTTP20Enabled
               ClientAffinityEnabled = this.ClientAffinityEnabled

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.3.0-beta1</Version>
+    <Version>1.3.0-beta2</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019, 2020 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -184,6 +184,11 @@ let tests = testList "Web App Tests" [
         let wa : Site = webApp { system_identity; add_identity (createUserAssignedIdentity "test"); add_identity (createUserAssignedIdentity "test2") } |> getResourceAtIndex 0
         Expect.equal wa.Identity.Type (Nullable ManagedServiceIdentityType.SystemAssignedUserAssigned) "Should have system identity"
         Expect.sequenceEqual (wa.Identity.UserAssignedIdentities |> Seq.map(fun r -> r.Key)) [ "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'test2')]"; "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'test')]" ] "Should have two user assigned identities"
-
+    }
+    
+    test "Unmanaged server farm is fully qualified in ARM" {
+        let farm = ResourceId.create(serverFarms, ResourceName "my-asp-name", "my-asp-resource-group")
+        let wa : Site = webApp { name "test"; link_to_unmanaged_service_plan farm } |> getResourceAtIndex 0
+        Expect.equal wa.ServerFarmId "[resourceId('my-asp-resource-group', 'Microsoft.Web/serverfarms', 'my-asp-name')]" ""
     }
 ]


### PR DESCRIPTION
This PR closes #455 

The changes in this PR are as follows:

* Server Farm ID on ARM Web is now a Resource Id
* Provide Resource ID from member on Web App and Functions builders.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
