### PR TITLE
Adds initContainer support in container groups

### DIFF
--- a/Farmer.sln
+++ b/Farmer.sln
@@ -14,7 +14,7 @@ ProjectSection(SolutionItems) = preProject
 	samples\scripts\appinsights.fsx = samples\scripts\appinsights.fsx
 	samples\scripts\container-registry.fsx = samples\scripts\container-registry.fsx
 	samples\scripts\cosmos.fsx = samples\scripts\cosmos.fsx
-	samples\scripts\loganalytics.fsx=samples\scripts\loganalytics.fsx
+	samples\scripts\loganalytics.fsx = samples\scripts\loganalytics.fsx
 	samples\scripts\eventhubs.fsx = samples\scripts\eventhubs.fsx
 	samples\scripts\functions.fsx = samples\scripts\functions.fsx
 	samples\scripts\keyvault.fsx = samples\scripts\keyvault.fsx
@@ -27,6 +27,7 @@ ProjectSection(SolutionItems) = preProject
 	samples\scripts\postgresql.fsx = samples\scripts\postgresql.fsx
 	samples\scripts\aks.fsx = samples\scripts\aks.fsx
 	samples\scripts\bastion.fsx = samples\scripts\bastion.fsx
+	samples\scripts\container-instance.fsx = samples\scripts\container-instance.fsx
 EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "SampleApp", "samples\SampleApp\SampleApp.fsproj", "{2F230746-189D-4AFD-9B60-D49BB23C98DA}"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.4.0-beta2
+* Container Groups: Support for init containers.
+
 ## 1.4.0-beta1
 * Storage: Support for setting default blob access tier at account level with "default_blob_access_tier"
 

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -11,16 +11,22 @@ The Container Group builder is used to create Azure Container Group instances.
 * Container Group (`Microsoft.ContainerInstance/containerGroups`)
 
 #### Builder Keywords
-| Applies To | Keyword | Purpose |
-|-|-|-|
-| containerInstance | name | Sets the name of the Container Group instance. |
-| containerInstance | image | Sets the container image. |
+| Applies To        | Keyword | Purpose |
+|-------------------|---------|------------------------------------------|
+| containerInstance | name    | Sets the name of the container instance. |
+| containerInstance | image   | Sets the container image. |
 | containerInstance | command | Sets the commands to execute within the container instance in exec form. |
 | containerInstance | add_ports | Sets the ports the container exposes. |
 | containerInstance | cpu_cores | Sets the maximum CPU cores the container may use. |
 | containerInstance | memory | Sets the maximum gigabytes of memory the container may use. |
 | containerInstance | env_vars | Sets a list of environment variables for the container. |
 | containerInstance | add_volume_mount | Adds a volume mount on a container from a volume in the container group. |
+| initContainer | name | Sets the name of the init container. |
+| initContainer | image | Sets the init container image. |
+| initContainer | command | Sets the commands to execute within the init container in exec form. |
+| initContainer | env_vars | Sets a list of environment variables for the init container. |
+| initContainer | add_volume_mount | Adds a volume mount on an init container from a volume in the container group. |
+| containerGroup | name | Sets the name of the container group. |
 | containerGroup | add_instances | Adds container instances to the group. |
 | containerGroup | operating_system | Sets the OS type (default Linux). |
 | containerGroup | restart_policy | Sets the restart policy (default Always) |
