### PR TITLE
Make reusable keywords for common Builder behaviours.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@ Release Notes
 * Web App: Automatically add Client Id setting for user assigned identities.
 * SQL Azure: Validation and fail fast on account names instead of silently fixing them.
 
+* Framework: Extension methods for Taggable and Dependable to simplify boilerplate keywords. 
+
 ## 1.3.2
 * Storage: Revert User Assigned Identity scope to ResourceGroup
 * User Assigned Identity: Allow explicitly setting dependencies

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,14 +2,16 @@ Release Notes
 =============
 ## vNext
 * Storage: Support for setting default blob access tier at account level with "default_blob_access_tier"
+* Functions: Added some extra keywords which were already present on Web App.
 * Web App: Automatically add Logging extension for ASP.NET Core apps.
 * Web App: Added Instrumentation Key Setting for Linux WebApp.
 * Web App: Automatically add Client Id setting for user assigned identities.
-* Web App: Support for 64 bits.  
+* Web App: Support for 64 bits.
 * SQL Azure: Validation and fail fast on account names instead of silently fixing them.
 * Azure CLI: Ensure JSON output.
 
-* Framework: Extension methods for Taggable and Dependable to simplify boilerplate keywords. 
+* Framework: Extension methods for Taggable and Dependable to simplify boilerplate keywords.
+* Framework: Common keywords between Functions and Web Apps factored out.
 
 ## 1.3.2
 * Storage: Revert User Assigned Identity scope to ResourceGroup

--- a/docs/content/api-overview/resources/functions.md
+++ b/docs/content/api-overview/resources/functions.md
@@ -20,16 +20,19 @@ The Functions builder is used to create Azure Functions accounts. It abstracts t
 | name | Sets the name of the functions instance. |
 | service_plan_name | Sets the name of the service plan hosting the function instance. |
 | link_to_service_plan | Instructs Farmer to link this webapp to an existing service plan rather than creating a new one. |
+| link_to_unmanaged_service_plan | Instructs Farmer to link this Functions instance to an existing service plan that is externally managed, rather than creating a new one. |
 | link_to_storage_account | Do not create an automatic storage account; instead, link to a storage account that is created outside of this Functions instance but within this Farmer template. |
 | link_to_unmanaged_storage_account | Do not create an automatic storage account; instead, link to an existing storage account that was created external to Farmer. |
 | https_only | Disables http for this functions app so that only HTTPS is used. |
-| app_insights_auto_name | Sets the name of the automatically-created app insights instance. |
+| app_insights_name | Sets the name of the automatically-created app insights instance. |
 | app_insights_off | Removes any automatic app insights creation, configuration and settings for this webapp. |
 | link_to_app_insights | Instead of creating a new AI instance, configure this webapp to point to another AI instance that you are managing yourself. |
+| link_to_unmanaged_app_insights | Instructs Farmer to link this functions instance to an existing app insights instance that is externally managed, rather than creating a new one. |
 | use_runtime | Sets the runtime of the Functions host. |
 | use_extension_version | Sets the extension version of the functions host. |
 | operating_system | Sets the operating system of the Functions host. |
 | setting | Sets an app setting of the web app in the form "key" "value". |
+| secret_setting | Sets a "secret" app setting of the function. You must supply the "key", whilst the value will be supplied as a secure parameter or an ARM expression. |
 | settings | Sets a list of app setting of the web app as tuples in the form of ("key", "value"). |
 | depends_on | [Sets dependencies for the web app.](../../dependencies/) |
 | enable_cors | Enables CORS support for the app. Either specify AllOrigins or a list of valid URIs. |

--- a/src/Farmer/Arm/Cdn.fs
+++ b/src/Farmer/Arm/Cdn.fs
@@ -25,7 +25,7 @@ module Profiles =
     type Endpoint =
         { Name : ResourceName
           Profile : ResourceName
-          Dependencies : ResourceId list
+          Dependencies : ResourceId Set
           CompressedContentTypes : string Set
           QueryStringCachingBehaviour : QueryStringCachingBehaviour
           Http : FeatureFlag

--- a/src/Farmer/Arm/EventHub.fs
+++ b/src/Farmer/Arm/EventHub.fs
@@ -48,7 +48,7 @@ module Namespaces =
           Location : Location
           MessageRetentionDays : int option
           Partitions : int
-          Dependencies : ResourceId list
+          Dependencies : ResourceId Set
           CaptureDestination : CaptureDestination option
           Tags: Map<string,string>  }
         interface IArmResource with

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -17,7 +17,7 @@ module Vaults =
           Enabled : bool option
           ActivationDate : DateTime option
           ExpirationDate : DateTime option
-          Dependencies : ResourceId list
+          Dependencies : ResourceId Set
           Tags: Map<string,string> }
         static member ``1970`` = DateTime(1970,1,1,0,0,0)
         static member TotalSecondsSince1970 (d:DateTime) = (d.Subtract Secret.``1970``).TotalSeconds |> int

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -113,7 +113,7 @@ type Namespace =
     { Name : ResourceName
       Location : Location
       Sku : Sku
-      Dependencies : ResourceId list
+      Dependencies : ResourceId Set
       Tags: Map<string,string>  }
     member this.Capacity =
         match this.Sku with

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -53,5 +53,6 @@ type AppInsightsBuilder() =
         if state.SamplingPercentage > 100  then failwith "Sampling Percentage cannot be higher than 100%"
         elif state.SamplingPercentage <= 0 then failwith "Sampling Percentage cannot be lower than or equal to 0%"
         state
+    interface ITaggable<AppInsightsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let appInsights = AppInsightsBuilder()

--- a/src/Farmer/Builders/Builders.Cdn.fs
+++ b/src/Farmer/Builders/Builders.Cdn.fs
@@ -54,6 +54,7 @@ type CdnConfig =
         ]
 
 type CdnBuilder() =
+    interface ITaggable<CdnConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Standard_Akamai
@@ -65,12 +66,6 @@ type CdnBuilder() =
     member _.Sku(state:CdnConfig, sku) = { state with Sku = sku }
     [<CustomOperation "add_endpoints">]
     member _.AddEndpoints(state:CdnConfig, endpoints) = { state with Endpoints = state.Endpoints @ endpoints }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:CdnConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:CdnConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 type EndpointBuilder() =
     member _.Yield _ : EndpointConfig =

--- a/src/Farmer/Builders/Builders.Cdn.fs
+++ b/src/Farmer/Builders/Builders.Cdn.fs
@@ -54,7 +54,7 @@ type CdnConfig =
         ]
 
 type CdnBuilder() =
-    interface ITaggable<CdnConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<CdnConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Standard_Akamai
@@ -68,7 +68,7 @@ type CdnBuilder() =
     member _.AddEndpoints(state:CdnConfig, endpoints) = { state with Endpoints = state.Endpoints @ endpoints }
 
 type EndpointBuilder() =
-    interface IDependsOn<EndpointConfig> with member _.SetDependencies state mergeDeps = { state with Dependencies = mergeDeps state.Dependencies }
+    interface IDependsOn<EndpointConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member _.Yield _ : EndpointConfig =
         { Name = ResourceName.Empty
           Dependencies = Set.empty

--- a/src/Farmer/Builders/Builders.Cdn.fs
+++ b/src/Farmer/Builders/Builders.Cdn.fs
@@ -54,7 +54,6 @@ type CdnConfig =
         ]
 
 type CdnBuilder() =
-    interface ITaggable<CdnConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Standard_Akamai
@@ -66,6 +65,7 @@ type CdnBuilder() =
     member _.Sku(state:CdnConfig, sku) = { state with Sku = sku }
     [<CustomOperation "add_endpoints">]
     member _.AddEndpoints(state:CdnConfig, endpoints) = { state with Endpoints = state.Endpoints @ endpoints }
+    interface ITaggable<CdnConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 type EndpointBuilder() =
     interface IDependsOn<EndpointConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }

--- a/src/Farmer/Builders/Builders.Cdn.fs
+++ b/src/Farmer/Builders/Builders.Cdn.fs
@@ -68,7 +68,7 @@ type CdnBuilder() =
     interface ITaggable<CdnConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 type EndpointBuilder() =
-    interface IDependsOn<EndpointConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface IDependable<EndpointConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member _.Yield _ : EndpointConfig =
         { Name = ResourceName.Empty
           Dependencies = Set.empty

--- a/src/Farmer/Builders/Builders.CognitiveServices.fs
+++ b/src/Farmer/Builders/Builders.CognitiveServices.fs
@@ -29,7 +29,6 @@ type CognitiveServicesConfig =
         ]
 
 type CognitiveServicesBuilder() =
-    interface ITaggable<CognitiveServicesConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = F0
@@ -41,5 +40,6 @@ type CognitiveServicesBuilder() =
     member _.Sku (state:CognitiveServicesConfig, sku) = { state with Sku = sku }
     [<CustomOperation "api">]
     member _.Api (state:CognitiveServicesConfig, api) = { state with Api = api }
