### PR TITLE
Auto add logging extension

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 Release Notes
 =============
 ## vNext
+* Web App: Automatically add Logging extension for ASP.NET Core apps.
 
 ## 1.3.0-beta3
 * Container Instance: Support for secure parameters for environment variables and secret volumes.

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -46,6 +46,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | disable_source_control_ci | Disables continuous integration from source control on push |
 | Web App | enable_source_control_ci | Enables continuous integration from source control on push |
 | Web App | add_extension | Adds the named extension to the Web App |
+| Web App | automatic_logging_extension | Enables or disables automatically adding the ASP .NET logging extension for netcore apps (defaults to on). |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | always_on | Sets "Always On" flag. |
 | Service Plan | runtime_stack | Sets the runtime stack. |

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -4,9 +4,7 @@ module rec Farmer.Builders.WebApp
 open Farmer
 open Farmer.Arm
 open Farmer.WebApp
-open Farmer.Arm.Web
 open Farmer.Arm.KeyVault.Vaults
-open Farmer.Arm.Insights
 open Sites
 open System
 open Farmer.Identity
@@ -105,6 +103,7 @@ type WebAppConfig =
 
       SecretStore : SecretStore
 
+      AutomaticLoggingExtension : bool
       SiteExtensions : ExtensionName Set
     }
     /// Gets the ARM expression path to the publishing password of this web app.
@@ -397,6 +396,7 @@ type WebAppBuilder() =
           SourceControlSettings = None
           DockerAcrCredentials = None
           SecretStore = AppService
+          AutomaticLoggingExtension = true
           SiteExtensions = Set.empty }
     member __.Run(state:WebAppConfig) =
         let operatingSystem =
@@ -406,9 +406,11 @@ type WebAppBuilder() =
         { state with
             OperatingSystem = operatingSystem
             SiteExtensions =
-                match state.Runtime with
-                | Runtime.DotNetCore _ -> state.SiteExtensions.Add WebApp.Extensions.Logging
-                | _ -> state.SiteExtensions
+                match state with
+                | { Runtime = Runtime.DotNetCore _; AutomaticLoggingExtension = true } ->
+                    state.SiteExtensions.Add WebApp.Extensions.Logging
+                | _ ->
+                    state.SiteExtensions
             DockerImage =
                 match state.DockerImage, state.DockerAcrCredentials with
                 | Some (image, tag), Some credentials when not (image.Contains "azurecr.io") ->
@@ -420,7 +422,7 @@ type WebAppBuilder() =
         }
     /// Sets the name of the web app.
     [<CustomOperation "name">]
-    member __.Name(state:WebAppConfig, name) = { state with Name = name }
+    member _.Name(state:WebAppConfig, name) = { state with Name = name }
     member this.Name(state:WebAppConfig, name:string) = this.Name(state, ResourceName name)
     /// Sets the name of the service plan.
     [<CustomOperation "service_plan_name">]
@@ -429,48 +431,48 @@ type WebAppBuilder() =
     /// Instead of creating a new service plan instance, configure this webapp to point to another Farmer-managed service plan instance.
     /// A dependency will automatically be set for this instance.
     [<CustomOperation "link_to_service_plan">]
-    member __.LinkToServicePlan(state:WebAppConfig, name) = { state with ServicePlan = managed serverFarms name }
+    member _.LinkToServicePlan(state:WebAppConfig, name) = { state with ServicePlan = managed serverFarms name }
     member this.LinkToServicePlan(state:WebAppConfig, name:string) = this.LinkToServicePlan (state, ResourceName name)
     member this.LinkToServicePlan(state:WebAppConfig, config:ServicePlanConfig) = this.LinkToServicePlan (state, config.Name)
     /// Instead of creating a new service plan instance, configure this webapp to point to another unmanaged service plan instance.
     /// A dependency will automatically be set for this instance.
     [<CustomOperation "link_to_unmanaged_service_plan">]
-    member __.LinkToUnmanagedServicePlan(state:WebAppConfig, resourceId) = { state with ServicePlan = External (Unmanaged resourceId) }
+    member _.LinkToUnmanagedServicePlan(state:WebAppConfig, resourceId) = { state with ServicePlan = External (Unmanaged resourceId) }
     [<CustomOperation "sku">]
-    member __.Sku(state:WebAppConfig, sku) = { state with Sku = sku }
+    member _.Sku(state:WebAppConfig, sku) = { state with Sku = sku }
     /// Sets the size of the service plan worker.
     [<CustomOperation "worker_size">]
-    member __.WorkerSize(state:WebAppConfig, workerSize) = { state with WorkerSize = workerSize }
+    member _.WorkerSize(state:WebAppConfig, workerSize) = { state with WorkerSize = workerSize }
     /// Sets the number of instances on the service plan.
     [<CustomOperation "number_of_workers">]
