### PR TITLE
602 add mongo as database kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,12 @@
 Release Notes
 =============
 
-## v-Next
-* CosmosDb: Add support for MongoDB as a database kind.
 ##  1.5.0-beta
 * Container Groups: Support for init containers.
 * Container Groups: Support for liveliness and readiness probes on containers.
 * Container Groups: Connect network profile to an existing virtual network.
 * Container Groups: Bugfix for outputs.
+* CosmosDb: Add support for MongoDB as a database kind.
 * Event Grid: Ensure destination Queues are created as a dependency
 * Event Grid: Add ServiceBus Queue and Topic as supported destinations
 * Functions: Support for 64 bits.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+
+## v-Next
+* CosmosDb: Add support for MongoDB as a database kind.
 ##  1.5.0-beta
 * Container Groups: Support for init containers.
 * Container Groups: Support for liveliness and readiness probes on containers.

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -9,7 +9,8 @@ weight: 3
 The CosmosDb package containers two builders, used to create *databases* and *containers*.
 
 * CosmosDB Account (`Microsoft.DocumentDb/databaseAccounts`)
-* CosmosDB SQL (`"Microsoft.DocumentDB/databaseAccounts/sqlDatabases`)
+* CosmosDB SQL (`Microsoft.DocumentDB/databaseAccounts/sqlDatabases`)
+* CosmosDB MongoDB (`Microsoft.DocumentDB/databaseAccounts/mongodbDatabases`)
 * CosmosDB SQL Container (`Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers`)
 
 > There is currently only support for document databases (the so-called "SQL API"), with support for Gremlin, Table and Cassandra data models planned.

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -4,10 +4,10 @@ module Farmer.Arm.DocumentDb
 open Farmer
 open Farmer.CosmosDb
 
-let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2021-03-01-preview")
-let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2021-03-01-preview")
-let mongoDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2021-03-01-preview")
-let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2021-03-01-preview")
+let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2021-01-15")
+let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2021-01-15")
+let mongoDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2021-01-15")
+let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2021-01-15")
 
 type DatabaseKind =
     | Document

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -4,9 +4,14 @@ module Farmer.Arm.DocumentDb
 open Farmer
 open Farmer.CosmosDb
 
-let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2020-03-01")
-let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2020-03-01")
-let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2020-03-01")
+let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2021-03-01-preview")
+let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2021-03-01-preview")
+let mongoDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2021-03-01-preview")
+let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2021-03-01-preview")
+
+type DatabaseKind =
+    | Document
+    | Mongo
 
 module DatabaseAccounts =
     module SqlDatabases =
@@ -65,11 +70,16 @@ module DatabaseAccounts =
     type SqlDatabase =
         { Name : ResourceName
           Account : ResourceName
-          Throughput : int<RU> }
+          Throughput : int<RU>
+          Kind: DatabaseKind }
         interface IArmResource with
             member this.ResourceId = sqlDatabases.resourceId (this.Account/this.Name)
             member this.JsonModel =
-                {| sqlDatabases.Create(this.Account/this.Name, dependsOn = [ databaseAccounts.resourceId this.Account ]) with
+                let resource =
+                    match this.Kind with
+                    | Document -> sqlDatabases
+                    | Mongo -> mongoDatabases
+                {| resource.Create(this.Account/this.Name, dependsOn = [ databaseAccounts.resourceId this.Account ]) with
                        properties =
                            {| resource = {| id = this.Name.Value |}
                               options = {| throughput = string this.Throughput |} |}
@@ -82,6 +92,7 @@ type DatabaseAccount =
       FailoverPolicy : FailoverPolicy
       PublicNetworkAccess : FeatureFlag
       FreeTier : bool
+      Kind : DatabaseKind
       Tags: Map<string,string>  }
     member this.MaxStatelessPrefix =
         match this.ConsistencyPolicy with
@@ -113,7 +124,10 @@ type DatabaseAccount =
         member this.ResourceId = databaseAccounts.resourceId this.Name
         member this.JsonModel =
             {| databaseAccounts.Create(this.Name, this.Location, tags = this.Tags) with
-                   kind = "GlobalDocumentDB"
+                   kind =
+                    match this.Kind with
+                    | Document -> "GlobalDocumentDB"
+                    | Mongo -> "MongoDB"
                    properties =
                        {| consistencyPolicy =
                             {| defaultConsistencyLevel =

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -180,7 +180,7 @@ type CosmosDbBuilder() =
     /// Sets the throughput of the server.
     [<CustomOperation "throughput">]
     member __.Throughput(state:CosmosDbConfig, throughput) = { state with DbThroughput = throughput }
-    /// Sets the storage type
+    /// Sets the storage kind
     [<CustomOperation "kind">]
     member __.StorageKind(state:CosmosDbConfig, kind) = { state with Kind = kind }
     /// Adds a list of containers to the database.

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -37,7 +37,8 @@ type CosmosDbConfig =
       Containers : CosmosDbContainerConfig list
       PublicNetworkAccess : FeatureFlag
       FreeTier : bool
-      Tags: Map<string,string> }
+      Tags: Map<string,string>
+      Kind: DatabaseKind }
     member private this.AccountResourceId = this.AccountName.resourceId this
     member this.PrimaryKey = CosmosDb.getKey(this.AccountResourceId, PrimaryKey, ReadWrite)
     member this.SecondaryKey = CosmosDb.getKey(this.AccountResourceId, SecondaryKey, ReadWrite)
@@ -57,6 +58,7 @@ type CosmosDbConfig =
             | DeployableResource this _ ->
                 { Name = this.AccountResourceId.Name
                   Location = location
+                  Kind = this.Kind
                   ConsistencyPolicy = this.AccountConsistencyPolicy
                   PublicNetworkAccess = this.PublicNetworkAccess
                   FailoverPolicy = this.AccountFailoverPolicy
@@ -68,7 +70,8 @@ type CosmosDbConfig =
             // Database
             { Name = this.DbName
               Account = this.AccountResourceId.Name
-              Throughput = this.DbThroughput }
+              Throughput = this.DbThroughput
+              Kind = this.Kind }
 
             // Containers
             for container in this.Containers do
@@ -153,7 +156,8 @@ type CosmosDbBuilder() =
           Containers = []
           PublicNetworkAccess = Enabled
           FreeTier = false
-          Tags = Map.empty }
+          Tags = Map.empty
+          Kind = DatabaseKind.Document }
 
     /// Sets the name of the CosmosDB server.
     [<CustomOperation "account_name">]
