### PR TITLE
Support for CORS on Storage Accounts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* Storage Accounts: Support for CORS.
 
 ##  1.5.0
 * Container Groups: Support for init containers.

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -31,11 +31,13 @@ The Storage Account builder creates storage accounts and their associated contai
 | add_queues | Adds a list of queues to the storage account |
 | add_table | Adds a table to the storage account |
 | add_tables | Adds a list of tables to the storage account |
+| add_cors_rules | Adds a list of CORS rules to the different storage services |
 | use_static_website | Activates static website host, and uploads the provided local content as a post-deployment task to the storage with the specified index page |
 | static_website_error_page | Specifies the 404 page to display for static website hosting |
 | enable_data_lake | Enables Azure Data Lake Gen2 support on the storage account |
 | add_lifecycle_policy | Given a rule name, a list of PolicyActions and a list of string filters, creates a lifecycle policy for the storage account |
 | grant_access | Given a managed identity (can be either user- or system- assigned), and a specific RoleId from the Roles module, grants access to the identity for the provided role. |
+
 
 #### Configuration Members
 
@@ -70,5 +72,11 @@ let storage = storageAccount {
     add_lifecycle_rule "moveToCool" [ Storage.CoolAfter 30<Days>; Storage.ArchiveAfter 90<Days> ] Storage.NoRuleFilters
     add_lifecycle_rule "cleanup" [ Storage.DeleteAfter 7<Days> ] [ "data/recyclebin" ]
     grant_access myWebApp.SystemIdentity Roles.StorageBlobDataReader
+    add_cors_rules [        
+        StorageService.Blobs, CorsRule.AllowAll
+        StorageService.Tables, CorsRule.create [ "https://compositional-it.com" ]
+        StorageService.Files, { CorsRule.AllowAll with MaxAgeInSeconds = 10 }
+        StorageService.Queues, CorsRule.create ([ "https://compositional-it.com" ], [ GET ])
+    ]    
 }
 ```

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -5,11 +5,19 @@ open Farmer
 open Farmer.Storage
 
 let storageAccounts = ResourceType ("Microsoft.Storage/storageAccounts", "2019-06-01")
-let containers = ResourceType ("Microsoft.Storage/storageAccounts/blobServices/containers", "2018-03-01-preview")
+
 let blobServices = ResourceType ("Microsoft.Storage/storageAccounts/blobServices", "2019-06-01")
+let containers = ResourceType ("Microsoft.Storage/storageAccounts/blobServices/containers", "2018-03-01-preview")
+
+let fileServices = ResourceType ("Microsoft.Storage/storageAccounts/fileServices", "2019-06-01")
 let fileShares = ResourceType ("Microsoft.Storage/storageAccounts/fileServices/shares", "2019-06-01")
+
+let queueServices = ResourceType ("Microsoft.Storage/storageAccounts/queueServices", "2019-06-01")
 let queues = ResourceType ("Microsoft.Storage/storageAccounts/queueServices/queues", "2019-06-01")
+
+let tableServices = ResourceType ("Microsoft.Storage/storageAccounts/tableServices", "2019-06-01")
 let tables = ResourceType ("Microsoft.Storage/storageAccounts/tableServices/tables", "2019-06-01")
+
 let managementPolicies = ResourceType ("Microsoft.Storage/storageAccounts/managementPolicies", "2019-06-01")
 let roleAssignments = ResourceType ("Microsoft.Storage/storageAccounts/providers/roleAssignments", "2018-09-01-preview")
 
@@ -92,14 +100,16 @@ module Extensions =
                         specificItemMapper item
                 ]
 
-type BlobServices =
+/// A generic storage service that can be used for Blob, Table, Queue or FileServices
+type StorageService =
     { StorageAccount : StorageResourceName
-      CorsRules : CorsRule list }
+      CorsRules : CorsRule list
+      ResourceType : ResourceType }
     interface IArmResource with
         member this.ResourceId =
-            blobServices.resourceId (this.StorageAccount.ResourceName/"default")
+            this.ResourceType.resourceId (this.StorageAccount.ResourceName/"default")
         member this.JsonModel =
-            {| blobServices.Create(this.StorageAccount.ResourceName/"default", dependsOn = [ storageAccounts.resourceId this.StorageAccount.ResourceName ]) with
+            {| this.ResourceType.Create(this.StorageAccount.ResourceName/"default", dependsOn = [ storageAccounts.resourceId this.StorageAccount.ResourceName ]) with
                 properties =
                     {| cors =
                         {| corsRules =

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -200,7 +200,7 @@ type ContainerGroupBuilder() =
     [<CustomOperation "restart_policy">]
     member _.RestartPolicy(state:ContainerGroupConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
     member private _.SetIpAddress(state:ContainerGroupConfig, ipAddressType, ports) =
-        { state with        
+        { state with
             IpAddress =
                 { Type = ipAddressType
                   Ports = ports |> Seq.map(fun (protocol, port) -> {| Protocol = protocol; Port = port |}) |> Set } |> Some }

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -200,15 +200,15 @@ type ContainerGroupBuilder() =
     [<CustomOperation "restart_policy">]
     member _.RestartPolicy(state:ContainerGroupConfig, restartPolicy) = { state with RestartPolicy = restartPolicy }
     member private _.SetIpAddress(state:ContainerGroupConfig, ipAddressType, ports) =
-        { state with
+        { state with        
             IpAddress =
                 { Type = ipAddressType
-                  Ports = ports |> Seq.map(fun (prot, port) -> {| Protocol = prot; Port = port |}) |> Set } |> Some }
+                  Ports = ports |> Seq.map(fun (protocol, port) -> {| Protocol = protocol; Port = port |}) |> Set } |> Some }
 
-    /// Sets the IP addresss to a public address with a DNS label
+    /// Sets the IP address to a public address with a DNS label
     [<CustomOperation "public_dns">]
     member this.PublicDns(state, dnsLabel, ports) = this.SetIpAddress(state, PublicAddressWithDns dnsLabel, ports)
-    /// Sets the IP addresss to a private address assigned by the vnet
+    /// Sets the IP address to a private address assigned by the vnet
     [<CustomOperation "private_ip">]
     member this.PrivateIp(state:ContainerGroupConfig, ports) = this.SetIpAddress(state, PrivateAddress, ports)
     /// Sets a network profile for the container's group.

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -7,7 +7,6 @@ open Farmer.Arm.KeyVault
 open System
 open Vaults
 
-type NonEmptyList<'T> = 'T * 'T List
 type AccessPolicyConfig =
     { ObjectId : ArmExpression
       ApplicationId : Guid option
@@ -121,14 +120,14 @@ type KeyVaultConfig =
                         | Recover(policy, secondaryPolicies) -> policy :: secondaryPolicies
                         | Default policies -> policies
                     [ for policy in policies do
-                       {| ObjectId = policy.ObjectId
-                          ApplicationId = policy.ApplicationId
-                          Permissions =
-                           {| Certificates = policy.Permissions.Certificates
-                              Storage = policy.Permissions.Storage
-                              Keys = policy.Permissions.Keys
-                              Secrets = policy.Permissions.Secrets |}
-                       |}
+                        {| ObjectId = policy.ObjectId
+                           ApplicationId = policy.ApplicationId
+                           Permissions =
+                            {| Certificates = policy.Permissions.Certificates
+                               Storage = policy.Permissions.Storage
+                               Keys = policy.Permissions.Keys
+                               Secrets = policy.Permissions.Secrets |}
+                        |}
                     ]
                   Uri = this.Uri
                   DefaultAction = this.NetworkAcl.DefaultAction

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -117,7 +117,7 @@ type KeyVaultConfig =
                     let policies =
                         match this.Policies with
                         | Unspecified policies -> policies
-                        | Recover(policy, secondaryPolicies) -> policy :: secondaryPolicies
+                        | Recover list -> list.Value
                         | Default policies -> policies
                     [ for policy in policies do
                         {| ObjectId = policy.ObjectId
@@ -246,8 +246,8 @@ type KeyVaultBuilder() =
             match state.CreateMode, state.Policies with
             | None, policies -> Unspecified policies
             | Some SimpleCreateMode.Default, policies -> Default policies
-            | Some SimpleCreateMode.Recover, primary :: secondary -> Recover(primary, secondary)
             | Some SimpleCreateMode.Recover, [] -> failwith "Setting the creation mode to Recover requires at least one access policy. Use the accessPolicy builder to create a policy, and add it to the vault configuration using add_access_policy."
+            | Some SimpleCreateMode.Recover, policies -> Recover (NonEmptyList.create policies)
           Secrets = state.Secrets
           Uri = state.Uri
           Tags = state.Tags  }

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -44,6 +44,8 @@ type StorageAccountConfig =
       RoleAssignments : Roles.RoleAssignment Set
       /// Static Website Settings
       StaticWebsite : {| IndexPage : string; ContentPath : string; ErrorPage : string option |} option
+      /// The CORS rules for a storage service
+      CorsRules : List<Storage.StorageService * CorsRule>
       /// Tags to apply to the storage account
       Tags: Map<string,string> }
     /// Gets the ARM expression path to the key of this storage account.
@@ -110,6 +112,14 @@ type StorageAccountConfig =
                       ResourceId.create(storageAccounts, this.Name.ResourceName)
                       yield! roleAssignment.Owner |> Option.toList
                   ] }
+
+            for rule in this.CorsRules |> List.groupBy fst do
+                match rule with
+                | StorageService.Blobs, rules ->
+                    { StorageAccount = StorageResourceName.Create(this.Name.ResourceName).OkValue
+                      CorsRules = rules |> List.map snd }
+                | _ ->
+                    ()                    
         ]
 
 type StorageAccountBuilder() =
@@ -124,6 +134,7 @@ type StorageAccountBuilder() =
         Tables = Set.empty
         RoleAssignments = Set.empty
         StaticWebsite = None
+        CorsRules = []
         Tags = Map.empty
     }
     static member private AddContainer(state, access, name:string) = { state with Containers = state.Containers @ [ ((StorageResourceName.Create name).OkValue, access) ] }
@@ -204,6 +215,10 @@ type StorageAccountBuilder() =
                 | GeneralPurpose (V2 (replication, _)) -> GeneralPurpose (V2 (replication, Some tier))
                 | other -> failwith $"You can only set the default access tier for Blobs or General Purpose V2 storage accounts. This account is %A{other}."
         }
+    /// Adds a set of CORS rules to the storage account.
+    [<CustomOperation "add_cors_rules">]
+    member _.AddCorsRules(state:StorageAccountConfig, rules) =
+        { state with CorsRules = state.CorsRules @ rules }
     interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 /// Allow adding storage accounts directly to CDNs

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -458,19 +458,19 @@ module Storage =
     type CorsRule =
         { AllowedOrigins : AllOrSpecific<Uri>
           AllowedMethods : HttpMethod NonEmptyList
-          MaxAgeInSeconds : uint
+          MaxAgeInSeconds : int
           ExposedHeaders : AllOrSpecific<string>
           AllowedHeaders : AllOrSpecific<string> }
         static member AllowAll =
             { AllowedOrigins = All
               AllowedMethods = HttpMethod.All
-              MaxAgeInSeconds = 0u
+              MaxAgeInSeconds = 0
               ExposedHeaders = All
               AllowedHeaders = All }
         static member create (?allowedOrigins, ?allowedMethods, ?maxAgeInSeconds, ?exposedHeaders, ?allowedHeaders) =
             { AllowedOrigins = Specific (defaultArg allowedOrigins [] |> List.map Uri)
               AllowedMethods = defaultArg (allowedMethods |> Option.map NonEmptyList.create) HttpMethod.All
-              MaxAgeInSeconds = defaultArg maxAgeInSeconds 0u
+              MaxAgeInSeconds = defaultArg maxAgeInSeconds 0
               ExposedHeaders = Specific (defaultArg exposedHeaders [])
               AllowedHeaders = Specific (defaultArg allowedHeaders []) }
     [<RequireQualifiedAccess>]

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -9,6 +9,7 @@ module NonEmptyList =
         match l with
         | [] -> failwith "Not allowed!"
         | h :: t -> NonEmptyList (h, t)
+    let toList (h, t) = h :: t       
 
 [<AutoOpen>]
 module internal DuHelpers =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -467,12 +467,14 @@ module Storage =
               MaxAgeInSeconds = 0
               ExposedHeaders = All
               AllowedHeaders = All }
+        /// Creates a new CORS rule with 
         static member create (?allowedOrigins, ?allowedMethods, ?maxAgeInSeconds, ?exposedHeaders, ?allowedHeaders) =
-            { AllowedOrigins = Specific (defaultArg allowedOrigins [] |> List.map Uri)
-              AllowedMethods = defaultArg (allowedMethods |> Option.map NonEmptyList.create) HttpMethod.All
-              MaxAgeInSeconds = defaultArg maxAgeInSeconds 0
-              ExposedHeaders = Specific (defaultArg exposedHeaders [])
-              AllowedHeaders = Specific (defaultArg allowedHeaders []) }
+            let mapDefault mapper defaultValue = Option.map mapper >> Option.defaultValue defaultValue 
+            { AllowedOrigins = allowedOrigins |> mapDefault (List.map Uri >> Specific) CorsRule.AllowAll.AllowedOrigins
+              AllowedMethods = allowedMethods |> mapDefault NonEmptyList.create CorsRule.AllowAll.AllowedMethods
+              MaxAgeInSeconds = defaultArg maxAgeInSeconds CorsRule.AllowAll.MaxAgeInSeconds
+              ExposedHeaders = exposedHeaders |> mapDefault Specific CorsRule.AllowAll.ExposedHeaders
+              AllowedHeaders = allowedHeaders |> mapDefault Specific CorsRule.AllowAll.AllowedHeaders }
     [<RequireQualifiedAccess>]
     type StorageService = Blobs | Tables | Files | Queues
 

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -34,7 +34,7 @@ let tests = testList "Storage Tests" [
                 sku Sku.Premium_LRS
                 enable_data_lake true
             }
-            arm { add_resource account }            
+            arm { add_resource account }
             |> getStorageResource
 
         resource.Validate()
@@ -246,22 +246,22 @@ let tests = testList "Storage Tests" [
 
         let rules = (account |> findCorsResource "blobServices").properties.cors.corsRules
         Expect.equal 2 rules.Length "Incorrect number of CORS rules"
-        
-        let rule = rules.[0]
-        Expect.equal [| "*" |] rule.allowedHeaders "Incorrect default headers"
-        Expect.equal (HttpMethod.All |> NonEmptyList.toList |> List.map string |> List.toArray) rule.allowedMethods "Incorrect default methods"    
-        Expect.equal [| "*" |] rule.allowedOrigins "Incorrect default origin"
-        Expect.equal [| "*" |] rule.exposedHeaders "Incorrect default exposed headers"    
-        Expect.equal 0 rule.maxAgeInSeconds "Incorrect default max age is seconds"
-        
-        let rule = rules.[1]
-        Expect.equal [| "https://compositional-it.com/" |] rule.allowedOrigins "Incorrect custom allowed origin"
-        
-        let rule = (account |> findCorsResource "queueServices").properties.cors.corsRules |> Seq.exactlyOne
-        Expect.equal [| "ALLOWED1"; "ALLOWED2" |] rule.allowedHeaders "Incorrect factory headers"
-        Expect.equal [| string GET |] rule.allowedMethods "Incorrect factory methods"    
-        Expect.equal [| "https://compositional-it.com/" |] rule.allowedOrigins "Incorrect factory origin"
-        Expect.equal [| "exposed1"; "exposed2" |] rule.exposedHeaders "Incorrect factory exposed headers"    
-        Expect.equal 15 rule.maxAgeInSeconds "Incorrect factory max age is seconds"         
+
+        let blobAllowAllRule = rules.[0]
+        Expect.equal [| "*" |] blobAllowAllRule.allowedHeaders "Incorrect default headers"
+        Expect.equal (HttpMethod.All.Value |> List.map string |> List.toArray) blobAllowAllRule.allowedMethods "Incorrect default methods"
+        Expect.equal [| "*" |] blobAllowAllRule.allowedOrigins "Incorrect default origin"
+        Expect.equal [| "*" |] blobAllowAllRule.exposedHeaders "Incorrect default exposed headers"
+        Expect.equal 0 blobAllowAllRule.maxAgeInSeconds "Incorrect default max age is seconds"
+
+        let blobSpecificRule = rules.[1]
+        Expect.equal [| "https://compositional-it.com/" |] blobSpecificRule.allowedOrigins "Incorrect custom allowed origin"
+
+        let queueRule = (account |> findCorsResource "queueServices").properties.cors.corsRules |> Seq.exactlyOne
+        Expect.equal [| "ALLOWED1"; "ALLOWED2" |] queueRule.allowedHeaders "Incorrect factory headers"
+        Expect.equal [| string GET |] queueRule.allowedMethods "Incorrect factory methods"
+        Expect.equal [| "https://compositional-it.com/" |] queueRule.allowedOrigins "Incorrect factory origin"
+        Expect.equal [| "exposed1"; "exposed2" |] queueRule.exposedHeaders "Incorrect factory exposed headers"
+        Expect.equal 15 queueRule.maxAgeInSeconds "Incorrect factory max age is seconds"
     }
 ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -66,7 +66,7 @@
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.SignalR" Version="1.0.1" />
     <PackageReference Include="Microsoft.Azure.Management.Sql" Version="1.43.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage" Version="21.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.WebSites" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />


### PR DESCRIPTION
This PR closes #575

The changes in this PR are as follows:

* Create a new `add_cors_rules` keyword to the Storage builder.
* Support for CORS across all four storage services.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.