### PR TITLE
Added instrumentation key for linux webapp

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 ## vNext
 * Storage: Support for setting default blob access tier at account level with "default_blob_access_tier"
 * Web App: Automatically add Logging extension for ASP.NET Core apps.
+* Web App: Added Instrumentation Key Setting for Linux WebApp.
 * SQL Azure: Validation and fail fast on account names instead of silently fixing them.
 
 ## 1.3.0

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -196,8 +196,9 @@ type WebAppConfig =
                         "SnapshotDebugger_EXTENSION_VERSION", "~1"
                         "XDT_MicrosoftApplicationInsights_BaseExtensions", "~1"
                         "XDT_MicrosoftApplicationInsights_Mode", "recommended"
-                    | Windows, None
-                    | Linux, _ ->
+                    | Linux, Some resource ->
+                        "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.getInstrumentationKey(resource.resourceId this).Eval()
+                    | _, None ->
                         ()
                     if this.DockerCi then "DOCKER_ENABLE_CI", "true"
                 ]

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -185,9 +185,9 @@ type WebAppConfig =
                 let literalSettings = [
                     if this.RunFromPackage then AppSettings.RunFromPackage
                     yield! this.WebsiteNodeDefaultVersion |> Option.mapList AppSettings.WebsiteNodeDefaultVersion
+                    yield! this.AppInsights |> Option.mapList (fun resource -> "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.getInstrumentationKey(resource.resourceId this).Eval())
                     match this.OperatingSystem, this.AppInsights with
-                    | Windows, Some resource ->
-                        "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.getInstrumentationKey(resource.resourceId this).Eval()
+                    | Windows, Some _ ->
                         "APPINSIGHTS_PROFILERFEATURE_VERSION", "1.0.0"
                         "APPINSIGHTS_SNAPSHOTFEATURE_VERSION", "1.0.0"
                         "ApplicationInsightsAgent_EXTENSION_VERSION", "~2"
@@ -196,10 +196,10 @@ type WebAppConfig =
                         "SnapshotDebugger_EXTENSION_VERSION", "~1"
                         "XDT_MicrosoftApplicationInsights_BaseExtensions", "~1"
                         "XDT_MicrosoftApplicationInsights_Mode", "recommended"
-                    | Linux, Some resource ->
-                        "APPINSIGHTS_INSTRUMENTATIONKEY", AppInsights.getInstrumentationKey(resource.resourceId this).Eval()
-                    | _, None ->
+                    | Linux, Some _
+                    | _ , None ->
                         ()
+
                     if this.DockerCi then "DOCKER_ENABLE_CI", "true"
                 ]
 

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -237,10 +237,14 @@ let tests = testList "Web App Tests" [
     }
 
     test "Deploys AI configuration correctly" {
+        let hasSetting key message (wa:Site) = Expect.isTrue (wa.SiteConfig.AppSettings |> Seq.exists(fun k -> k.Name = key)) message
         let wa : Site = webApp { name "" } |> getResourceAtIndex 0
-        Expect.isTrue (wa.SiteConfig.AppSettings |> Seq.exists(fun k -> k.Name = "APPINSIGHTS_INSTRUMENTATIONKEY")) "Missing Windows instrumentation key"
+        wa |> hasSetting "APPINSIGHTS_INSTRUMENTATIONKEY" "Missing Windows instrumentation key"
 
         let wa : Site = webApp { name ""; operating_system Linux } |> getResourceAtIndex 0
-        Expect.isTrue (wa.SiteConfig.AppSettings |> Seq.exists(fun k -> k.Name = "APPINSIGHTS_INSTRUMENTATIONKEY")) "Missing Linux instrumentation key"
+        wa |> hasSetting "APPINSIGHTS_INSTRUMENTATIONKEY" "Missing Linux instrumentation key"
+
+        let wa : Site = webApp { name ""; app_insights_off } |> getResourceAtIndex 0
+        Expect.isEmpty wa.SiteConfig.AppSettings "Should be no settings"
     }
 ]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -235,4 +235,12 @@ let tests = testList "Web App Tests" [
 
         Expect.equal resourceId.ArmExpression.Value "resourceId('Microsoft.Web/sites/siteextensions', 'siteX')" ""
     }
+
+    test "Deploys AI configuration correctly" {
+        let wa : Site = webApp { name "" } |> getResourceAtIndex 0
+        Expect.isTrue (wa.SiteConfig.AppSettings |> Seq.exists(fun k -> k.Name = "APPINSIGHTS_INSTRUMENTATIONKEY")) "Missing Windows instrumentation key"
+
+        let wa : Site = webApp { name ""; operating_system Linux } |> getResourceAtIndex 0
+        Expect.isTrue (wa.SiteConfig.AppSettings |> Seq.exists(fun k -> k.Name = "APPINSIGHTS_INSTRUMENTATIONKEY")) "Missing Linux instrumentation key"
+    }
 ]


### PR DESCRIPTION
This PR closes #509 

I've added `APPINSIGHTS_INSTRUMENTATIONKEY` setting for linux webapps if it's being deployed together with AppInsight
Now we can use TelemetryClient through the code!

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
There is no need to document or test this change