### PR TITLE
Only publish nuget package on new release tags

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,9 @@ trigger:
   paths:
     exclude:
     - 'docs/'
+  tags:
+    include:
+    - '*'
 stages:
 - stage: "Prepare"
   displayName: "Build, test and pack"
@@ -57,7 +60,7 @@ stages:
 - stage: "Release"
   displayName: "Release to NuGet"
   dependsOn: ["Prepare"]
-  condition:  and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master')) #optional, only trigger for master
+  condition:  and(succeeded(), eq(variables['build.sourceBranch'], 'refs/tags/')) #optional, only publish nuget pkg for new tags
   jobs:
   - deployment: "NugetPublish"
     displayName: "Publish to NuGet"


### PR DESCRIPTION
The changes in this PR are as follows:

* Triggers CI on new tags as well.
* *Only* publishes NuGet packages when a new tags is created (such as drafting a GitHub Release)

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
This is a CI change only.