### PR TITLE
ServiceBus.Sku coding standards fix

### DIFF
--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -109,14 +109,6 @@ module Namespaces =
                            enablePartitioning = this.EnablePartitioning |> Option.toNullable |}
                 |} :> _
 
-module private Sku =
-    let name (sku:Sku) =
-        match sku with
-        | Basic -> "Basic"
-        | Standard -> "Standard"
-        | Premium OneUnit 
-        | Premium TwoUnits
-        | Premium FourUnits -> "Premium"
 type Namespace =
     { Name : ResourceName
       Location : Location
@@ -135,7 +127,7 @@ type Namespace =
         member this.JsonModel =
             {| namespaces.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
                 sku =
-                     {| name = Sku.name this.Sku
-                        tier = Sku.name this.Sku
+                     {| name = this.Sku.NameArmValue
+                        tier = this.Sku.TierArmValue
                         capacity = this.Capacity |> Option.toNullable |}
             |} :> _

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -994,6 +994,14 @@ module ServiceBus =
         | Basic
         | Standard
         | Premium of MessagingUnits
+        member this.NameArmValue =
+                match this with
+                | Basic -> "Basic"
+                | Standard -> "Standard"
+                | Premium OneUnit 
+                | Premium TwoUnits
+                | Premium FourUnits -> "Premium"
+        member this.TierArmValue = this.NameArmValue
     type Rule =
         | SqlFilter of ResourceName * SqlExpression : string
         | CorrelationFilter of Name : ResourceName * CorrelationId : string option * Properties : Map<string, string>


### PR DESCRIPTION
This PR closes https://github.com/CompositionalIT/farmer/pull/620#discussion_r623899098

The changes in this PR are as follows:
* removes ServiceBus Sku module and move functions onto  type as members

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