+    interface ITaggable<CognitiveServicesConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let cognitiveServices = CognitiveServicesBuilder()

--- a/src/Farmer/Builders/Builders.CognitiveServices.fs
+++ b/src/Farmer/Builders/Builders.CognitiveServices.fs
@@ -29,6 +29,7 @@ type CognitiveServicesConfig =
         ]
 
 type CognitiveServicesBuilder() =
+    interface ITaggable<CognitiveServicesConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = F0
@@ -40,11 +41,5 @@ type CognitiveServicesBuilder() =
     member _.Sku (state:CognitiveServicesConfig, sku) = { state with Sku = sku }
     [<CustomOperation "api">]
     member _.Api (state:CognitiveServicesConfig, api) = { state with Api = api }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:CognitiveServicesConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:CognitiveServicesConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let cognitiveServices = CognitiveServicesBuilder()

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -100,7 +100,6 @@ type ContainerGroupConfig =
         ]
 
 type ContainerGroupBuilder() =
-    interface ITaggable<ContainerGroupConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member private _.AddPort (state, portType, port): ContainerGroupConfig =
         { state with IpAddress =
                         match state.IpAddress with
@@ -174,6 +173,7 @@ type ContainerGroupBuilder() =
     member this.AddIdentity(state, identity:UserAssignedIdentityConfig) = this.AddIdentity(state, identity.UserAssignedIdentity)
     [<CustomOperation "system_identity">]
     member _.SystemIdentity(state:ContainerGroupConfig) = { state with Identity = { state.Identity with SystemAssigned = Enabled } }
+    interface ITaggable<ContainerGroupConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 /// Creates an image registry credential with a generated SecureParameter for the password.
 let registry (server:string) (username:string) =
@@ -257,7 +257,6 @@ type NetworkProfileConfig =
         ]
 
 type NetworkProfileBuilder() =
-    interface ITaggable<NetworkProfileConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           ContainerNetworkInterfaceConfigurations = []
@@ -275,5 +274,6 @@ type NetworkProfileBuilder() =
     /// Sets the virtual network for the profile
     [<CustomOperation "vnet">]
     member _.VirtualNetwork(state:NetworkProfileConfig, vnet) = { state with VirtualNetwork = ResourceName vnet }
+    interface ITaggable<NetworkProfileConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let networkProfile = NetworkProfileBuilder ()

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -100,7 +100,7 @@ type ContainerGroupConfig =
         ]
 
 type ContainerGroupBuilder() =
-    interface ITaggable<ContainerGroupConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<ContainerGroupConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member private _.AddPort (state, portType, port): ContainerGroupConfig =
         { state with IpAddress =
                         match state.IpAddress with
@@ -257,7 +257,7 @@ type NetworkProfileConfig =
         ]
 
 type NetworkProfileBuilder() =
-    interface ITaggable<NetworkProfileConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<NetworkProfileConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           ContainerNetworkInterfaceConfigurations = []

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -23,7 +23,6 @@ type ContainerRegistryConfig =
               Tags = this.Tags }
         ]
 type ContainerRegistryBuilder() =
-    interface ITaggable<ContainerRegistryConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic
@@ -41,5 +40,6 @@ type ContainerRegistryBuilder() =
     [<CustomOperation "enable_admin_user">]
     /// Enables the admin user on the Azure Container Registry.
     member _.EnableAdminUser (state:ContainerRegistryConfig) = { state with AdminUserEnabled = true }
+    interface ITaggable<ContainerRegistryConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let containerRegistry = ContainerRegistryBuilder()

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -23,7 +23,7 @@ type ContainerRegistryConfig =
               Tags = this.Tags }
         ]
 type ContainerRegistryBuilder() =
-    interface ITaggable<ContainerRegistryConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<ContainerRegistryConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -23,6 +23,7 @@ type ContainerRegistryConfig =
               Tags = this.Tags }
         ]
 type ContainerRegistryBuilder() =
+    interface ITaggable<ContainerRegistryConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic
@@ -40,11 +41,5 @@ type ContainerRegistryBuilder() =
     [<CustomOperation "enable_admin_user">]
     /// Enables the admin user on the Azure Container Registry.
     member _.EnableAdminUser (state:ContainerRegistryConfig) = { state with AdminUserEnabled = true }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:ContainerRegistryConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:ContainerRegistryConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let containerRegistry = ContainerRegistryBuilder()

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -137,6 +137,7 @@ type CosmosDbContainerBuilder() =
     member __.ExcludePath (state:CosmosDbContainerConfig, path) =
         { state with ExcludedPaths = path :: state.ExcludedPaths }
 type CosmosDbBuilder() =