@@ -153,4 +159,52 @@ let group = containerGroup {
     add_instances [ wordcount ]
 }
 ```
+#### Using an initContainer on startup
 
+An initContainer will run on container group startup before any of the containers are executed.
+
+If there are any issues with the initContainer, it will remain in a 'Creating' state indefinitely. Check
+for issues by viewing the logs for the init container(s):
+
+`az container logs -g resource-group-name -n container-group-name --container-name init-container-name`
+
+The example below creates a volume mount that is shared between the initContainer and the container
+instances. It writes to a file so that the nginx container can serve that file once the group is running.
+
+```fsharp
+arm {
+    location Location.WestEurope
+    add_resources [
+        containerGroup {
+            name "container-group-with-init"
+            operating_system Linux
+            restart_policy ContainerGroup.AlwaysRestart
+            add_volumes [
+                volume_mount.empty_dir "html"
+            ]
+            add_init_containers [
+                initContainer {
+                    name "write-index-file"
+                    image "debian"
+                    add_volume_mount "html" "/usr/share/nginx/html"
+                    command_line [
+                        "/bin/sh"
+                        "-c"
+                        "mkdir -p /usr/share/nginx/html && echo 'hello there' >> /usr/share/nginx/html/index.html"
+                    ]
+                }
+            ]
+            add_instances [
+                containerInstance {
+                    name "nginx"
+                    image "nginx:alpine"
+                    add_volume_mount "html" "/usr/share/nginx/html"
+                    add_public_ports [ 80us; 443us ]
+                    memory 0.5<Gb>
+                    cpu_cores 0.2
+                }
+            ]
+        }
+    ]
+}
+```

--- a/samples/scripts/container-instance.fsx
+++ b/samples/scripts/container-instance.fsx
@@ -13,27 +13,41 @@ let template = arm {
     add_resources [
         containerGroupUser
         containerGroup {
-            name "isaac-container-group"
+            name "container-group-with-init"
             operating_system Linux
             restart_policy ContainerGroup.AlwaysRestart
+            add_volumes [
+                volume_mount.empty_dir "html"
+            ]
+            add_init_containers [
+                initContainer {
+                    name "init-stuff"
+                    image "debian"
+                    add_volume_mount "html" "/usr/share/nginx/html"
+                    command_line [
+                        "/bin/sh"
+                        "-c"
+                        "mkdir -p /usr/share/nginx/html && echo 'hello there' >> /usr/share/nginx/html/index.html"
+                    ]
+                }
+            ]
             add_identity containerGroupUser
             add_instances [
                 containerInstance {
                     name "nginx"
-                    image "nginx:1.17.6-alpine"
+                    image "nginx:alpine"
+                    add_volume_mount "html" "/usr/share/nginx/html"
 
                     add_public_ports [ 80us; 443us ]
                     add_internal_ports [ 123us ]
 
                     memory 0.5<Gb>
-                    cpu_cores 1
+                    cpu_cores 0.2
                 }
             ]
         }
     ]
 }
 
-Writer.quickWrite "generated-template" template
-
-Deploy.execute "my-resource-group" [] template
+Writer.quickWrite "container-instance" template
 

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -6,7 +6,7 @@ open Farmer.ContainerGroup
 open Farmer.Identity
 open System
 
-let containerGroups = ResourceType ("Microsoft.ContainerInstance/containerGroups", "2018-10-01")
+let containerGroups = ResourceType ("Microsoft.ContainerInstance/containerGroups", "2019-12-01")
 
 type ContainerGroupIpAddress =
     { Type : IpAddressType
@@ -36,6 +36,13 @@ type ContainerGroup =
       RestartPolicy : RestartPolicy
       Identity : ManagedIdentity
       ImageRegistryCredentials : ImageRegistryCredential list
+      InitContainers :
+        {| Name : ResourceName
+           Image : string
+           Command : string list
+           EnvironmentVariables: Map<string, EnvVar>
+           VolumeMounts : Map<string,string>
+        |} list
       IpAddress : ContainerGroupIpAddress option
       NetworkProfile : ResourceName option
       Volumes : Map<string, Volume>
@@ -106,6 +113,26 @@ type ContainerGroup =
                                            {| cpu = container.Cpu
                                               memoryInGB = container.Memory |}
                                        |}
+                                      volumeMounts =
+                                          container.VolumeMounts
+                                          |> Seq.map (fun kvp -> {| name=kvp.Key; mountPath=kvp.Value |}) |> List.ofSeq
+                                   |}
+                               |})
+                          initContainers =
+                           this.InitContainers
+                           |> List.map (fun container ->
+                               {| name = container.Name.Value.ToLowerInvariant ()
+                                  properties =
+                                   {| image = container.Image
+                                      command = container.Command
+                                      environmentVariables = [
+                                          for key, value in Map.toSeq container.EnvironmentVariables do
+                                              match value with
+                                              | EnvValue value ->
+                                                {| name = key; value = value; secureValue = null |}
+                                              | SecureEnvValue value ->
+                                                {| name = key; value = null; secureValue = value.ArmExpression.Eval() |}
+                                      ]
                                       volumeMounts =
                                           container.VolumeMounts
                                           |> Seq.map (fun kvp -> {| name=kvp.Key; mountPath=kvp.Value |}) |> List.ofSeq

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.Management.CognitiveServices" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.Compute" Version="35.2.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerService" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.DeviceProvisioningServices" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="2.10.0-preview" />

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -392,7 +392,7 @@
       "type": "Microsoft.Cdn/profiles/endpoints"
     },
     {
-      "apiVersion": "2018-10-01",
+      "apiVersion": "2019-12-01",
       "dependsOn": [],
       "identity": {
         "type": "None"
@@ -428,6 +428,7 @@
           }
         ],
         "imageRegistryCredentials": [],
+        "initContainers": [],
         "ipAddress": {
           "ports": [
             {


### PR DESCRIPTION
The changes in this PR are as follows:

* Adds initContainer support in Azure Container Instances (container groups).

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.