### PR TITLE
Allow connecting ACI to existing vnet

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 ## vNext
 * Container Groups: Support for init containers.
 * Container Groups: Support for liveliness and readiness probes on containers.
+* Container Groups: Connect network profile to an existing virtual network.
 * Container Groups: Bugfix for outputs.
 * Functions: Support for 64 bits.
 * Storage: Add support for tables

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -9,6 +9,7 @@ weight: 3
 The Container Group builder is used to create Azure Container Group instances.
 
 * Container Group (`Microsoft.ContainerInstance/containerGroups`)
+* Network Profile (`Microsoft.Network/networkProfiles`)
 
 #### Builder Keywords
 | Applies To        | Keyword | Purpose |
@@ -54,6 +55,10 @@ The Container Group builder is used to create Azure Container Group instances.
 | readiness | failure_threshold | Sets the number of times a check can fail before the container is considered unhealthy and will be restarted - default is 3. |
 | readiness | success_threshold | Sets the number of times a check must succeed before the container is considered healthy - default is 1. |
 | readiness | timeout_seconds | Sets the number of seconds a check is allowed to run before considering the check a failure - default is 1 second. |
+| networkProfile | name | Name of the container network profile for connecting a container group to a virtual network. |
+| networkProfile | vnet | Resource name of the virtual network to connect (if created in the same deployment). |
+| networkProfile | link_to_vnet | Resource name of an existing virtual network to connect. |
+| networkProfile | subnet | Name of the subnet in the virtual network where the container group should attach. |
 
 #### Example
 ```fsharp

--- a/samples/scripts/container-group.fsx
+++ b/samples/scripts/container-group.fsx
@@ -1,0 +1,30 @@
+#r @"C:\Users\isaac\code\farmer\src\Farmer\bin\Debug\net5.0\Farmer.dll"
+
+open Farmer
+open Farmer.Builders
+open Farmer.ContainerGroup
+
+let nginx = containerInstance {
+    name "nginx"
+    image "nginx:1.17.6-alpine"
+    add_ports PublicPort [ 80us; 443us ]
+    add_ports InternalPort [ 9090us; ]
+    memory 0.5<Gb>
+    cpu_cores 1
+}
+
+let profile = networkProfile {
+    name "netprofile"
+    vnet "containernet"
+    subnet "ContainerSubnet"
+}
+
+let g = containerGroup {
+    name "appWithHttpFrontend"
+    operating_system Linux
+    restart_policy AlwaysRestart
+    add_udp_port 123us
+    add_instances [ nginx ]
+    network_profile profile
+}
+

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -236,16 +236,16 @@ type NetworkInterface =
 type NetworkProfile =
     { Name : ResourceName
       Location : Location
+      Dependencies : ResourceId Set
       ContainerNetworkInterfaceConfigurations :
         {| IpConfigs : {| SubnetName : ResourceName |} list
         |} list
-      VirtualNetwork : ResourceName
+      VirtualNetwork : ResourceId
       Tags: Map<string,string> }
     interface IArmResource with
         member this.ResourceId = networkProfiles.resourceId this.Name
         member this.JsonModel =
-            let dependsOn = [ virtualNetworks.resourceId this.VirtualNetwork ]
-            {| networkProfiles.Create(this.Name, this.Location, dependsOn, this.Tags) with
+            {| networkProfiles.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
                 properties =
                     {| containerNetworkInterfaceConfigurations =
                         this.ContainerNetworkInterfaceConfigurations
@@ -258,7 +258,7 @@ type NetworkProfile =
                                     {| name = $"ipconfig{index + 1}"
                                        properties =
                                         {| subnet =
-                                            {| id = subnets.resourceId(this.VirtualNetwork, ipConfig.SubnetName).Eval() |}
+                                            {| id = subnets.resourceId(this.VirtualNetwork.Name, ipConfig.SubnetName).Eval() |}
                                         |}
                                     |})
                                 |}

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -405,4 +405,14 @@ let tests = testList "Container Group" [
         let dependsOn = jobj.SelectToken("resources[?(@.name=='netprofile')].dependsOn")
         Expect.hasLength dependsOn 0 "network profile had dependencies when existing vnet was linked"
     }
+    test "Can link a network profile directly to a container group" {
+        let profile = networkProfile { name "netprofile" }
+        let template =
+            containerGroup {
+                name "appWithHttpFrontend"
+                network_profile profile
+            } |> asAzureResource
+
+        Expect.equal "[resourceId('Microsoft.Network/networkProfiles', 'netprofile')]" template.NetworkProfile.Id "Incorrect profile name"
+    }
 ]

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -342,4 +342,67 @@ let tests = testList "Container Group" [
         Expect.equal readinessProbe.InitialDelaySeconds.Value 30 "Incorrect initial delay threshold on readiness probe"
         Expect.equal readinessProbe.FailureThreshold.Value 5 "Incorrect failure threshold on readiness probe"
     }
+    test "Container network profile with vnet has expected dependsOn" {
+        let template =
+            arm {
+                add_resources [
+                    vnet {
+                        name "containernet"
+                        add_address_spaces [
+                            "10.30.40.0/20"
+                        ]
+                        add_subnets [
+                            subnet {
+                                name "ContainerSubnet"
+                                prefix "10.40.41.0/24"
+                                add_delegations [ SubnetDelegationService.ContainerGroups ]
+                            }
+                        ]
+                    }
+                    networkProfile {
+                        name "netprofile"
+                        vnet "containernet"
+                        subnet "ContainerSubnet"
+                    }
+                    containerGroup {
+                        name "appWithHttpFrontend"
+                        operating_system Linux
+                        restart_policy AlwaysRestart
+                        add_instances [ nginx ]
+                        network_profile "netprofile"
+                    }
+                ]
+            }
+        let json = template.Template |> Writer.toJson
+        let jobj = Newtonsoft.Json.Linq.JObject.Parse(json)
+        let expectedContainerNetDeps = "[resourceId('Microsoft.Network/virtualNetworks', 'containernet')]"
+        let dependsOn = jobj.SelectToken("resources[?(@.name=='netprofile')].dependsOn")
+        Expect.hasLength dependsOn 1 "netprofile has wrong number of dependencies"
+        let actualContainerNetDeps =
+            (dependsOn :?> Newtonsoft.Json.Linq.JArray).First.ToString()
+        Expect.equal actualContainerNetDeps expectedContainerNetDeps "Dependencies didn't match"
+    }
+    test "Container network profile with linked vnet has empty dependsOn" {
+        let template =
+            arm {
+                add_resources [
+                    networkProfile {
+                        name "netprofile"
+                        link_to_vnet "containernet"
+                        subnet "ContainerSubnet"
+                    }
+                    containerGroup {
+                        name "appWithHttpFrontend"
+                        operating_system Linux
+                        restart_policy AlwaysRestart
+                        add_instances [ nginx ]
+                        network_profile "netprofile"
+                    }
+                ]
+            }
+        let json = template.Template |> Writer.toJson
+        let jobj = Newtonsoft.Json.Linq.JObject.Parse(json)
+        let dependsOn = jobj.SelectToken("resources[?(@.name=='netprofile')].dependsOn")
+        Expect.hasLength dependsOn 0 "network profile had dependencies when existing vnet was linked"
+    }
 ]


### PR DESCRIPTION
This PR closes #577 

The changes in this PR are as follows:

* Adds `link_to_vnet` in `networkProfile` for connecting a container group to an existing virtual network.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