-    member __.NumberOfWorkers(state:WebAppConfig, workerCount) = { state with WorkerCount = workerCount }
+    member _.NumberOfWorkers(state:WebAppConfig, workerCount) = { state with WorkerCount = workerCount }
     /// Sets the name of the automatically-created app insights instance.
     [<CustomOperation "app_insights_name">]
-    member __.UseAppInsights(state:WebAppConfig, name) = { state with AppInsights = Some (named components name) }
+    member _.UseAppInsights(state:WebAppConfig, name) = { state with AppInsights = Some (named components name) }
     member this.UseAppInsights(state:WebAppConfig, name:string) = this.UseAppInsights(state, ResourceName name)
     /// Removes any automatic app insights creation, configuration and settings for this webapp.
     [<CustomOperation "app_insights_off">]
-    member __.DeactivateAppInsights(state:WebAppConfig) = { state with AppInsights = None }
+    member _.DeactivateAppInsights(state:WebAppConfig) = { state with AppInsights = None }
     /// Instead of creating a new AI instance, configure this webapp to point to another Farmer-managed AI instance.
     /// A dependency will automatically be set for this instance.
     [<CustomOperation "link_to_app_insights">]
-    member __.LinkToAi(state:WebAppConfig, name) = { state with AppInsights = Some (managed components name) }
+    member _.LinkToAi(state:WebAppConfig, name) = { state with AppInsights = Some (managed components name) }
     member this.LinkToAi(state:WebAppConfig, name) = this.LinkToAi (state, ResourceName name)
     member this.LinkToAi(state:WebAppConfig, name:ResourceName option) = match name with Some name -> this.LinkToAi (state, name) | None -> state
     member this.LinkToAi(state:WebAppConfig, config:AppInsightsConfig) = this.LinkToAi (state, config.Name)
     /// Instead of creating a new AI instance, configure this webapp to point to an unmanaged AI instance.
     /// A dependency will not be set for this instance.
     [<CustomOperation "link_to_unmanaged_app_insights">]
-    member __.LinkUnmanagedAppInsights(state:WebAppConfig, resourceId) = { state with AppInsights = Some (External(Unmanaged resourceId)) }
+    member _.LinkUnmanagedAppInsights(state:WebAppConfig, resourceId) = { state with AppInsights = Some (External(Unmanaged resourceId)) }
     /// Sets the web app to use "run from package" deployment capabilities.
     [<CustomOperation "run_from_package">]
-    member __.RunFromPackage(state:WebAppConfig) = { state with RunFromPackage = true }
+    member _.RunFromPackage(state:WebAppConfig) = { state with RunFromPackage = true }
     /// Sets the node version of the web app.
     [<CustomOperation "website_node_default_version">]
-    member __.NodeVersion(state:WebAppConfig, version) = { state with WebsiteNodeDefaultVersion = Some version }
+    member _.NodeVersion(state:WebAppConfig, version) = { state with WebsiteNodeDefaultVersion = Some version }
     /// Sets an app setting of the web app in the form "key" "value".
     [<CustomOperation "setting">]
-    member __.AddSetting(state:WebAppConfig, key, value) = { state with Settings = state.Settings.Add(key, LiteralSetting value) }
+    member _.AddSetting(state:WebAppConfig, key, value) = { state with Settings = state.Settings.Add(key, LiteralSetting value) }
     member this.AddSetting(state:WebAppConfig, key, resourceName:ResourceName) = this.AddSetting(state, key, resourceName.Value)
     member _.AddSetting(state:WebAppConfig, key, value:ArmExpression) = { state with Settings = state.Settings.Add(key, ExpressionSetting value) }
     /// Sets a list of app setting of the web app in the form "key" "value".
@@ -483,7 +485,7 @@ type WebAppBuilder() =
         |> List.fold (fun state (key, value:ArmExpression) -> this.AddSetting(state, key, value)) state
     /// Creates an app setting of the web app whose value will be supplied as a secret parameter.
     [<CustomOperation "secret_setting">]
-    member __.AddSecret(state:WebAppConfig, key) =
+    member _.AddSecret(state:WebAppConfig, key) =
         { state with Settings = state.Settings.Add(key, ParameterSetting (SecureParameter key)) }
     /// Creates a set of connection strings of the web app whose values will be supplied as secret parameters.
     [<CustomOperation "connection_string">]
