### PR TITLE
Deployment script improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 Release Notes
 =============
 ## 1.3.0-beta2
+* Deployment Scripts: Specifies cleanup on expiration when retention interval is set, and enables cleanup on success only.
 * Web App: Unmanaged Server Farm uses Resource Id for fully-qualified path.
 
 ## 1.3.0-beta1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 ## 1.3.0-beta2
 * Deployment Scripts: Specifies cleanup on expiration when retention interval is set, and enables cleanup on success only.
+* Deployment Scripts: Support for running the script after other resources are deployed.
 * Web App: Unmanaged Server Farm uses Resource Id for fully-qualified path.
 
 ## 1.3.0-beta1

--- a/docs/content/api-overview/resources/deployment-script.md
+++ b/docs/content/api-overview/resources/deployment-script.md
@@ -15,13 +15,14 @@ The Deployment Script builder is used to execute Azure CLI scripts as part of an
 |-|-|
 | name | Sets the name of the deployment script resource. |
 | arguments | List of arguments to pass to the script. |
+| cleanup_on_success | The script will *only* be cleaned up on success to allow for inspection of failures. |
 | cli | Specifies the CLI runtime, default is az cli. |
 | content | Sets script content for the resource. |
 | env_vars | Defines environment variables in the script environment. |
 | force_update_tag | A tag that cn be changed to force a resource update so the script is run again. |
 | identity | Sets the user assigned identity for the deployment script resource (must be a contributor in the resource group). |
 | primary_script_uri | Sets a URI to download script content. |
-| retention_interval_days | Sets the days to retain the script runtime infrastructure to run again quickly. |
+| retention_interval | Sets the hours to retain the script runtime infrastructure to run again quickly. |
 | script_content | Sets script content for the resource. |
 | supporting_script_uris | Sets a URI to download additional content for the script. |
 | timeout | Sets the maximum amount of time to allow the script to run. |

--- a/docs/content/api-overview/resources/deployment-script.md
+++ b/docs/content/api-overview/resources/deployment-script.md
@@ -23,10 +23,10 @@ The Deployment Script builder is used to execute Azure CLI scripts as part of an
 | identity | Sets the user assigned identity for the deployment script resource (must be a contributor in the resource group). |
 | primary_script_uri | Sets a URI to download script content. |
 | retention_interval | Sets the hours to retain the script runtime infrastructure to run again quickly. |
-| run_after | Specifies the resource ID of resource that must exist before script execution. |
 | script_content | Sets script content for the resource. |
 | supporting_script_uris | Sets a URI to download additional content for the script. |
 | timeout | Sets the maximum amount of time to allow the script to run. |
+| depends_on | Specifies the resource or resource ID of resources that must exist before script execution. |
 | add_tags | Adds tags to the script runtime resource. |
 | add_tag | Adds a tag to the script runtime resource. |
 
@@ -38,8 +38,8 @@ open Farmer.Builders
 open Farmer.CoreTypes
 
 /// The deployment script must run under an identity with any necessary permissions
-/// to perform the commands in the script. Also must be a contributor in the 
-/// resource group. 
+/// to perform the commands in the script. Also must be a contributor in the
+/// resource group.
 let scriptIdentity = userAssignedIdentity {
     name "script-user"
 }