@@ -176,6 +180,9 @@ type CosmosDbBuilder() =
     /// Sets the throughput of the server.
     [<CustomOperation "throughput">]
     member __.Throughput(state:CosmosDbConfig, throughput) = { state with DbThroughput = throughput }
+    /// Sets the storage type
+    [<CustomOperation "kind">]
+    member __.StorageKind(state:CosmosDbConfig, kind) = { state with Kind = kind }
     /// Adds a list of containers to the database.
     [<CustomOperation "add_containers">]
     member __.AddContainers(state:CosmosDbConfig, containers) = { state with Containers = state.Containers @ containers }

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -4,10 +4,7 @@ open Expecto
 open Farmer
 open Farmer.Builders
 open Farmer.Storage
-open Microsoft.Azure.Management.Storage
-open Microsoft.Azure.Management.Storage.Models
-open Microsoft.Rest
-open System
+open Farmer.Arm.DocumentDb
 
 let tests = testList "Cosmos" [
     test "Cosmos container should ignore duplicate unique keys" {
@@ -27,14 +24,32 @@ let tests = testList "Cosmos" [
     }
     test "DB properties are correctly evaluated" {
         let db = cosmosDb { name "test" }
-        Expect.equal "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2020-03-01').documentEndpoint]" (db.Endpoint.Eval()) "Endpoint is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" (db.PrimaryKey.Eval()) "Primary Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryMasterKey]" (db.SecondaryKey.Eval()) "Secondary Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryreadonlyMasterKey]" (db.PrimaryReadonlyKey.Eval()) "Primary Readonly Key is incorrect"
-        Expect.equal "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryreadonlyMasterKey]" (db.SecondaryReadonlyKey.Eval()) "Secondary Readonly Key is incorrect"
-        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" (db.PrimaryConnectionString.Eval()) "Primary Connection String is incorrect"
-        Expect.equal "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" (db.SecondaryConnectionString.Eval()) "Secondary Connection String is incorrect"
+        Expect.equal (db.Endpoint.Eval()) "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2021-03-01-preview').documentEndpoint]" "Endpoint is incorrect"
+        Expect.equal (db.PrimaryKey.Eval()) "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" "Primary Key is incorrect"
+        Expect.equal (db.SecondaryKey.Eval()) "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryMasterKey]" "Secondary Key is incorrect"
+        Expect.equal (db.PrimaryReadonlyKey.Eval()) "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryreadonlyMasterKey]" "Primary Readonly Key is incorrect"
+        Expect.equal (db.SecondaryReadonlyKey.Eval()) "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryreadonlyMasterKey]" "Secondary Readonly Key is incorrect"
+        Expect.equal (db.PrimaryConnectionString.Eval()) "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[0].connectionString]" "Primary Connection String is incorrect"
+        Expect.equal (db.SecondaryConnectionString.Eval()) "[listConnectionStrings(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).connectionStrings[1].connectionString]" "Secondary Connection String is incorrect"
     }
+
+    testList "db type" [
+        test "default" {
+            let db = cosmosDb { name "test"; account_name "account" }
+            Expect.equal db.Kind Document ""
+        }
+
+        test "sql" {
+            let db = cosmosDb { name "test"; kind Document }
+            Expect.equal db.Kind Document ""
+        }
+
+        test "mongoDB" {
+            let db = cosmosDb { name "test"; kind Mongo }
+            Expect.equal db.Kind Mongo ""
+        }
+    ]
+
     test "Correctly serializes to JSON" {
         let t = arm { add_resource (cosmosDb { name "test" }) }
 

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -24,7 +24,7 @@ let tests = testList "Cosmos" [
     }
     test "DB properties are correctly evaluated" {
         let db = cosmosDb { name "test" }
-        Expect.equal (db.Endpoint.Eval()) "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2021-03-01-preview').documentEndpoint]" "Endpoint is incorrect"
+        Expect.equal (db.Endpoint.Eval()) "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2021-01-15').documentEndpoint]" "Endpoint is incorrect"
         Expect.equal (db.PrimaryKey.Eval()) "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryMasterKey]" "Primary Key is incorrect"
         Expect.equal (db.SecondaryKey.Eval()) "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).secondaryMasterKey]" "Secondary Key is incorrect"
         Expect.equal (db.PrimaryReadonlyKey.Eval()) "[listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), providers('Microsoft.DocumentDb','databaseAccounts').apiVersions[0]).primaryreadonlyMasterKey]" "Primary Readonly Key is incorrect"

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -44,9 +44,17 @@ let tests =
                     }
                 ]
             }
+            let cosmosMongo = cosmosDb {
+                name "testdbmongo"
+                account_name "testaccountmongo"
+                kind Mongo
+                throughput 400<CosmosDb.RU>
+                failover_policy CosmosDb.NoFailover
+                consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
+            }
 
             compareResourcesToJson
-                [ sql; storage; web; fns; svcBus; cdn; containerGroup; cosmos ]
+                [ sql; storage; web; fns; svcBus; cdn; containerGroup; cosmos; cosmosMongo ]
                 "lots-of-resources.json"
         }
 

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -453,7 +453,7 @@
       "type": "Microsoft.ContainerInstance/containerGroups"
     },
     {
-      "apiVersion": "2020-03-01",
+      "apiVersion": "2021-03-01-preview",
       "kind": "GlobalDocumentDB",
       "location": "northeurope",
       "name": "testaccount",
@@ -471,7 +471,7 @@
       "type": "Microsoft.DocumentDb/databaseAccounts"
     },
     {
-      "apiVersion": "2020-03-01",
+      "apiVersion": "2021-03-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccount')]"
       ],
