### PR TITLE
Add support for dotnet-isolated runtime.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ Release Notes
 * Event Grid: Add ServiceBus Queue and Topic as supported destinations
 * Functions: Support for 64 bits.
 * Functions: Add option to use managed Key Vault
+* Functions: Add support for dotnet-isolated runtime (NET5)
 * KeyVault: Fix an issue with adding tags on main KeyVault builder.
 * ServiceBus: update namespace validation rules to follow [Microsoft documentation](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftservicebus)
 * Storage: Add support for tables

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -12,10 +12,7 @@ open Farmer.Arm.KeyVault
 open Farmer.Arm.KeyVault.Vaults
 open System
 
-type RuntimeKind =
-    | Isolated
-    | InProcess
-type FunctionsRuntime = DotNet of RuntimeKind | Node | Java | Python
+type FunctionsRuntime = DotNet | DotNetIsolated | Node | Java | Python
 type FunctionsExtensionVersion = V1 | V2 | V3
 
 module private FunctionsConfig =
@@ -147,8 +144,8 @@ type FunctionsConfig =
 
             let functionsRuntime =
                 match this.Runtime with
-                | DotNet Isolated -> "dotnet-isolated"
-                | DotNet InProcess -> "dotnet"
+                | DotNetIsolated -> "dotnet-isolated"
+                | DotNet -> "dotnet"
                 | other -> (string other).ToLower()
             { Name = this.Name
               ServicePlan = this.ServicePlanId
@@ -288,7 +285,7 @@ type FunctionsBuilder() =
           StorageAccount = derived (fun config ->
             let storage = config.Name.Map (sprintf "%sstorage") |> sanitiseStorage |> ResourceName
             storageAccounts.resourceId storage)
-          Runtime = DotNet InProcess
+          Runtime = DotNet
           ExtensionVersion = V3
           Cors = None
           HTTPSOnly = false

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -108,7 +108,7 @@ let tests = testList "Functions tests" [
     }
 
     test "Supports dotnet-isolated runtime" {
-        let f = functions { use_runtime (FunctionsRuntime.DotNet RuntimeKind.Isolated) }
+        let f = functions { use_runtime (FunctionsRuntime.DotNetIsolated) }
         let resources = (f :> IBuilder).BuildResources Location.WestEurope
         let site = resources.[0] :?> Web.Site
         Expect.equal site.AppSettings.["FUNCTIONS_WORKER_RUNTIME"] (LiteralSetting "dotnet-isolated") "Should use dotnet-isolated functions runtime"

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -106,4 +106,11 @@ let tests = testList "Functions tests" [
         Expect.equal secrets.[1].Value (ExpressionSecret sa.Key) "Incorrect secret value"
         Expect.sequenceEqual secrets.[1].Dependencies [ vaults.resourceId "testfuncvault"; storageAccounts.resourceId "teststorage" ] "Incorrect secret dependencies"
     }
+
+    test "Supports dotnet-isolated runtime" {
+        let f = functions { use_runtime (FunctionsRuntime.DotNet RuntimeKind.Isolated) }
+        let resources = (f :> IBuilder).BuildResources Location.WestEurope
+        let site = resources.[0] :?> Web.Site
+        Expect.equal site.AppSettings.["FUNCTIONS_WORKER_RUNTIME"] (LiteralSetting "dotnet-isolated") "Should use dotnet-isolated functions runtime"
+    }
 ]


### PR DESCRIPTION
This PR closes #596

The changes in this PR are as follows:

* Add RuntimeKind for DotNet runtime for Azure Functions to enable running as dotnet-isolated.


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
No docs updated, the runtime options are not currently listed in the docs.