--- a/samples/scripts/deployment-script.fsx
+++ b/samples/scripts/deployment-script.fsx
@@ -7,7 +7,7 @@ open Farmer.Builders
 let createFileScript = deploymentScript {
     name "custom-deploy-steps"
     force_update
-    retention_interval 3<Days>
+    retention_interval 3<Hours>
     supporting_script_uris []
     /// Set the script content directly
     /// Format output as JSON and pipe to $AZ_SCRIPTS_OUTPUT_PATH to make it available as output.

--- a/src/Farmer/Arm/DeploymentScript.fs
+++ b/src/Farmer/Arm/DeploymentScript.fs
@@ -26,6 +26,7 @@ type Cleanup =
 type DeploymentScript =
     { Name : ResourceName
       Location : Location
+      AdditionalDependencies : ResourceId list
       Arguments : string list
       CleanupPreference : Cleanup option
       Cli : CliVersion
@@ -36,7 +37,7 @@ type DeploymentScript =
       SupportingScriptUris : Uri list
       Timeout : TimeSpan option
       Tags: Map<string,string> }
-    member private this.Dependencies = [ this.Identity.ResourceId ]
+    member private this.Dependencies = this.Identity.ResourceId :: this.AdditionalDependencies
     interface IArmResource with
         member this.ResourceName = this.Name
         member this.JsonModel =

--- a/src/Farmer/Builders/Builders.DeploymentScript.fs
+++ b/src/Farmer/Builders/Builders.DeploymentScript.fs
@@ -18,6 +18,7 @@ type OutputCollection(owner) =
 
 type DeploymentScriptConfig =
     { Name : ResourceName
+      AdditionalDependencies : ResourceId list
       Arguments : string list
       CleanupPreference : Cleanup option
       Cli : CliVersion
@@ -61,6 +62,7 @@ type DeploymentScriptConfig =
             // Deployment Script
             { Location = location
               Name = this.Name
+              AdditionalDependencies = this.AdditionalDependencies
               Arguments = this.Arguments
               CleanupPreference = this.CleanupPreference
               Cli = this.Cli
@@ -76,6 +78,7 @@ type DeploymentScriptConfig =
 type DeploymentScriptBuilder() =
     member _.Yield _ =
         { Name = ResourceName.Empty
+          AdditionalDependencies = []
           Arguments = []
           CleanupPreference = None
           Cli = AzCli "2.9.1"
@@ -101,6 +104,10 @@ type DeploymentScriptBuilder() =
     /// Specify the CLI type and version to use - defaults to the 'az cli' version 2.12.1.
     [<CustomOperation "cli">]
     member _.Cli(state:DeploymentScriptConfig, cliVersion) = { state with Cli = cliVersion }
+    [<CustomOperation "run_after">]
+    /// Specify the script runs after other resources are created.
+    member _.RunAfter(state:DeploymentScriptConfig, resourceId) =
+        { state with AdditionalDependencies = resourceId :: state.AdditionalDependencies }
     /// The contents of the script to execute.
     [<CustomOperation "script_content">]
     member _.Content(state:DeploymentScriptConfig, content) = { state with ScriptSource = Content content }

--- a/src/Farmer/Builders/Builders.DeploymentScript.fs
+++ b/src/Farmer/Builders/Builders.DeploymentScript.fs
@@ -132,8 +132,8 @@ type DeploymentScriptBuilder() =
     /// Time to retain the container instance that runs the script - 1 to 26 hours.
     [<CustomOperation "retention_interval">]
     member _.RetentionInterval(state:DeploymentScriptConfig, retentionInterval) =
-        let maxRetention = min retentionInterval 26<Hours>
-        { state with CleanupPreference = Cleanup.OnExpiration (TimeSpan.FromHours (float maxRetention)) }
+        if retentionInterval > 26<Hours> then failwithf "Max retention interval is 26 hours, but was set as %i" retentionInterval
+        { state with CleanupPreference = Cleanup.OnExpiration (TimeSpan.FromHours (float retentionInterval)) }
     /// Additional URIs to download scripts that the primary script relies on.
     [<CustomOperation "supporting_script_uris">]
     member _.SupportingScriptUris(state:DeploymentScriptConfig, supportingScriptUris) =

--- a/src/Tests/DeploymentScript.fs
+++ b/src/Tests/DeploymentScript.fs
@@ -80,4 +80,12 @@ let tests = testList "deploymentScripts" [
         Expect.hasLength script.Dependencies 1 "Should have additional dependency"
         Expect.equal (Set.toList script.Dependencies).[0].Name.Value "storagewithstuff" "Dependency should be on storage account"
     }
+
+    test "Retention period cannot be more than 26 hours" {
+        let createScript hours () =
+            deploymentScript { retention_interval (hours * 1<Hours>) } |> ignore
+
+        Expect.equal (createScript 26 ()) () "Should have not thrown"
+        Expect.throws (createScript 27) ""
+    }
 ]

--- a/src/Tests/DeploymentScript.fs
+++ b/src/Tests/DeploymentScript.fs
@@ -5,7 +5,6 @@ open Farmer
 open Farmer.Arm.DeploymentScript
 open Farmer.Arm.Storage
 open Farmer.Builders
-open Farmer.CoreTypes
 
 let tests = testList "deploymentScripts" [
     test "creates a script" {


### PR DESCRIPTION
The changes in this PR are as follows:

* Specifies cleanup on expiration when retention interval is set, and enables cleanup on success only.
* Support for running a deployment script after other resources are deployed.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.