+    interface ITaggable<CosmosDbConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member __.Yield _ =
         { DbName = ResourceName.Empty
           AccountName = derived (fun config ->
@@ -188,12 +189,6 @@ type CosmosDbBuilder() =
     /// Enables the use of CosmosDB free tier (one per subscription).
     [<CustomOperation "free_tier">]
     member __.FreeTier(state:CosmosDbConfig) = { state with FreeTier = true }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:CosmosDbConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:CosmosDbConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let cosmosDb = CosmosDbBuilder()
 let cosmosContainer = CosmosDbContainerBuilder()

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -137,7 +137,7 @@ type CosmosDbContainerBuilder() =
     member __.ExcludePath (state:CosmosDbContainerConfig, path) =
         { state with ExcludedPaths = path :: state.ExcludedPaths }
 type CosmosDbBuilder() =
-    interface ITaggable<CosmosDbConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<CosmosDbConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
         { DbName = ResourceName.Empty
           AccountName = derived (fun config ->

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -137,7 +137,6 @@ type CosmosDbContainerBuilder() =
     member __.ExcludePath (state:CosmosDbContainerConfig, path) =
         { state with ExcludedPaths = path :: state.ExcludedPaths }
 type CosmosDbBuilder() =
-    interface ITaggable<CosmosDbConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
         { DbName = ResourceName.Empty
           AccountName = derived (fun config ->
@@ -189,6 +188,7 @@ type CosmosDbBuilder() =
     /// Enables the use of CosmosDB free tier (one per subscription).
     [<CustomOperation "free_tier">]
     member __.FreeTier(state:CosmosDbConfig) = { state with FreeTier = true }
+    interface ITaggable<CosmosDbConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let cosmosDb = CosmosDbBuilder()
 let cosmosContainer = CosmosDbContainerBuilder()

--- a/src/Farmer/Builders/Builders.DataLake.fs
+++ b/src/Farmer/Builders/Builders.DataLake.fs
@@ -21,7 +21,6 @@ type DataLakeConfig =
         ]
 
 type DataLakeBuilder() =
-    interface ITaggable<DataLakeConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
         { Name = ResourceName ""
           EncryptionState = Disabled
@@ -30,13 +29,11 @@ type DataLakeBuilder() =
 
     /// Sets the name of the data lake.
     [<CustomOperation "name">]
-    member __.Name (state:DataLakeConfig, name) =
-        { state with Name = ResourceName name }
+    member __.Name (state:DataLakeConfig, name) = { state with Name = ResourceName name }
     [<CustomOperation "enable_encryption">]
-    member _.EncryptionState (state:DataLakeConfig) =
-        { state with EncryptionState = Enabled }
+    member _.EncryptionState (state:DataLakeConfig) = { state with EncryptionState = Enabled }
     [<CustomOperation "sku">]
-    member _.Sku (state:DataLakeConfig, sku) =
-        { state with Sku = sku }
+    member _.Sku (state:DataLakeConfig, sku) = { state with Sku = sku }
+    interface ITaggable<DataLakeConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let dataLake = DataLakeBuilder()

--- a/src/Farmer/Builders/Builders.DataLake.fs
+++ b/src/Farmer/Builders/Builders.DataLake.fs
@@ -21,6 +21,7 @@ type DataLakeConfig =
         ]
 
 type DataLakeBuilder() =
+    interface ITaggable<DataLakeConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member __.Yield _ =
         { Name = ResourceName ""
           EncryptionState = Disabled
@@ -37,11 +38,5 @@ type DataLakeBuilder() =
     [<CustomOperation "sku">]
     member _.Sku (state:DataLakeConfig, sku) =
         { state with Sku = sku }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:DataLakeConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:DataLakeConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let dataLake = DataLakeBuilder()

--- a/src/Farmer/Builders/Builders.DataLake.fs
+++ b/src/Farmer/Builders/Builders.DataLake.fs
@@ -21,7 +21,7 @@ type DataLakeConfig =
         ]
 
 type DataLakeBuilder() =
-    interface ITaggable<DataLakeConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<DataLakeConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
         { Name = ResourceName ""
           EncryptionState = Disabled

--- a/src/Farmer/Builders/Builders.DeploymentScript.fs
+++ b/src/Farmer/Builders/Builders.DeploymentScript.fs
@@ -75,8 +75,6 @@ type DeploymentScriptConfig =
         ]
 
 type DeploymentScriptBuilder() =
-    interface ITaggable<DeploymentScriptConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
-    interface IDependsOn<DeploymentScriptConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Dependencies = Set.empty
@@ -147,5 +145,7 @@ type DeploymentScriptBuilder() =
     /// Timeout for script execution in ISO 8601 format, e.g. PT30M.
     member _.Timeout(state:DeploymentScriptConfig, timeout) =
         { state with Timeout = Some (Xml.XmlConvert.ToTimeSpan timeout) }
+    interface ITaggable<DeploymentScriptConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependsOn<DeploymentScriptConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 let deploymentScript = DeploymentScriptBuilder()

--- a/src/Farmer/Builders/Builders.DeploymentScript.fs
+++ b/src/Farmer/Builders/Builders.DeploymentScript.fs
@@ -147,6 +147,6 @@ type DeploymentScriptBuilder() =
     member _.Timeout(state:DeploymentScriptConfig, timeout) =
         { state with Timeout = Some (Xml.XmlConvert.ToTimeSpan timeout) }
     interface ITaggable<DeploymentScriptConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
-    interface IDependsOn<DeploymentScriptConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface IDependable<DeploymentScriptConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 let deploymentScript = DeploymentScriptBuilder()

--- a/src/Farmer/Builders/Builders.DeploymentScript.fs
+++ b/src/Farmer/Builders/Builders.DeploymentScript.fs
@@ -75,6 +75,7 @@ type DeploymentScriptConfig =
         ]
 
 type DeploymentScriptBuilder() =
+    interface ITaggable<DeploymentScriptConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Dependencies = Set.empty
@@ -145,12 +146,6 @@ type DeploymentScriptBuilder() =
     /// Timeout for script execution in ISO 8601 format, e.g. PT30M.
     member _.Timeout(state:DeploymentScriptConfig, timeout) =
         { state with Timeout = Some (Xml.XmlConvert.ToTimeSpan timeout) }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:DeploymentScriptConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:DeploymentScriptConfig, key, value) = this.Tags(state, [ (key,value) ])
 
     /// Sets a dependency for the deployment script. Use this if you want to ensure that the script runs only after another resource has been deployed.
     [<CustomOperation "depends_on">]

--- a/src/Farmer/Builders/Builders.DeploymentScript.fs
+++ b/src/Farmer/Builders/Builders.DeploymentScript.fs
@@ -75,8 +75,8 @@ type DeploymentScriptConfig =
         ]
 
 type DeploymentScriptBuilder() =
-    interface ITaggable<DeploymentScriptConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
-    interface IDependsOn<DeploymentScriptConfig> with member _.SetDependencies state mergeDeps = { state with Dependencies = mergeDeps state.Dependencies }
+    interface ITaggable<DeploymentScriptConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependsOn<DeploymentScriptConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Dependencies = Set.empty

--- a/src/Farmer/Builders/Builders.DeploymentScript.fs
+++ b/src/Farmer/Builders/Builders.DeploymentScript.fs
@@ -76,6 +76,7 @@ type DeploymentScriptConfig =
 
 type DeploymentScriptBuilder() =
     interface ITaggable<DeploymentScriptConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface IDependsOn<DeploymentScriptConfig> with member _.SetDependencies state mergeDeps = { state with Dependencies = mergeDeps state.Dependencies }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Dependencies = Set.empty
@@ -146,14 +147,5 @@ type DeploymentScriptBuilder() =
     /// Timeout for script execution in ISO 8601 format, e.g. PT30M.
     member _.Timeout(state:DeploymentScriptConfig, timeout) =
         { state with Timeout = Some (Xml.XmlConvert.ToTimeSpan timeout) }
-
-    /// Sets a dependency for the deployment script. Use this if you want to ensure that the script runs only after another resource has been deployed.
-    [<CustomOperation "depends_on">]
-    member this.DependsOn(state:DeploymentScriptConfig, builder:IBuilder) = this.DependsOn (state, builder.ResourceId)
-    member this.DependsOn(state:DeploymentScriptConfig, builders:IBuilder list) = this.DependsOn (state, builders |> List.map (fun x -> x.ResourceId))
-    member this.DependsOn(state:DeploymentScriptConfig, resource:IArmResource) = this.DependsOn (state, resource.ResourceId)
-    member this.DependsOn(state:DeploymentScriptConfig, resources:IArmResource list) = this.DependsOn (state, resources |> List.map (fun x -> x.ResourceId))
-    member _.DependsOn (state:DeploymentScriptConfig, resourceId:ResourceId) = { state with Dependencies = state.Dependencies.Add resourceId }
-    member _.DependsOn (state:DeploymentScriptConfig, resourceIds:ResourceId list) = { state with Dependencies = Set resourceIds + state.Dependencies }
 
 let deploymentScript = DeploymentScriptBuilder()

--- a/src/Farmer/Builders/Builders.EventHub.fs
+++ b/src/Farmer/Builders/Builders.EventHub.fs
@@ -145,7 +145,7 @@ type EventHubBuilder() =
     member this.CaptureToStorage(state:EventHubConfig, storageAccount:StorageAccountConfig, container) =
         this.CaptureToStorage(state, storageAccount.Name.ResourceName, container)
 
-    interface IDependsOn<EventHubConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface IDependable<EventHubConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     interface ITaggable<EventHubConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let eventHub = EventHubBuilder()

--- a/src/Farmer/Builders/Builders.EventHub.fs
+++ b/src/Farmer/Builders/Builders.EventHub.fs
@@ -23,7 +23,7 @@ type EventHubConfig =
       ConsumerGroups : ResourceName Set
       CaptureDestination : CaptureDestination option
       AuthorizationRules : Map<ResourceName, AuthorizationRuleRight Set>
-      Dependencies : ResourceId list
+      Dependencies : ResourceId Set
       Tags: Map<string,string>  }
     member private this.CreateKeyExpression (resourceId:ResourceId) =
         ArmExpression
@@ -64,7 +64,7 @@ type EventHubConfig =
               MessageRetentionDays = this.MessageRetentionInDays
               Partitions = this.Partitions
               CaptureDestination = this.CaptureDestination
-              Dependencies = [
+              Dependencies = Set [
                   namespaces.resourceId this.EventHubNamespaceName
                   yield! this.CaptureDestination |> Option.mapList (fun (StorageAccount (name, _)) -> storageAccounts.resourceId name)
                   yield! this.Dependencies
@@ -105,7 +105,7 @@ type EventHubBuilder() =
           CaptureDestination = None
           ConsumerGroups = Set [ ResourceName "$Default" ]
           AuthorizationRules = Map.empty
-          Dependencies = []
+          Dependencies = Set.empty
           Tags = Map.empty }
     /// Sets the name of the Event Hub instance.
     [<CustomOperation "name">]
@@ -145,20 +145,7 @@ type EventHubBuilder() =
     member this.CaptureToStorage(state:EventHubConfig, storageAccount:StorageAccountConfig, container) =
         this.CaptureToStorage(state, storageAccount.Name.ResourceName, container)
 
-    /// Sets a dependency for the web app.
-    [<CustomOperation "depends_on">]
-    member this.DependsOn(state:EventHubConfig, builder:IBuilder) = this.DependsOn (state, builder.ResourceId)
-    member this.DependsOn(state:EventHubConfig, builders:IBuilder list) = this.DependsOn (state, builders |> List.map (fun x -> x.ResourceId))
-    member this.DependsOn(state:EventHubConfig, resource:IArmResource) = this.DependsOn (state, resource.ResourceId)
-    member this.DependsOn(state:EventHubConfig, resources:IArmResource list) = this.DependsOn (state, resources |> List.map (fun x -> x.ResourceId))
-    member _.DependsOn (state:EventHubConfig, resourceId:ResourceId) = { state with Dependencies = resourceId :: state.Dependencies }
-    member _.DependsOn (state:EventHubConfig, resourceIds:ResourceId list) = { state with Dependencies = resourceIds @ state.Dependencies }
-
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:EventHubConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:EventHubConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface IDependsOn<EventHubConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface ITaggable<EventHubConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let eventHub = EventHubBuilder()

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -105,6 +105,7 @@ type ExpressRouteConfig =
         ]
 
 type ExpressRouteBuilder() =
+    interface ITaggable<ExpressRouteConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member __.Yield _ =
       { Name = ResourceName.Empty
         Tier = Standard
@@ -139,10 +140,4 @@ type ExpressRouteBuilder() =
     /// Enables Global Reach on the circuit
     [<CustomOperation "enable_global_reach">]
     member __.EnableGlobalReach(state:ExpressRouteConfig) = { state with GlobalReachEnabled = true }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:ExpressRouteConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:ExpressRouteConfig, key, value) = this.Tags(state, [ (key,value) ])
 let expressRoute = ExpressRouteBuilder()

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -105,7 +105,6 @@ type ExpressRouteConfig =
         ]
 
 type ExpressRouteBuilder() =
