### PR TITLE
added credential arm expressions to ACR

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,8 @@ Release Notes
 * Framework: Extension methods for Taggable and Dependable to simplify boilerplate keywords.
 * Framework: Common keywords between Functions and Web Apps factored out.
 
+* Container Registry: Added ARM expressions for admin account credentials
+
 ## 1.3.2
 * Storage: Revert User Assigned Identity scope to ResourceGroup
 * User Assigned Identity: Allow explicitly setting dependencies

--- a/docs/content/api-overview/resources/container-registry.md
+++ b/docs/content/api-overview/resources/container-registry.md
@@ -17,6 +17,14 @@ The Container Registry builder is used to create Azure Container Registry (ACR) 
 | sku | Sets the SKU of the instance. Defaults to Basic. |
 | enable_admin_user | The value that indicates whether the admin user is enabled. |
 
+#### Configuration Members
+
+| Member | Purpose |
+|-|-|
+| Password | Gets the ARM expression path to the first admin password of this container registry if admin user was enabled. |
+| Password2 | Gets the ARM expression path to the second admin password of this container registry if admin user was enabled. |
+| Username | Gets the ARM expression path to the admin username of this container registry if admin user was enabled. |
+
 #### Example
 ```fsharp
 open Farmer

--- a/samples/scripts/container-registry.fsx
+++ b/samples/scripts/container-registry.fsx
@@ -16,6 +16,9 @@ let deployment = arm {
     add_resource myRegistry
     output "registry" myRegistry.Name
     output "loginServer" myRegistry.LoginServer
+    output "user" myRegistry.Username
+    output "pwd" myRegistry.Password
+    output "pwd2" myRegistry.Password2
 }
 
 deployment

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -13,6 +13,18 @@ type ContainerRegistryConfig =
     member this.LoginServer =
         (sprintf "reference(resourceId('Microsoft.ContainerRegistry/registries', '%s'),'2019-05-01').loginServer" this.Name.Value)
         |> ArmExpression.create
+    /// Returns first Admin password if AdminUserEnabled
+    member this.Password =
+        (sprintf "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries','%s'),'2019-05-01').passwords[0].value]" this.Name.Value)
+        |> ArmExpression.create
+    /// Returns second Admin password if AdminUserEnabled
+    member this.Password2 =
+        (sprintf "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries','%s'),'2019-05-01').passwords[1].value]" this.Name.Value)
+        |> ArmExpression.create
+    /// Returns Admin username if AdminUserEnabled
+    member this.Username =
+        (sprintf "[listCredentials(resourceId('Microsoft.ContainerRegistry/registries','%s'),'2019-05-01').username]" this.Name.Value)
+        |> ArmExpression.create
     interface IBuilder with
         member this.ResourceId = registries.resourceId this.Name
         member this.BuildResources location = [


### PR DESCRIPTION
This PR closes #459 and kind of #501 

I've added 3 ARM expressions to grab admin creds from ACR if admin user has been enabled.
They are needed to push anything to ACR.
WebApp with `docker_ci` model requires password for ACR as parameter, and without these expressions we had to pass it manually.

Response model for ACR listCredentials call
https://docs.microsoft.com/en-us/rest/api/containerregistry/registries/listcredentials#registrylistcredentials

How it looks in Portal
![image](https://user-images.githubusercontent.com/10308233/102378817-1a268400-3fbe-11eb-8a0b-21fbd02f1d1d.png)


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes. (Only samples)
* [ ] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
I haven't added any unit test, because I've added only ARM expressions. 
At least I've tested them :)