### PR TITLE
Enables linking a container group to a vnet in another resource group.

### DIFF
--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -258,7 +258,10 @@ type NetworkProfile =
                                     {| name = $"ipconfig{index + 1}"
                                        properties =
                                         {| subnet =
-                                            {| id = subnets.resourceId(this.VirtualNetwork.Name, ipConfig.SubnetName).Eval() |}
+                                            {| id =
+                                                { subnets.resourceId(this.VirtualNetwork.Name, ipConfig.SubnetName)
+                                                     with ResourceGroup = this.VirtualNetwork.ResourceGroup }.Eval()
+                                             |}
                                         |}
                                     |})
                                 |}

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -419,6 +419,8 @@ type NetworkProfileBuilder() =
     [<CustomOperation "link_to_vnet">]
     member _.LinkToVirtualNetwork(state:NetworkProfileConfig, vnet) =
         { state with VirtualNetwork = Unmanaged(virtualNetworks.resourceId(ResourceName vnet)) }
+    member _.LinkToVirtualNetwork(state:NetworkProfileConfig, resourceId) =
+        { state with VirtualNetwork = Unmanaged resourceId }
     interface ITaggable<NetworkProfileConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let networkProfile = NetworkProfileBuilder ()

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -405,6 +405,23 @@ let tests = testList "Container Group" [
         let dependsOn = jobj.SelectToken("resources[?(@.name=='netprofile')].dependsOn")
         Expect.hasLength dependsOn 0 "network profile had dependencies when existing vnet was linked"
     }
+    test "Container network profile with linked vnet in another resource group has empty dependsOn" {
+        let template =
+            arm {
+                add_resources [
+                    networkProfile {
+                        name "netprofile"
+                        link_to_vnet (ResourceId.create(Arm.Network.virtualNetworks, (ResourceName "containerNet"), group="other-res-group"))
+                        subnet "ContainerSubnet"
+                    }
+                ]
+            }
+        let json = template.Template |> Writer.toJson
+        let jobj = Newtonsoft.Json.Linq.JObject.Parse(json)
+        let subnetId = jobj.SelectToken("..subnet.id") |> string
+        let expectedSubnetId = "[resourceId('other-res-group', 'Microsoft.Network/virtualNetworks/subnets', 'containerNet', 'ContainerSubnet')]"
+        Expect.equal subnetId expectedSubnetId "Generated incorrect subnet ID." 
+    }
     test "Can link a network profile directly to a container group" {
         let profile = networkProfile { name "netprofile" }
         let template =


### PR DESCRIPTION
The changes in this PR are as follows:

* Enables linking a container group to a virtual network in another resource group.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
Slight extension on feature from previous PR.