-    interface ITaggable<ExpressRouteConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
       { Name = ResourceName.Empty
         Tier = Standard
@@ -140,4 +139,5 @@ type ExpressRouteBuilder() =
     /// Enables Global Reach on the circuit
     [<CustomOperation "enable_global_reach">]
     member __.EnableGlobalReach(state:ExpressRouteConfig) = { state with GlobalReachEnabled = true }
+    interface ITaggable<ExpressRouteConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 let expressRoute = ExpressRouteBuilder()

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -105,7 +105,7 @@ type ExpressRouteConfig =
         ]
 
 type ExpressRouteBuilder() =
-    interface ITaggable<ExpressRouteConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<ExpressRouteConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
       { Name = ResourceName.Empty
         Tier = Standard

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -14,9 +14,9 @@ type FunctionsRuntime = DotNet | Node | Java | Python
 type FunctionsExtensionVersion = V1 | V2 | V3
 type FunctionsConfig =
     { Name : ResourceName
-      ServicePlan : ResourceRef<FunctionsConfig>
+      ServicePlan : ResourceRef<ResourceName>
       HTTPSOnly : bool
-      AppInsights : ResourceRef<FunctionsConfig> option
+      AppInsights : ResourceRef<ResourceName> option
       OperatingSystem : OS
       Settings : Map<string, Setting>
       Tags : Map<string, string>
@@ -45,11 +45,11 @@ type FunctionsConfig =
         sprintf "listkeys(concat(resourceId('Microsoft.Web/sites', '%s'), '/host/default/'),'2016-08-01').masterKey" this.Name.Value
         |> ArmExpression.create
     /// Gets this web app's Server Plan's full resource ID.
-    member this.ServicePlanId = this.ServicePlan.resourceId this
+    member this.ServicePlanId = this.ServicePlan.resourceId this.Name
     /// Gets the Service Plan name for this web app.
     member this.ServicePlanName = this.ServicePlanId.Name
     /// Gets the App Insights name for this functions app, if it exists.
-    member this.AppInsightsName : ResourceName option = this.AppInsights |> Option.map (fun ai -> ai.resourceId(this).Name)
+    member this.AppInsightsName : ResourceName option = this.AppInsights |> Option.map (fun ai -> ai.resourceId(this.Name).Name)
     /// Gets the Storage Account name for this functions app.
     member this.StorageAccountName : Storage.StorageAccountName = this.StorageAccount.resourceId(this).Name |> Storage.StorageAccountName.Create |> Result.get
     interface IBuilder with
@@ -87,7 +87,7 @@ type FunctionsConfig =
                 yield! this.Dependencies
 
                 match this.AppInsights with
-                | Some (DependableResource this resourceId) -> resourceId
+                | Some (DependableResource this.Name resourceId) -> resourceId
                 | _ -> ()
 
                 for setting in this.Settings do
@@ -96,7 +96,7 @@ type FunctionsConfig =
                     | ParameterSetting _ | LiteralSetting _ -> ()
 
                 match this.ServicePlan with
-                | DependableResource this resourceId -> resourceId
+                | DependableResource this.Name resourceId -> resourceId
                 | _ -> ()
 
                 match this.StorageAccount with
@@ -120,7 +120,7 @@ type FunctionsConfig =
               AppCommandLine = None
             }
             match this.ServicePlan with
-            | DeployableResource this resourceId ->
+            | DeployableResource this.Name resourceId ->
                 { Name = resourceId.Name
                   Location = location
                   Sku = Sku.Y1
@@ -144,7 +144,7 @@ type FunctionsConfig =
                 ()
 
             match this.AppInsights with
-            | Some (DeployableResource this resourceId) ->
+            | Some (DeployableResource this.Name resourceId) ->
                 { Name = resourceId.Name
                   Location = location
                   DisableIpMasking = false
@@ -162,8 +162,8 @@ type FunctionsConfig =
 type FunctionsBuilder() =
     member _.Yield _ =
         { Name = ResourceName.Empty
-          ServicePlan = derived (fun config -> serverFarms.resourceId (config.Name-"farm"))
-          AppInsights = Some (derived (fun config -> components.resourceId (config.Name-"ai")))
+          ServicePlan = derived (fun name -> serverFarms.resourceId (name-"farm"))
+          AppInsights = Some (derived (fun name -> components.resourceId (name-"ai")))
           StorageAccount = derived (fun config ->
             let storage = config.Name.Map (sprintf "%sstorage") |> sanitiseStorage |> ResourceName
             storageAccounts.resourceId storage)
@@ -177,17 +177,6 @@ type FunctionsBuilder() =
           Identity = ManagedIdentity.Empty
           Tags = Map.empty
           ZipDeployPath = None }
-    /// Sets the name of the functions instance.
-    [<CustomOperation "name">]
-    member _.Name(state:FunctionsConfig, name) = { state with Name = ResourceName name }
-    /// Sets the name of the service plan hosting the function instance.
-    [<CustomOperation "service_plan_name">]
-    member _.ServicePlanName(state:FunctionsConfig, name) = { state with ServicePlan = named serverFarms (ResourceName name) }
-    /// Do not create an automatic service plan; instead, link to a service plan that is created outside of this Functions instance.
-    [<CustomOperation "link_to_service_plan">]
-    member _.LinkToServicePlan(state:FunctionsConfig, name) = { state with ServicePlan = managed serverFarms name }
-    member this.LinkToServicePlan(state:FunctionsConfig, name:string) = this.LinkToServicePlan (state, ResourceName name)
-    member this.LinkToServicePlan(state:FunctionsConfig, config:ServicePlanConfig) = this.LinkToServicePlan (state, config.Name)
     /// Do not create an automatic storage account; instead, link to a storage account that is created outside of this Functions instance.
     [<CustomOperation "link_to_storage_account">]
     member _.LinkToStorageAccount(state:FunctionsConfig, name) = { state with StorageAccount = managed storageAccounts name }
@@ -197,72 +186,36 @@ type FunctionsBuilder() =
     /// Set the name of the storage account instead of using an auto-generated one based on the function instance name.
     [<CustomOperation "storage_account_name">]
     member _.StorageAccountName(state:FunctionsConfig, name) = { state with StorageAccount = named storageAccounts (ResourceName name) }
-    /// Sets the name of the automatically-created app insights instance.
-    [<CustomOperation "app_insights_name">]
-    member _.AppInsightsName(state:FunctionsConfig, name) = { state with AppInsights = Some (named components name) }
-    member this.AppInsightsName(state:FunctionsConfig, name:string) = this.AppInsightsName(state, ResourceName name)
-    /// Removes any automatic app insights creation, configuration and settings for this webapp.
-    [<CustomOperation "app_insights_off">]
-    member _.DeactivateAppInsights(state:FunctionsConfig) = { state with AppInsights = None }
     /// Disables http for this webapp so that only https is used.
     [<CustomOperation "https_only">]
     member _.HttpsOnly(state:FunctionsConfig) = { state with HTTPSOnly = true }
-    /// Instead of creating a new AI instance, configure this webapp to point to another AI instance that you are managing
-    /// yourself.
-    [<CustomOperation "link_to_app_insights">]
-    member _.LinkToAppInsights(state:FunctionsConfig, name) = { state with AppInsights = Some(managed components name) }
-    member _.LinkToAppInsights(state:FunctionsConfig, name) = { state with AppInsights = name |> Option.map (managed components)  }
     /// Sets the runtime of the Functions host.
     [<CustomOperation "use_runtime">]
     member _.Runtime(state:FunctionsConfig, runtime) = { state with Runtime = runtime }
     [<CustomOperation "use_extension_version">]
     member _.ExtensionVersion(state:FunctionsConfig, version) = { state with ExtensionVersion = version }
-    /// Sets the operating system of the Functions host.
-    [<CustomOperation "operating_system">]
-    member _.OperatingSystem(state:FunctionsConfig, os) = { state with OperatingSystem = os }
-    /// Sets an app setting of the web app in the form "key" "value".
-    [<CustomOperation "setting">]
-    member _.AddSetting(state:FunctionsConfig, key, value) = { state with Settings = state.Settings.Add(key, LiteralSetting value) }
-    member _.AddSetting(state:FunctionsConfig, key, value:ArmExpression) = { state with Settings = state.Settings.Add(key, ExpressionSetting value) }
-    member this.AddSetting(state:FunctionsConfig, key, resourceName:ResourceName) = this.AddSetting(state, key, resourceName.Value)
-    /// Sets a list of app setting of the web app in the form "key" "value".
-    [<CustomOperation "settings">]
-    member this.AddSettings(state:FunctionsConfig, settings: (string * string) list) =
-        settings
-        |> List.fold (fun state (key,value: string) -> this.AddSetting(state, key, value)) state
-    member this.AddSettings(state:FunctionsConfig, settings) =
-        settings
-        |> List.fold (fun state (key,value: ArmExpression) -> this.AddSetting(state, key, value)) state
-    /// Sets a dependency for the functions app.
-    /// Creates an app setting of the web app whose value will be supplied as a secret parameter.
-    [<CustomOperation "secret_setting">]
-    member _.AddSecret(state:FunctionsConfig, key) =
-        { state with Settings = state.Settings.Add(key, ParameterSetting (SecureParameter key)) }
 
-    /// sets the list of origins that should be allowed to make cross-origin calls. Use AllOrigins to allow all.
-    [<CustomOperation "enable_cors">]
-    member _.EnableCors (state:FunctionsConfig, origins) = { state with Cors = Some (SpecificOrigins (List.map Uri origins, None)) }
-    member _.EnableCors (state:FunctionsConfig, origins) = { state with Cors = Some origins }
-    /// Allows CORS requests with credentials.
-    [<CustomOperation "enable_cors_credentials">]
-    member _.EnableCorsCredentials (state:FunctionsConfig) =
-        { state with
-            Cors =
-                state.Cors
-                |> Option.map (function
-                | SpecificOrigins (origins, _) -> SpecificOrigins (origins, Some true)
-                | AllOrigins -> failwith "You cannot enable CORS Credentials if you have already set CORS to AllOrigins.")
-        }
-    [<CustomOperation "add_identity">]
-    member _.AddIdentity(state:FunctionsConfig, identity:UserAssignedIdentity) = { state with Identity = state.Identity + identity }
-    member this.AddIdentity(state, identity:UserAssignedIdentityConfig) = this.AddIdentity(state, identity.UserAssignedIdentity)
-    [<CustomOperation "system_identity">]
-    member _.SystemIdentity(state:FunctionsConfig) =
-        { state with Identity = { state.Identity with SystemAssigned = Enabled } }
-    [<CustomOperation "zip_deploy">]
-    /// Specifies a folder path or a zip file containing the function app to install as a post-deployment task.
-    member _.ZipDeploy(state:FunctionsConfig, path) = { state with ZipDeployPath = Some path }
     interface ITaggable<FunctionsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     interface IDependable<FunctionsConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
-
+    interface IServicePlanApp<FunctionsConfig> with
+        member this.Get state =
+            { Name = state.Name
+              ServicePlan = state.ServicePlan
+              AppInsights = state.AppInsights
+              OperatingSystem = state.OperatingSystem
+              Settings = state.Settings
+              Cors = state.Cors
+              Identity = state.Identity
+              ZipDeployPath = state.ZipDeployPath }
+        member this.Wrap state config =
+            { state with
+                Name = config.Name
+                ServicePlan = config.ServicePlan
+                AppInsights = config.AppInsights
+                OperatingSystem = config.OperatingSystem
+                Settings = config.Settings
+                Cors = config.Cors
+                Identity = config.Identity
+                ZipDeployPath = config.ZipDeployPath }
+        
 let functions = FunctionsBuilder()

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -160,8 +160,6 @@ type FunctionsConfig =
         ]
 
 type FunctionsBuilder() =
-    interface ITaggable<FunctionsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
-    interface IDependsOn<FunctionsConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member _.Yield _ =
         { Name = ResourceName.Empty
           ServicePlan = derived (fun config -> serverFarms.resourceId (config.Name-"farm"))
@@ -264,5 +262,7 @@ type FunctionsBuilder() =
     [<CustomOperation "zip_deploy">]
     /// Specifies a folder path or a zip file containing the function app to install as a post-deployment task.
     member _.ZipDeploy(state:FunctionsConfig, path) = { state with ZipDeployPath = Some path }
+    interface ITaggable<FunctionsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependsOn<FunctionsConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 let functions = FunctionsBuilder()

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -160,6 +160,7 @@ type FunctionsConfig =
         ]
 
 type FunctionsBuilder() =
+    interface ITaggable<FunctionsConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           ServicePlan = derived (fun config -> serverFarms.resourceId (config.Name-"farm"))
@@ -268,12 +269,6 @@ type FunctionsBuilder() =
     [<CustomOperation "system_identity">]
     member _.SystemIdentity(state:FunctionsConfig) =
         { state with Identity = { state.Identity with SystemAssigned = Enabled } }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:FunctionsConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:FunctionsConfig, key, value) = this.Tags(state, [ (key,value) ])
     [<CustomOperation "zip_deploy">]
     /// Specifies a folder path or a zip file containing the function app to install as a post-deployment task.
     member _.ZipDeploy(state:FunctionsConfig, path) = { state with ZipDeployPath = Some path }

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -263,6 +263,6 @@ type FunctionsBuilder() =
     /// Specifies a folder path or a zip file containing the function app to install as a post-deployment task.
     member _.ZipDeploy(state:FunctionsConfig, path) = { state with ZipDeployPath = Some path }
     interface ITaggable<FunctionsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
-    interface IDependsOn<FunctionsConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface IDependable<FunctionsConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 let functions = FunctionsBuilder()

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -160,8 +160,8 @@ type FunctionsConfig =
         ]
 
 type FunctionsBuilder() =