@@ -487,7 +487,7 @@
       "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases"
     },
     {
-      "apiVersion": "2020-03-01",
+      "apiVersion": "2021-03-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.DocumentDb/databaseAccounts/sqlDatabases', 'testaccount', 'testdb')]"
       ],
@@ -527,6 +527,40 @@
         }
       },
       "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers"
+    },
+    {
+      "apiVersion": "2021-03-01-preview",
+      "kind": "MongoDB",
+      "location": "northeurope",
+      "name": "testaccountmongo",
+      "properties": {
+        "consistencyPolicy": {
+          "defaultConsistencyLevel": "BoundedStaleness",
+          "maxIntervalInSeconds": 1000,
+          "maxStalenessPrefix": 500
+        },
+        "databaseAccountOfferType": "Standard",
+        "enableFreeTier": false,
+        "publicNetworkAccess": "Enabled"
+      },
+      "tags": {},
+      "type": "Microsoft.DocumentDb/databaseAccounts"
+    },
+    {
+      "apiVersion": "2021-03-01-preview",
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccountmongo')]"
+      ],
+      "name": "testaccountmongo/testdbmongo",
+      "properties": {
+        "options": {
+          "throughput": "400"
+        },
+        "resource": {
+          "id": "testdbmongo"
+        }
+      },
+      "type": "Microsoft.DocumentDb/databaseAccounts/mongodbDatabases"
     }
   ]
 }

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -453,7 +453,7 @@
       "type": "Microsoft.ContainerInstance/containerGroups"
     },
     {
-      "apiVersion": "2021-03-01-preview",
+      "apiVersion": "2021-01-15",
       "kind": "GlobalDocumentDB",
       "location": "northeurope",
       "name": "testaccount",
@@ -471,7 +471,7 @@
       "type": "Microsoft.DocumentDb/databaseAccounts"
     },
     {
-      "apiVersion": "2021-03-01-preview",
+      "apiVersion": "2021-01-15",
       "dependsOn": [
         "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccount')]"
       ],
@@ -487,7 +487,7 @@
       "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases"
     },
     {
-      "apiVersion": "2021-03-01-preview",
+      "apiVersion": "2021-01-15",
       "dependsOn": [
         "[resourceId('Microsoft.DocumentDb/databaseAccounts/sqlDatabases', 'testaccount', 'testdb')]"
       ],
@@ -529,7 +529,7 @@
       "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers"
     },
     {
-      "apiVersion": "2021-03-01-preview",
+      "apiVersion": "2021-01-15",
       "kind": "MongoDB",
       "location": "northeurope",
       "name": "testaccountmongo",
@@ -547,7 +547,7 @@
       "type": "Microsoft.DocumentDb/databaseAccounts"
     },
     {
-      "apiVersion": "2021-03-01-preview",
+      "apiVersion": "2021-01-15",
       "dependsOn": [
         "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccountmongo')]"
       ],


### PR DESCRIPTION
This PR closes #602 

The changes in this PR are as follows:

* Adds MongoDB as database kind to CosmosDB

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
