### PR TITLE
Adds ExpressRoute ServiceKey property for output expressions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.5.1
 * Communication Services: add builder.
+* ExpressRoute: Adds ServiceKey property to generate an expression for the service key on a new circuit.
 * ServiceBus: Fix an issue with Premium Sku ARM Writer
 * ServiceBus: Fix an issue with Rules depends on ARM Writer
 * Storage Accounts: Support for CORS.

--- a/docs/content/api-overview/resources/express-route.md
+++ b/docs/content/api-overview/resources/express-route.md
@@ -27,6 +27,12 @@ An ExpressRoute circuit is a dedicated link to Azure to provide communication wi
 | Peering | vlan | A unique VLAN ID for the peering |
 | Peering | shared_key | An optional shared key the service provider may specify for the peering |
 
+#### Configuration Members
+
+| Member | Purpose |
+|-|-|
+| ServiceKey | An ARM expression path to get the service key on the newly created circuit. |
+
 #### Example
 
 ```fsharp
@@ -35,21 +41,26 @@ open Farmer.Builders
 open Farmer.ExpressRoute
 
 let circuit = expressRoute {
-   name "my-express-route"
-   service_provider "Equinix"
-   peering_location "New York"
-   tier Premium
-   family MeteredData
-   bandwidth 1000<Mbps>
-   add_peering (
-       peering {
-           peering_type AzurePrivatePeering
-           peer_asn 55277L
-           azure_asn 12076
-           primary_prefix (IPAddressCidr.parse "10.254.12.0/30")
-           secondary_prefix (IPAddressCidr.parse "10.254.12.4/30")
-           vlan 2406
-       }
-   )
+    name "my-express-route"
+    service_provider "Equinix"
+    peering_location "New York"
+    tier Premium
+    family MeteredData
+    bandwidth 1000<Mbps>
+    add_peering (
+        peering {
+            peering_type AzurePrivatePeering
+            peer_asn 55277L
+            azure_asn 12076
+            primary_prefix (IPAddressCidr.parse "10.254.12.0/30")
+            secondary_prefix (IPAddressCidr.parse "10.254.12.4/30")
+            vlan 2406
+        }
+    )
+}
+
+arm {
+    add_resource circuit
+    output "er-service-key" circuit.ServiceKey
 }
 ```

--- a/src/Farmer/Builders/Builders.ExpressRoute.fs
+++ b/src/Farmer/Builders/Builders.ExpressRoute.fs
@@ -78,6 +78,11 @@ type ExpressRouteConfig =
     /// Peerings on this circuit
     Peerings : ExpressRouteCircuitPeeringConfig list
     Tags: Map<string,string>  }
+    /// Returns the service key on the newly created circuit.
+    member this.ServiceKey =
+        let erId = ResourceId.create(Arm.Network.expressRouteCircuits, this.Name)
+        $"reference({erId.ArmExpression.Value}).serviceKey"
+        |> ArmExpression.create
 
     interface IBuilder with
         member this.ResourceId = expressRouteCircuits.resourceId this.Name


### PR DESCRIPTION
This PR closes #614

The changes in this PR are as follows:

* Adds ServiceKey property to generate an expression for the service key on a new circuit.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.