-    interface ITaggable<FunctionsConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
-    interface IDependsOn<FunctionsConfig> with member _.SetDependencies state mergeDeps = { state with Dependencies = mergeDeps state.Dependencies }
+    interface ITaggable<FunctionsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependsOn<FunctionsConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member _.Yield _ =
         { Name = ResourceName.Empty
           ServicePlan = derived (fun config -> serverFarms.resourceId (config.Name-"farm"))

--- a/src/Farmer/Builders/Builders.IotHub.fs
+++ b/src/Farmer/Builders/Builders.IotHub.fs
@@ -57,6 +57,7 @@ type IotHubConfig =
         ]
 
 type IotHubBuilder() =
+    interface ITaggable<IotHubConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = F1
@@ -96,13 +97,5 @@ type IotHubBuilder() =
     [<CustomOperation "enable_device_provisioning">]
     /// Sets the name of the SKU/Tier for the IOT Hub instance.
     member _.DeviceProvisioning (state:IotHubConfig) = { state with DeviceProvisioning = Enabled }
-
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:IotHubConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:IotHubConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let iotHub = IotHubBuilder()

--- a/src/Farmer/Builders/Builders.IotHub.fs
+++ b/src/Farmer/Builders/Builders.IotHub.fs
@@ -57,7 +57,7 @@ type IotHubConfig =
         ]
 
 type IotHubBuilder() =
-    interface ITaggable<IotHubConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<IotHubConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = F1

--- a/src/Farmer/Builders/Builders.IotHub.fs
+++ b/src/Farmer/Builders/Builders.IotHub.fs
@@ -57,7 +57,6 @@ type IotHubConfig =
         ]
 
 type IotHubBuilder() =
-    interface ITaggable<IotHubConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = F1
@@ -97,5 +96,6 @@ type IotHubBuilder() =
     [<CustomOperation "enable_device_provisioning">]
     /// Sets the name of the SKU/Tier for the IOT Hub instance.
     member _.DeviceProvisioning (state:IotHubConfig) = { state with DeviceProvisioning = Enabled }
+    interface ITaggable<IotHubConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let iotHub = IotHubBuilder()

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -347,7 +347,7 @@ type SecretBuilder() =
     [<CustomOperation "expiration_date">]
     member __.ExpirationDate(state:SecretConfig, expirationDate) = { state with ExpirationDate = Some expirationDate }
     interface ITaggable<SecretConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
-    interface IDependsOn<SecretConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface IDependable<SecretConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 let secret = SecretBuilder()
 let keyVault = KeyVaultBuilder()

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -216,7 +216,7 @@ type KeyVaultBuilderState =
       Tags: Map<string,string> }
 
 type KeyVaultBuilder() =
-    interface ITaggable<KeyVaultConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<KeyVaultConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield (_:unit) =
         { Name = ResourceName.Empty
           TenantId = Subscription.TenantId
@@ -329,8 +329,8 @@ type KeyVaultBuilder() =
 
 
 type SecretBuilder() =
-    interface ITaggable<SecretConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
-    interface IDependsOn<SecretConfig> with member _.SetDependencies state mergeDeps = { state with Dependencies = mergeDeps state.Dependencies }
+    interface ITaggable<SecretConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependsOn<SecretConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member __.Run(state:SecretConfig) =
         SecretConfig.isValid state.Key
         state

--- a/src/Farmer/Builders/Builders.LogAnalytics.fs
+++ b/src/Farmer/Builders/Builders.LogAnalytics.fs
@@ -29,6 +29,7 @@ type WorkspaceConfig =
         ]
 
 type WorkspaceBuilder() =
