### PR TITLE
Fix 467

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 Release Notes
 =============
-## To Be Decided
+## Next release
 * Web App: Support for adding site extensions with "use_extension"
+* Functions: Support for external unmanaged storage accounts.
 
 ## 1.3.0-beta2
 * Deployment Scripts: Specifies cleanup on expiration when retention interval is set, and enables cleanup on success only.

--- a/docs/content/api-overview/resources/functions.md
+++ b/docs/content/api-overview/resources/functions.md
@@ -20,7 +20,8 @@ The Functions builder is used to create Azure Functions accounts. It abstracts t
 | name | Sets the name of the functions instance. |
 | service_plan_name | Sets the name of the service plan hosting the function instance. |
 | link_to_service_plan | Instructs Farmer to link this webapp to an existing service plan rather than creating a new one. |
-| link_to_storage_account | Do not create an automatic storage account; instead, link to a storage account that is created outside of this Functions instance. |
+| link_to_storage_account | Do not create an automatic storage account; instead, link to a storage account that is created outside of this Functions instance but within this Farmer template. |
+| link_to_unmanaged_storage_account | Do not create an automatic storage account; instead, link to an existing storage account that was created external to Farmer. |
 | https_only | Disables http for this functions app so that only HTTPS is used. |
 | app_insights_auto_name | Sets the name of the automatically-created app insights instance. |
 | app_insights_off | Removes any automatic app insights creation, configuration and settings for this webapp. |

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -5,15 +5,27 @@ open Farmer
 open Farmer.Builders
 open Farmer.WebApp
 open Farmer.Arm
+open Microsoft.Azure.Management.Storage.Models
 open Microsoft.Azure.Management.WebSites
 open Microsoft.Azure.Management.WebSites.Models
 open Microsoft.Rest
 open System
 
+let getResource<'T when 'T :> IArmResource> (data:IArmResource list) = data |> List.choose(function :? 'T as x -> Some x | _ -> None)
+/// Client instance needed to get the serializer settings.
+let dummyClient = new WebSiteManagementClient (Uri "http://management.azure.com", TokenCredentials "NotNullOrWhiteSpace")
+let getResourceAtIndex o = o |> getResourceAtIndex dummyClient.SerializationSettings
+
 let tests = testList "Functions tests" [
     test "Renames storage account correctly" {
         let f = functions { name "test"; storage_account_name "foo" }
-        Expect.equal f.StorageAccountName.ResourceName.Value "foo" "Incorrect storage name"
+        let resources = (f :> IBuilder).BuildResources Location.WestEurope
+        let site = resources.[0] :?> Web.Site
+        let storage = resources.[2] :?> Storage.StorageAccount
+
+        Expect.contains site.Dependencies (storageAccounts.resourceId "foo") "Storage account has not been added a dependency"
+        Expect.equal f.StorageAccountName.ResourceName.Value "foo" "Incorrect storage account  name on site"
+        Expect.equal storage.Name.ResourceName.Value "foo" "Incorrect storage account name"
     }
     test "Implicitly sets dependency on connection string" {
         let db = sqlDb { name "mySql" }
@@ -21,5 +33,17 @@ let tests = testList "Functions tests" [
         let f = functions { name "test"; storage_account_name "foo"; setting "db" (sql.ConnectionString db) } :> IBuilder
         let site = f.BuildResources Location.NorthEurope |> List.head :?> Web.Site
         Expect.contains site.Dependencies (ResourceId.create (Sql.databases, ResourceName "test2", ResourceName "mySql")) "Missing dependency"
+    }
+    test "Works with unmanaged storage account" {
+        let externalStorageAccount = ResourceId.create(storageAccounts, ResourceName "foo", "group")
+        let functionsBuilder = functions { name "test"; link_to_unmanaged_storage_account externalStorageAccount }
+        let f = functionsBuilder :> IBuilder
+        let resources = f.BuildResources Location.WestEurope
+        let site = resources |> List.head :?> Web.Site
+
+        Expect.isFalse (resources |> List.exists (fun r -> r.ResourceId.Type = storageAccounts)) "Storage Account should not exist"
+        Expect.isFalse (site.Dependencies |> Set.contains externalStorageAccount) "Should not be a dependency"
+        Expect.stringContains site.AppSettings.["AzureWebJobsStorage"].Value "foo" "Web Jobs Storage setting should have storage account name"
+        Expect.stringContains site.AppSettings.["AzureWebJobsDashboard"].Value "foo" "Web Jobs Dashboard setting should have storage account name"
     }
 ]


### PR DESCRIPTION
This PR closes #467 

The changes in this PR are as follows:

* Add a new `link_to_unmanaged_storage_account` keyword on the Functions builder.
* Amend the Functions builder to properly respect the full Storage Account resource id, rather than just the name.
* Only emit the Storage Account resource id as a dependency if the storage account is dependable.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.