@@ -503,8 +505,8 @@ type WebAppBuilder() =
     member this.DependsOn(state:WebAppConfig, builders:IBuilder list) = this.DependsOn (state, builders |> List.map (fun x -> x.ResourceId))
     member this.DependsOn(state:WebAppConfig, resource:IArmResource) = this.DependsOn (state, resource.ResourceId)
     member this.DependsOn(state:WebAppConfig, resources:IArmResource list) = this.DependsOn (state, resources |> List.map (fun x -> x.ResourceId))
-    member this.DependsOn (state:WebAppConfig, resourceId:ResourceId) = { state with Dependencies = state.Dependencies.Add resourceId }
-    member this.DependsOn (state:WebAppConfig, resourceIds:ResourceId list) = { state with Dependencies = state.Dependencies + Set resourceIds }
+    member _.DependsOn (state:WebAppConfig, resourceId:ResourceId) = { state with Dependencies = state.Dependencies.Add resourceId }
+    member _.DependsOn (state:WebAppConfig, resourceIds:ResourceId list) = { state with Dependencies = state.Dependencies + Set resourceIds }
 
     /// Sets "Always On" flag
     [<CustomOperation "always_on">]
@@ -607,6 +609,10 @@ type WebAppBuilder() =
         { state with SiteExtensions = state.SiteExtensions.Add extension }
     member this.AddExtension(state, name) =
         this.AddExtension(state, ExtensionName name)
+    /// Automatically add the ASP.NET Core logging extension.
+    [<CustomOperation "automatic_logging_extension">]
+    member _.DefaultLogging(state, setting) =
+        { state with AutomaticLoggingExtension = setting }
 
 let webApp = WebAppBuilder()
 

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -405,6 +405,10 @@ type WebAppBuilder() =
             | Some _ -> Linux
         { state with
             OperatingSystem = operatingSystem
+            SiteExtensions =
+                match state.Runtime with
+                | Runtime.DotNetCore _ -> state.SiteExtensions.Add WebApp.Extensions.Logging
+                | _ -> state.SiteExtensions
             DockerImage =
                 match state.DockerImage, state.DockerAcrCredentials with
                 | Some (image, tag), Some credentials when not (image.Contains "azurecr.io") ->

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -196,7 +196,11 @@ let tests = testList "Web App Tests" [
         let extension = wa |> getResources |> getResource<SiteExtension> |> List.head
         Expect.equal extension.Name.Value "Microsoft.AspNetCore.AzureAppServices.SiteExtension" "Wrong extension"
 
-        let wa = webApp { name "otherSite"; runtime_stack Runtime.Java11 }
+        let wa = webApp { name "siteX"; runtime_stack Runtime.Java11 }
+        let extensions = wa |> getResources |> getResource<SiteExtension>
+        Expect.isEmpty extensions "Shouldn't be any extensions"
+
+        let wa = webApp { name "siteX"; automatic_logging_extension false }
         let extensions = wa |> getResources |> getResource<SiteExtension>
         Expect.isEmpty extensions "Shouldn't be any extensions"
     }

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -191,8 +191,18 @@ let tests = testList "Web App Tests" [
         Expect.equal wa.ServerFarmId "[resourceId('my-asp-resource-group', 'Microsoft.Web/serverfarms', 'my-asp-name')]" ""
     }
 
+    test "Adds the Logging extension automatically for .NET Core apps" {
+        let wa = webApp { name "siteX" }
+        let extension = wa |> getResources |> getResource<SiteExtension> |> List.head
+        Expect.equal extension.Name.Value "Microsoft.AspNetCore.AzureAppServices.SiteExtension" "Wrong extension"
+
+        let wa = webApp { name "otherSite"; runtime_stack Runtime.Java11 }
+        let extensions = wa |> getResources |> getResource<SiteExtension>
+        Expect.isEmpty extensions "Shouldn't be any extensions"
+    }
+
     test "Handles add_extension correctly" {
-        let wa = webApp { name "siteX"; add_extension "extensionA"; }
+        let wa = webApp { name "siteX"; add_extension "extensionA"; runtime_stack Runtime.Java11 }
         let resources = wa |> getResources
         let sx = resources |> getResource<SiteExtension> |> List.head
         let r  = sx :> IArmResource
@@ -204,7 +214,7 @@ let tests = testList "Web App Tests" [
     }
 
     test "Handles multiple add_extension correctly" {
-        let wa = webApp { name "siteX"; add_extension "extensionA"; add_extension "extensionB"; add_extension "extensionB" }
+        let wa = webApp { name "siteX"; add_extension "extensionA"; add_extension "extensionB"; add_extension "extensionB"; runtime_stack Runtime.Java11 }
         let resources = wa |> getResources |> getResource<SiteExtension>
 
         let actual = List.sort resources


### PR DESCRIPTION
This PR closes #489 

The changes in this PR are as follows:

* Automatically add the Logging Site Extension for .NET Core web apps.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