+    interface ITaggable<WorkspaceConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           RetentionPeriod = None
@@ -70,15 +71,6 @@ type WorkspaceBuilder() =
     [<CustomOperation "daily_cap">]
     member _.DailyCap(state: WorkspaceConfig, cap) = { state with DailyCap = Some cap }
 
-    /// Adds a set of tags to the resource
-    [<CustomOperation "add_tags">]
-        member _.Tags(state:WorkspaceConfig, pairs) =
-            { state with
-                Tags = pairs |> List.fold (fun map (key, value) -> Map.add key value map) state.Tags }
-
-    /// Adds a tag to the resource
-    [<CustomOperation "add_tag">]
-        member this.Tag(state:WorkspaceConfig, key, value) = this.Tags(state, [ key, value ])
 
 let logAnalytics = WorkspaceBuilder()
 

--- a/src/Farmer/Builders/Builders.LogAnalytics.fs
+++ b/src/Farmer/Builders/Builders.LogAnalytics.fs
@@ -29,7 +29,6 @@ type WorkspaceConfig =
         ]
 
 type WorkspaceBuilder() =
-    interface ITaggable<WorkspaceConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           RetentionPeriod = None
@@ -71,6 +70,7 @@ type WorkspaceBuilder() =
     [<CustomOperation "daily_cap">]
     member _.DailyCap(state: WorkspaceConfig, cap) = { state with DailyCap = Some cap }
 
+    interface ITaggable<WorkspaceConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let logAnalytics = WorkspaceBuilder()
 

--- a/src/Farmer/Builders/Builders.LogAnalytics.fs
+++ b/src/Farmer/Builders/Builders.LogAnalytics.fs
@@ -29,7 +29,7 @@ type WorkspaceConfig =
         ]
 
 type WorkspaceBuilder() =
-    interface ITaggable<WorkspaceConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<WorkspaceConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           RetentionPeriod = None

--- a/src/Farmer/Builders/Builders.Maps.fs
+++ b/src/Farmer/Builders/Builders.Maps.fs
@@ -20,6 +20,7 @@ type MapsConfig =
         ]
 
 type MapsBuilder() =
+    interface ITaggable<MapsConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = S0
@@ -33,10 +34,4 @@ type MapsBuilder() =
     /// Sets the SKU of the Azure Maps instance.
     [<CustomOperation("sku")>]
     member _.Sku(state:MapsConfig, sku) = { state with Sku = sku }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:MapsConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:MapsConfig, key, value) = this.Tags(state, [ (key,value) ])
 let maps = MapsBuilder()

--- a/src/Farmer/Builders/Builders.Maps.fs
+++ b/src/Farmer/Builders/Builders.Maps.fs
@@ -20,7 +20,7 @@ type MapsConfig =
         ]
 
 type MapsBuilder() =
-    interface ITaggable<MapsConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<MapsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = S0

--- a/src/Farmer/Builders/Builders.Maps.fs
+++ b/src/Farmer/Builders/Builders.Maps.fs
@@ -20,7 +20,6 @@ type MapsConfig =
         ]
 
 type MapsBuilder() =
-    interface ITaggable<MapsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = S0
@@ -34,4 +33,6 @@ type MapsBuilder() =
     /// Sets the SKU of the Azure Maps instance.
     [<CustomOperation("sku")>]
     member _.Sku(state:MapsConfig, sku) = { state with Sku = sku }
+    interface ITaggable<MapsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+
 let maps = MapsBuilder()

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -111,6 +111,7 @@ type NsgConfig =
                 buildNsgRule securityGroup rule ((priority + 1) * 100)
         ]
 type NsgBuilder() =
+    interface ITaggable<NsgConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member __.Yield _ =
         { Name = ResourceName.Empty
           SecurityRules = []
@@ -121,10 +122,4 @@ type NsgBuilder() =
     /// Adds rules to this NSG.
     [<CustomOperation "add_rules">]
     member _.AddSecurityRules (state:NsgConfig, rules) = { state with SecurityRules = state.SecurityRules @ rules }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:NsgConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:NsgConfig, key, value) = this.Tags(state, [ (key,value) ])
 let nsg = NsgBuilder()

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -111,7 +111,6 @@ type NsgConfig =
                 buildNsgRule securityGroup rule ((priority + 1) * 100)
         ]
 type NsgBuilder() =
-    interface ITaggable<NsgConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
         { Name = ResourceName.Empty
           SecurityRules = []
@@ -122,4 +121,6 @@ type NsgBuilder() =
     /// Adds rules to this NSG.
     [<CustomOperation "add_rules">]
     member _.AddSecurityRules (state:NsgConfig, rules) = { state with SecurityRules = state.SecurityRules @ rules }
+    interface ITaggable<NsgConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+
 let nsg = NsgBuilder()

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -111,7 +111,7 @@ type NsgConfig =
                 buildNsgRule securityGroup rule ((priority + 1) * 100)
         ]
 type NsgBuilder() =
-    interface ITaggable<NsgConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<NsgConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
         { Name = ResourceName.Empty
           SecurityRules = []

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -167,7 +167,7 @@ type PostgreSQLDbBuilder() =
 let postgreSQLDb = PostgreSQLDbBuilder()
 
 type PostgreSQLBuilder() =
-    interface ITaggable<PostgreSQLConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<PostgreSQLConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ : PostgreSQLConfig =
         { Name = ResourceName ""
           AdministratorCredentials = {| UserName = ""; Password = SecureParameter "" |}

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -167,7 +167,6 @@ type PostgreSQLDbBuilder() =
 let postgreSQLDb = PostgreSQLDbBuilder()
 
 type PostgreSQLBuilder() =
-    interface ITaggable<PostgreSQLConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member _.Yield _ : PostgreSQLConfig =
         { Name = ResourceName ""
           AdministratorCredentials = {| UserName = ""; Password = SecureParameter "" |}
@@ -288,5 +287,6 @@ type PostgreSQLBuilder() =
     [<CustomOperation "enable_azure_firewall">]
     member this.EnableAzureFirewall(state:PostgreSQLConfig) =
         this.AddFirewallWall(state, "allow-azure-services", "0.0.0.0", "0.0.0.0")
+    interface ITaggable<PostgreSQLConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let postgreSQL = PostgreSQLBuilder()

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -167,6 +167,7 @@ type PostgreSQLDbBuilder() =
 let postgreSQLDb = PostgreSQLDbBuilder()
 
 type PostgreSQLBuilder() =
+    interface ITaggable<PostgreSQLConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member _.Yield _ : PostgreSQLConfig =
         { Name = ResourceName ""
           AdministratorCredentials = {| UserName = ""; Password = SecureParameter "" |}
@@ -287,12 +288,5 @@ type PostgreSQLBuilder() =
     [<CustomOperation "enable_azure_firewall">]
     member this.EnableAzureFirewall(state:PostgreSQLConfig) =
         this.AddFirewallWall(state, "allow-azure-services", "0.0.0.0", "0.0.0.0")
-
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:PostgreSQLConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:PostgreSQLConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let postgreSQL = PostgreSQLBuilder()

--- a/src/Farmer/Builders/Builders.Redis.fs
+++ b/src/Farmer/Builders/Builders.Redis.fs
@@ -40,7 +40,7 @@ type RedisConfig =
         ]
 
 type RedisBuilder() =
-    interface ITaggable<RedisConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
+    interface ITaggable<RedisConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic

--- a/src/Farmer/Builders/Builders.Redis.fs
+++ b/src/Farmer/Builders/Builders.Redis.fs
@@ -40,7 +40,6 @@ type RedisConfig =
         ]
 
 type RedisBuilder() =
-    interface ITaggable<RedisConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     member __.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic
@@ -92,5 +91,6 @@ type RedisBuilder() =
     member __.ShardCount(state:RedisConfig, shardCount) = { state with ShardCount = Some shardCount }
     [<CustomOperation "minimum_tls_version">]
     member __.MinimumTlsVersion(state:RedisConfig, tlsVersion) = { state with MinimumTlsVersion = Some tlsVersion }
+    interface ITaggable<RedisConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let redis = RedisBuilder()

--- a/src/Farmer/Builders/Builders.Redis.fs
+++ b/src/Farmer/Builders/Builders.Redis.fs
@@ -40,6 +40,7 @@ type RedisConfig =
         ]
 
 type RedisBuilder() =
+    interface ITaggable<RedisConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member __.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic
@@ -91,11 +92,5 @@ type RedisBuilder() =
     member __.ShardCount(state:RedisConfig, shardCount) = { state with ShardCount = Some shardCount }
     [<CustomOperation "minimum_tls_version">]
     member __.MinimumTlsVersion(state:RedisConfig, tlsVersion) = { state with MinimumTlsVersion = Some tlsVersion }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:RedisConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:RedisConfig, key, value) = this.Tags(state, [ (key,value) ])
 
 let redis = RedisBuilder()

