### PR TITLE
Fix an issue with Event Grid dependency on storage queues.

### DIFF
--- a/src/Farmer/Arm/EventGrid.fs
+++ b/src/Farmer/Arm/EventGrid.fs
@@ -27,7 +27,7 @@ module Topics =
 type EndpointType =
     | WebHook of System.Uri
     | EventHub of eventHub:ResourceName
-    | StorageQueue of queue:string
+    | StorageQueue of queue:ResourceName
 
 type Topic =
     { Name : ResourceName
@@ -57,7 +57,7 @@ type Subscription<'T> =
             let destinationResourceId =
                 match this.DestinationEndpoint with
                 | EventHub hubName -> Some (Namespaces.eventHubs.resourceId (this.Destination, hubName))
-                | StorageQueue _ -> Some (storageAccounts.resourceId this.Destination)
+                | StorageQueue queue -> Some (Storage.queues.resourceId (this.Destination, ResourceName "default", queue))
                 | WebHook _ -> None
 
             {| eventSubscriptions.Create(this.Topic/this.Name, dependsOn = [ systemTopics.resourceId this.Topic; yield! Option.toList destinationResourceId ]) with
@@ -76,7 +76,7 @@ type Subscription<'T> =
                             {| endpointType = "StorageQueue"
                                properties =
                                 {| resourceId = (storageAccounts.resourceId this.Destination).Eval()
-                                   queueName = queueName |}
+                                   queueName = queueName.Value |}
                             |} :> _
                       filter = {| includedEventTypes = [ for event in this.Events do event.Value ] |}
                    |}

--- a/src/Farmer/Builders/Builders.EventGrid.fs
+++ b/src/Farmer/Builders/Builders.EventGrid.fs
@@ -141,7 +141,7 @@ type EventGridBuilder() =
 
     [<CustomOperation "add_queue_subscriber">]
     member _.AddQueueSubscription(state:EventGridConfig<'T>, storageAccount:StorageAccountConfig, queueName, events) =
-        EventGridBuilder.AddSub(state, queueName + "-queue", storageAccount.Name.ResourceName, StorageQueue queueName, events)
+        EventGridBuilder.AddSub(state, queueName + "-queue", storageAccount.Name.ResourceName, StorageQueue (ResourceName queueName), events)
     [<CustomOperation "add_webhook_subscriber">]
     member _.AddWebSubscription(state:EventGridConfig<'T>, webAppName:ResourceName, webHookEndpoint:Uri, events) =
         EventGridBuilder.AddSub(state, webHookEndpoint.LocalPath + "-webhook", webAppName, WebHook webHookEndpoint, events)

--- a/src/Tests/EventGrid.fs
+++ b/src/Tests/EventGrid.fs
@@ -25,7 +25,7 @@ let tests = testList "Event Grid" [
         let grid = eventGrid { add_queue_subscriber storage "thequeue" [ SystemEvents.Storage.BlobCreated ] }
         let sub = grid.Subscriptions.[0]
         Expect.equal sub.Name (ResourceName "test-thequeue-queue") "Incorrect subscription name"
-        Expect.equal sub.Endpoint (EndpointType.StorageQueue "thequeue") "Incorrect endpoint type"
+        Expect.equal sub.Endpoint (EndpointType.StorageQueue (ResourceName "thequeue")) "Incorrect endpoint type"
         Expect.equal sub.Destination (ResourceName "test") "Incorrect destination"
         Expect.equal sub.SystemEvents [ SystemEvents.Storage.BlobCreated ] "Incorrect system events"
     }

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -89,4 +89,20 @@ let tests =
             }
             compareResourcesToJson [ data; web; hub; logs; mydiagnosticSetting ] "diagnostics.json"
         }
+
+        test "Event Grid" {
+            let storageSource = storageAccount {
+                name "isaacgriddevprac"
+                add_private_container "data"
+                add_queue "todo"
+            }
+
+            let eventHubGrid = eventGrid {
+                topic_name "newblobscreated"
+                source storageSource
+                add_queue_subscriber storageSource "todo" [ SystemEvents.Storage.BlobCreated ]
+            }
+
+            compareResourcesToJson [ storageSource; eventHubGrid ] "event-grid.json"
+        }
     ]

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "outputs": {},
+  "parameters": {},
+  "resources": [
+    {
+      "apiVersion": "2019-06-01",
+      "dependsOn": [],
+      "kind": "StorageV2",
+      "location": "northeurope",
+      "name": "isaacgriddevprac",
+      "properties": {},
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "tags": {},
+      "type": "Microsoft.Storage/storageAccounts"
+    },
+    {
+      "apiVersion": "2018-03-01-preview",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', 'isaacgriddevprac')]"
+      ],
+      "name": "isaacgriddevprac/default/data",
+      "properties": {
+        "publicAccess": "None"
+      },
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers"
+    },
+    {
+      "apiVersion": "2019-06-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', 'isaacgriddevprac')]"
+      ],
+      "name": "isaacgriddevprac/default/todo",
+      "type": "Microsoft.Storage/storageAccounts/queueServices/queues"
+    },
+    {
+      "apiVersion": "2020-04-01-preview",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', 'isaacgriddevprac')]"
+      ],
+      "location": "northeurope",
+      "name": "newblobscreated",
+      "properties": {
+        "source": "[resourceId('Microsoft.Storage/storageAccounts', 'isaacgriddevprac')]",
+        "topicType": "Microsoft.Storage.StorageAccounts"
+      },
+      "tags": {},
+      "type": "Microsoft.EventGrid/systemTopics"
+    },
+    {
+      "apiVersion": "2020-04-01-preview",
+      "dependsOn": [
+        "[resourceId('Microsoft.EventGrid/systemTopics', 'newblobscreated')]",
+        "[resourceId('Microsoft.Storage/storageAccounts/queueServices/queues', 'isaacgriddevprac', 'default', 'todo')]"
+      ],
+      "name": "newblobscreated/isaacgriddevprac-todo-queue",
+      "properties": {
+        "destination": {
+          "endpointType": "StorageQueue",
+          "properties": {
+            "queueName": "todo",
+            "resourceId": "[resourceId('Microsoft.Storage/storageAccounts', 'isaacgriddevprac')]"
+          }
+        },
+        "filter": {
+          "includedEventTypes": [
+            "Microsoft.Storage.BlobCreated"
+          ]
+        }
+      },
+      "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions"
+    }
+  ]
+}


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Fixes an issue whereby Topics could be created before a destination queue was.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.