### PR TITLE
Adding json output flag to az execution.

### DIFF
--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -50,7 +50,7 @@ module Az =
                 let azProcess =
                     ProcessStartInfo(
                         FileName = azCliPath.Value,
-                        Arguments = arguments,
+                        Arguments = argumentsWithOutputSet,
                         UseShellExecute = false,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true)

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -43,6 +43,10 @@ module Az =
                     failwithf "OSPlatform: %s not supported" RuntimeInformation.OSDescription
         let executeAz arguments =
             try
+                let argumentsWithOutputSet =
+                    if System.Text.RegularExpressions.Regex.IsMatch(arguments, "(-o|--output) (json|table|jsonc|yaml|tsv|none)") then
+                        arguments
+                    else arguments + " -o json"
                 let azProcess =
                     ProcessStartInfo(
                         FileName = azCliPath.Value,

--- a/src/Tests/AzCli.fs
+++ b/src/Tests/AzCli.fs
@@ -33,6 +33,7 @@ let tests = testList "Azure CLI" [
         | Ok ok ->
             try
                 Newtonsoft.Json.JsonConvert.DeserializeObject(ok) |> ignore
+                failwith "Error overriding az output: expected deserialization to fail."
             with _ -> ()
         | Error error -> failwithf "Error overriding az output: %s" error
 


### PR DESCRIPTION
This PR closes https://github.com/CompositionalIT/farmer/issues/461

The changes in this PR are as follows:

Added a check for an output flag when executing `az`.  If it's not there, set to `json`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