--- a/src/Farmer/Builders/Builders.Search.fs
+++ b/src/Farmer/Builders/Builders.Search.fs
@@ -54,11 +54,6 @@ type SearchBuilder() =
     /// Sets the number of partitions of the Azure Search instance.
     [<CustomOperation "partitions">]
     member __.PartitionCount(state:SearchConfig, partitions:int) = { state with Partitions = partitions }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:SearchConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:SearchConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<SearchConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let search = SearchBuilder()

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -201,7 +201,7 @@ type ServiceBusConfig =
         ]
 
 type ServiceBusBuilder() =
-    interface IDependsOn<ServiceBusConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface IDependable<ServiceBusConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -138,7 +138,7 @@ type ServiceBusTopicBuilder() =
 type ServiceBusConfig =
     { Name : ResourceName
       Sku : Sku
-      Dependencies : ResourceId list
+      Dependencies : ResourceId Set
       Queues : Map<ResourceName, ServiceBusQueueConfig>
       Topics : Map<ResourceName, ServiceBusTopicConfig>
       Tags: Map<string,string>  }
@@ -201,12 +201,13 @@ type ServiceBusConfig =
         ]
 
 type ServiceBusBuilder() =
+    interface IDependsOn<ServiceBusConfig> with member _.SetDependencies state mergeDeps = { state with Dependencies = mergeDeps state.Dependencies }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic
           Queues = Map.empty
           Topics = Map.empty
-          Dependencies = List.empty
+          Dependencies = Set.empty
           Tags = Map.empty  }
     member _.Run (state:ServiceBusConfig) =
         let isBetween min max v = v >= min && v <= max
@@ -226,15 +227,6 @@ type ServiceBusBuilder() =
     /// The SKU of the namespace.
     [<CustomOperation "sku">]
     member _.Sku(state:ServiceBusConfig, sku) = { state with Sku = sku }
-
-    /// Sets a dependency for the web app.
-    [<CustomOperation "depends_on">]
-    member this.DependsOn(state:ServiceBusConfig, builder:IBuilder) = this.DependsOn (state, builder.ResourceId)
-    member this.DependsOn(state:ServiceBusConfig, builders:IBuilder list) = this.DependsOn (state, builders |> List.map (fun x -> x.ResourceId))
-    member this.DependsOn(state:ServiceBusConfig, resource:IArmResource) = this.DependsOn (state, resource.ResourceId)
-    member this.DependsOn(state:ServiceBusConfig, resources:IArmResource list) = this.DependsOn (state, resources |> List.map (fun x -> x.ResourceId))
-    member this.DependsOn (state:ServiceBusConfig, resourceId:ResourceId) = { state with Dependencies = resourceId :: state.Dependencies }
-    member this.DependsOn (state:ServiceBusConfig, resourceIds:ResourceId list) = { state with Dependencies = resourceIds @ state.Dependencies }
 
     [<CustomOperation "add_queues">]
     member _.AddQueues(state:ServiceBusConfig, queues) =

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -242,12 +242,7 @@ type ServiceBusBuilder() =
                 (state.Topics, topics)
                 ||> List.fold(fun state (topic:ServiceBusTopicConfig) -> state.Add(topic.Name, topic))
         }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:ServiceBusConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:ServiceBusConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<ServiceBusConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let serviceBus = ServiceBusBuilder()
 let topic = ServiceBusTopicBuilder()

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -201,7 +201,7 @@ type ServiceBusConfig =
         ]
 
 type ServiceBusBuilder() =
-    interface IDependsOn<ServiceBusConfig> with member _.SetDependencies state mergeDeps = { state with Dependencies = mergeDeps state.Dependencies }
+    interface IDependsOn<ServiceBusConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member _.Yield _ =
         { Name = ResourceName.Empty
           Sku = Basic

--- a/src/Farmer/Builders/Builders.ServicePlan.fs
+++ b/src/Farmer/Builders/Builders.ServicePlan.fs
@@ -50,10 +50,6 @@ type ServicePlanBuilder() =
     [<CustomOperation "serverless">]
     /// Configures this server farm to host serverless functions, not web apps.
     member __.Serverless(state:ServicePlanConfig) = { state with Sku = Dynamic; WorkerSize = Serverless }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:ServicePlanConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:ServicePlanConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<ServicePlanConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+
 let servicePlan = ServicePlanBuilder()

--- a/src/Farmer/Builders/Builders.SignalR.fs
+++ b/src/Farmer/Builders/Builders.SignalR.fs
@@ -50,12 +50,7 @@ type SignalRBuilder() =
     /// Sets the allowed origins of the Azure SignalR instance.
     [<CustomOperation("allowed_origins")>]
     member _.AllowedOrigins(state:SignalRConfig, allowedOrigins) = { state with AllowedOrigins = allowedOrigins}
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:SignalRConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:SignalRConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<SignalRConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let signalR = SignalRBuilder()
 

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -202,11 +202,7 @@ type SqlServerBuilder() =
             AdministratorCredentials =
                 {| state.AdministratorCredentials with
                     UserName = username |} }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:SqlAzureConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:SqlAzureConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<SqlAzureConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+
 let sqlServer = SqlServerBuilder()
 let sqlDb = SqlDbBuilder()

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -171,13 +171,6 @@ type StorageAccountBuilder() =
     [<CustomOperation "enable_data_lake">]
     member _.UseHns(state:StorageAccountConfig, value) = { state with EnableDataLake = Some value }
     /// Adds tags to the storage account
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:StorageAccountConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    /// Adds a tag to the storage account
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:StorageAccountConfig, key, value) = this.Tags(state, [ (key,value) ])
     /// Adds a lifecycle rule
     [<CustomOperation "add_lifecycle_rule">]
     member _.AddLifecycleRule(state:StorageAccountConfig, ruleName, actions, filters) =
@@ -205,6 +198,7 @@ type StorageAccountBuilder() =
                 | GeneralPurpose (V2 (replication, _)) -> GeneralPurpose (V2 (replication, Some tier))
                 | other -> failwithf "You can only set the default access tier for Blobs or General Purpose V2 storage accounts. This account is %A" other
         }
+    interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 /// Allow adding storage accounts directly to CDNs
 type EndpointBuilder with

--- a/src/Farmer/Builders/Builders.UserAssignedIdentity.fs
+++ b/src/Farmer/Builders/Builders.UserAssignedIdentity.fs
@@ -28,13 +28,7 @@ type UserAssignedIdentityBuilder() =
     [<CustomOperation "name">]
     member __.Name(state:UserAssignedIdentityConfig, name) = { state with Name = ResourceName name }
     /// Adds tags to the user assigned identity.
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:UserAssignedIdentityConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key, value) -> Map.add key value map) state.Tags }
-    /// Adds a tag to the user assigned identity.
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:UserAssignedIdentityConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<UserAssignedIdentityConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 /// Builds a user assigned identity.
 let userAssignedIdentity = UserAssignedIdentityBuilder()

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -133,11 +133,6 @@ type VirtualNetworkBuilder() =
         { state
           with Subnets = state.Subnets |> Seq.append newSubnets |> List.ofSeq
                AddressSpacePrefixes = state.AddressSpacePrefixes |> Seq.append newAddressSpaces |> List.ofSeq }
-      [<CustomOperation "add_tags">]
-      member _.Tags(state:VirtualNetworkConfig, pairs) =
-          { state with
-              Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-      [<CustomOperation "add_tag">]
-      member this.Tag(state:VirtualNetworkConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<VirtualNetworkConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let vnet = VirtualNetworkBuilder ()

--- a/src/Farmer/Builders/Builders.VirtualNetworkGateway.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetworkGateway.fs
@@ -168,12 +168,7 @@ type VnetGatewayBuilder() =
     /// Sets the VPN Client configuration.
     member _.SetVpnClient(state:VNetGatewayConfig, vpnClientConfig) =
         { state with VpnClientConfiguration = Some vpnClientConfig }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:VNetGatewayConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:VNetGatewayConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<VNetGatewayConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let gateway = VnetGatewayBuilder()
 
@@ -228,11 +223,6 @@ type ConnectionBuilder() =
     /// Sets the first vnet gateway
     [<CustomOperation "auth_key">]
     member _.Authorization(state:ConnectionConfig, auth) = { state with AuthorizationKey = Some auth }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:ConnectionConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:ConnectionConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<ConnectionConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let connection = ConnectionBuilder()

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -218,11 +218,6 @@ type VirtualMachineBuilder() =
     member _.CustomScript(state:VmConfig, script:string) = { state with CustomScript = Some script }
     [<CustomOperation "custom_script_files">]
     member _.CustomScriptFiles(state:VmConfig, uris:string list) = { state with CustomScriptFiles = uris |> List.map Uri }
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:VmConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:VmConfig, key, value) = this.Tags(state, [ (key,value) ])
+    interface ITaggable<VmConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let vm = VirtualMachineBuilder()

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -108,9 +108,8 @@ type WebAppConfig =
       DockerAcrCredentials : {| RegistryName : string; Password : SecureParameter |} option
       SecretStore : SecretStore
       AutomaticLoggingExtension : bool
-      SiteExtensions : ExtensionName Set }
-      
-      WorkerProcess : Bitness option
+      SiteExtensions : ExtensionName Set
+      WorkerProcess : Bitness option }
     /// Gets this web app's Server Plan's full resource ID.
     member this.ServicePlanId = this.ServicePlan.resourceId this.Name
     /// Gets the Service Plan name for this web app.
