### PR TITLE
Siteextension fix for containerapps

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes
 * Functions: Support for 64 bits.
 * Storage: Add support for tables
 * Event Grid: Ensure destination Queues are created as a dependency
+* Web App: Disables the automatic addition of the logging site extension when `docker_image` is used
 
 * Framework: Updated DeterministicGuid for RFC 4122 compatibility
 

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -46,7 +46,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | disable_source_control_ci | Disables continuous integration from source control on push |
 | Web App | enable_source_control_ci | Enables continuous integration from source control on push |
 | Web App | add_extension | Adds the named extension to the Web App |
-| Web App | automatic_logging_extension | Enables or disables automatically adding the ASP .NET logging extension for netcore apps (defaults to on). |
+| Web App | automatic_logging_extension | Enables or disables automatically adding the ASP .NET logging extension for netcore apps (defaults to on unless docker_image is set). |
 | Web App | worker_process | Specifies whether to set the web app to 32 or 64 Bitness. |
 | Web App | always_on | Sets the "Always On" flag. |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -409,7 +409,10 @@ type WebAppBuilder() =
         { state with
             SiteExtensions =
                 match state with
-                | { Runtime = Runtime.DotNetCore _; AutomaticLoggingExtension = true } ->
+                // its important to only add this extension if we're not using Web App for Containers - if we are
+                // then this will generate an error during deployment:
+                // No route registered for '/api/siteextensions/Microsoft.AspNetCore.AzureAppServices.SiteExtension'
+                | { Runtime = Runtime.DotNetCore _; AutomaticLoggingExtension = true ; DockerImage = None } ->
                     state.SiteExtensions.Add WebApp.Extensions.Logging
                 | _ ->
                     state.SiteExtensions

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -236,6 +236,12 @@ let tests = testList "Web App Tests" [
         let extensions = wa |> getResources |> getResource<SiteExtension>
         Expect.isEmpty extensions "Shouldn't be any extensions"
     }
+    
+    test "Does not add the logging extension for apps using a docker image" {
+        let wa = webApp { name "siteX" ; docker_image "someImage" "someCommand" }
+        let extensions = wa |> getResources |> getResource<SiteExtension>
+        Expect.isEmpty extensions "Shouldn't be any extensions"                
+    }
 
     test "Handles add_extension correctly" {
         let wa = webApp { name "siteX"; add_extension "extensionA"; runtime_stack Runtime.Java11 }


### PR DESCRIPTION
This PR closes #570 

The changes in this PR are as follows:

* Disables the automatic addition of the logging site extension when docker_image is used

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