@@ -553,11 +552,11 @@ type EndpointBuilder with
     member this.Origin(state:EndpointConfig, webApp:WebAppConfig) =
         let state = this.Origin(state, webApp.Endpoint)
         this.DependsOn(state, webApp.ResourceId)
-        
+
 type IServicePlanApp<'T> =
     abstract member Get : 'T -> CommonWebConfig
     abstract member Wrap : 'T -> CommonWebConfig -> 'T
-    
+
 [<AutoOpen>]
 module Extensions =
     type IServicePlanApp<'T> with
@@ -585,7 +584,7 @@ module Extensions =
         member this.UseAppInsights (state:'T, name:string) = this.UseAppInsights(state, ResourceName name)
         /// Removes any automatic app insights creation, configuration and settings for this webapp.
         [<CustomOperation "app_insights_off">]
-        member this.DeactivateAppInsights (state:'T) = { this.Get state with AppInsights = None } |> this.Wrap state        
+        member this.DeactivateAppInsights (state:'T) = { this.Get state with AppInsights = None } |> this.Wrap state
         /// Instead of creating a new AI instance, configure this webapp to point to another Farmer-managed AI instance.
         /// A dependency will automatically be set for this instance.
         [<CustomOperation "link_to_app_insights">]
@@ -632,7 +631,7 @@ module Extensions =
         member this.SystemIdentity (state:'T) =
             let current = this.Get state
             { current with Identity = { current.Identity with SystemAssigned = Enabled } }
-            |> this.Wrap state        
+            |> this.Wrap state
         /// sets the list of origins that should be allowed to make cross-origin calls. Use AllOrigins to allow all.
         [<CustomOperation "enable_cors">]
         member this.EnableCors (state:'T, origins) =

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -525,7 +525,7 @@ type WebAppBuilder() =
     interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     interface IDependable<WebAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     interface IServicePlanApp<WebAppConfig> with
-        member this.Get state =
+        member _.Get state =
             { Name = state.Name
               ServicePlan = state.ServicePlan
               AppInsights = state.AppInsights
@@ -534,7 +534,7 @@ type WebAppBuilder() =
               Cors = state.Cors
               Identity = state.Identity
               ZipDeployPath = state.ZipDeployPath }
-        member this.Wrap state config =
+        member _.Wrap state config =
             { state with
                 Name = config.Name
                 ServicePlan = config.ServicePlan
@@ -553,10 +553,13 @@ type EndpointBuilder with
         let state = this.Origin(state, webApp.Endpoint)
         this.DependsOn(state, webApp.ResourceId)
 
+/// An interface for shared capabilities between builders that work with Service Plan-style apps.
+/// In other words, Web Apps or Functions.
 type IServicePlanApp<'T> =
     abstract member Get : 'T -> CommonWebConfig
     abstract member Wrap : 'T -> CommonWebConfig -> 'T
 
+// Common keywords for IServicePlanApp live here.
 [<AutoOpen>]
 module Extensions =
     type IServicePlanApp<'T> with

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -550,7 +550,7 @@ type EndpointBuilder with
     member this.Origin(state:EndpointConfig, webApp:WebAppConfig) =
         let state = this.Origin(state, webApp.Endpoint)
         this.DependsOn(state, webApp.ResourceId)
-
+        
 type IServicePlanApp<'T> =
     abstract member Get : 'T -> CommonWebConfig
     abstract member Wrap : 'T -> CommonWebConfig -> 'T

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -601,7 +601,7 @@ type WebAppBuilder() =
     member _.DefaultLogging(state, setting) =
         { state with AutomaticLoggingExtension = setting }
     interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
-    interface IDependsOn<WebAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface IDependable<WebAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 let webApp = WebAppBuilder()
 

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -369,6 +369,7 @@ type WebAppConfig =
         ]
 
 type WebAppBuilder() =
+    interface ITaggable<WebAppConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
     member __.Yield _ =
         { Name = ResourceName.Empty
           ServicePlan = derived (fun config -> serverFarms.resourceId (config.Name-"farm"))
@@ -580,12 +581,6 @@ type WebAppBuilder() =
     member this.EnableCi(state:WebAppConfig) = this.SourceControlCi(state, Enabled)
     [<CustomOperation "disable_source_control_ci">]
     member this.DisableCi(state:WebAppConfig) = this.SourceControlCi(state, Disabled)
-    [<CustomOperation "add_tags">]
-    member _.Tags(state:WebAppConfig, pairs) =
-        { state with
-            Tags = pairs |> List.fold (fun map (key,value) -> Map.add key value map) state.Tags }
-    [<CustomOperation "add_tag">]
-    member this.Tag(state:WebAppConfig, key, value) = this.Tags(state, [ (key,value) ])
     [<CustomOperation "use_keyvault">]
     member this.UseKeyVault(state:WebAppConfig) =
         let state = this.SystemIdentity (state)

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -369,8 +369,8 @@ type WebAppConfig =
         ]
 
 type WebAppBuilder() =
-    interface ITaggable<WebAppConfig> with member _.SetTags state mergeTags = { state with Tags = mergeTags state.Tags }
-    interface IDependsOn<WebAppConfig> with member _.SetDependencies state mergeDeps = { state with Dependencies = mergeDeps state.Dependencies }
+    interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependsOn<WebAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member __.Yield _ =
         { Name = ResourceName.Empty
           ServicePlan = derived (fun config -> serverFarms.resourceId (config.Name-"farm"))

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -369,8 +369,6 @@ type WebAppConfig =
         ]
 
 type WebAppBuilder() =
-    interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
-    interface IDependsOn<WebAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     member __.Yield _ =
         { Name = ResourceName.Empty
           ServicePlan = derived (fun config -> serverFarms.resourceId (config.Name-"farm"))
@@ -590,6 +588,8 @@ type WebAppBuilder() =
         { state with SiteExtensions = state.SiteExtensions.Add extension }
     member this.AddExtension(state, name) =
         this.AddExtension(state, ExtensionName name)
+    interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependsOn<WebAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 let webApp = WebAppBuilder()
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -137,6 +137,24 @@ type ResourceType with
                 |> Option.toObj
                tags = tags |> Option.map box |> Option.toObj |}
 
+type ITaggable<'TConfig> =
+    abstract member SetTags : state:'TConfig -> (Map<string, string> -> Map<string,string>) -> 'TConfig
+
+[<AutoOpen>]
+module Extensions =
+    type ITaggable<'T> with
+        /// Adds the provided set of tags to the builder.
+        [<CustomOperation "add_tags">]
+        member this.Tags(state:'T, pairs) =
+            let mergeTags currentTags =
+                (currentTags, pairs)
+                ||> List.fold (fun map (key, value) -> Map.add key value map)
+            this.SetTags state mergeTags
+
+            //this.AddTags state pairs
+        /// Adds the provided tag to the builder.
+        [<CustomOperation "add_tag">]
+        member this.Tag(state:'T, key, value) = this.Tags(state, [ key, value])
 
 /// A secure parameter to be captured in an ARM template.
 type SecureParameter =

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -139,7 +139,7 @@ type ResourceType with
 
 type ITaggable<'TConfig> =
     abstract member Add : 'TConfig -> list<string * string> -> 'TConfig
-type IDependsOn<'TConfig> =
+type IDependable<'TConfig> =
     abstract member Add : 'TConfig -> ResourceId Set -> 'TConfig
 
 [<AutoOpen>]
@@ -159,7 +159,7 @@ module Extensions =
         [<CustomOperation "add_tag">]
         member this.Tag(state:'T, key, value) = this.Tags(state, [ key, value ])
 
-    type IDependsOn<'TConfig> with
+    type IDependable<'TConfig> with
         [<CustomOperation "depends_on">]
         member this.DependsOn(state:'TConfig, builder:IBuilder) = this.DependsOn (state, builder.ResourceId)
         member this.DependsOn(state:'TConfig, builders:IBuilder list) = this.DependsOn (state, builders |> List.map (fun x -> x.ResourceId))


### PR DESCRIPTION
This PR closes #524 

The changes in this PR are as follows:

* Adds two interfaces (`ITaggable` and `IDependable`) for common keywords. Builders now need only implement the data fields on their records and a single method; keywords will magically show up.
* Adds another interface for common keywords between WebApps and Functions.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
