### PR TITLE
Builders.ServiceBus TopicConfig now implements IBuilder and topicBuilder supports link_to_unmanaged_namespace

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.5.2
+* ServiceBus: TopicConfig implements IBuilder and supports link_to_unmanaged_namespace.
+
 ## 1.5.1
 * Communication Services: add builder.
 * ExpressRoute: Adds ServiceKey property to generate an expression for the service key on a new circuit.

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -39,6 +39,7 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Topic | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for. |
 | Topic | enable_partition | Enables partition support on the topic. |
 | Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes, or as an integer days e.g. `4<Days>`. |
+| Topic | link_to_unmanaged_namespace | Instead of creating or modifying a namespace, configure this topic to point to another unmanaged namespace instance. |
 | Namespace | sku | The ServiceBusNamespaceSku e.g. Standard |
 | Namespace | namespace_name | The name of the namespace that holds the queue. |
 | Namespace | depends_on | [Sets dependencies on the service bus namespace.](../../dependencies/) |

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -91,14 +91,15 @@ module Namespaces =
 
     type Topic =
         { Name : ResourceName
-          Namespace : ResourceName
+          Dependencies : ResourceId Set
+          Namespace : ResourceId
           DuplicateDetectionHistoryTimeWindow : IsoDateTime option
           DefaultMessageTimeToLive : IsoDateTime option
           EnablePartitioning : bool option }
         interface IArmResource with
-            member this.ResourceId = topics.resourceId (this.Namespace/this.Name)
+            member this.ResourceId = topics.resourceId (this.Namespace.Name/this.Name)
             member this.JsonModel =
-                {| topics.Create(this.Namespace/this.Name, dependsOn = [ namespaces.resourceId this.Namespace ]) with
+                {| topics.Create(this.Namespace.Name/this.Name, dependsOn = this.Dependencies) with
                     properties =
                         {| defaultMessageTimeToLive = tryGetIso this.DefaultMessageTimeToLive
                            requiresDuplicateDetection =

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -97,7 +97,7 @@ module Namespaces =
           DefaultMessageTimeToLive : IsoDateTime option
           EnablePartitioning : bool option }
         interface IArmResource with
-            member this.ResourceId = topics.resourceId (this.Namespace.Name/this.Name)
+            member this.ResourceId = topics.resourceId (this.Namespace.Name, this.Name)
             member this.JsonModel =
                 {| topics.Create(this.Namespace.Name/this.Name, dependsOn = this.Dependencies) with
                     properties =

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -167,7 +167,7 @@ type ServiceBusTopicBuilder() =
                 (state.Subscriptions, subscriptions)
                 ||> List.fold(fun state (subscription:ServiceBusSubscriptionConfig) -> state.Add(subscription.Name, subscription))
         }
-    /// Instead of creating a or modifying a namespace, configure this topic to point to another unmanaged namespace instance.
+    /// Instead of creating or modifying a namespace, configure this topic to point to another unmanaged namespace instance.
     [<CustomOperation "link_to_unmanaged_namespace">]
     member this.LinkToUnmanagedNamespace (state:ServiceBusTopicConfig, namespaceName:ResourceName) =
         { state with Namespace = Unmanaged(namespaces.resourceId namespaceName) }

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -108,7 +108,7 @@ type ServiceBusTopicConfig =
       EnablePartitioning : bool option
       Subscriptions : Map<ResourceName, ServiceBusSubscriptionConfig> }
     interface IBuilder with
-        member this.ResourceId = topics.resourceId this.Name
+        member this.ResourceId = topics.resourceId (this.Namespace.Name, this.Name)
         member this.BuildResources location = [
             { Name = this.Name
               Dependencies = [
@@ -258,7 +258,7 @@ type ServiceBusBuilder() =
         { state with
             Topics =
                 (state.Topics, topics)
-                ||> List.fold(fun state (topic:ServiceBusTopicConfig) -> state.Add(topic.Name, topic))
+                ||> List.fold(fun topics (topic:ServiceBusTopicConfig) -> topics.Add(topic.Name, {topic with Namespace = Managed(namespaces.resourceId state.Name)}))
         }
     interface ITaggable<ServiceBusConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -221,6 +221,10 @@ type LinkedResource =
     | Managed of ResourceId
     /// A id of a resource that is created externally from Farmer and already exists in Azure.
     | Unmanaged of ResourceId
+    member this.Name =
+        match this with
+        | Managed resId
+        | Unmanaged resId -> resId.Name
 
 /// A reference to another Azure resource that may or may not be created by Farmer.
 type ResourceRef<'TConfig> =

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -162,7 +162,7 @@ let tests =
         
         test "ServiceBus" {
             let svcBus = serviceBus {
-                name "farmerbus"
+                name "farmer-bus"
                 sku (ServiceBus.Sku.Premium MessagingUnits.OneUnit)
                 add_queues [ queue { name "queue1" } ]
                 add_topics [
@@ -177,7 +177,18 @@ let tests =
                     }
                 ]
             }
-            compareResourcesToJson [ svcBus ] "service-bus.json"
+            let topicWithUnmanagedNamespace =
+                topic {
+                    name "unmanaged-topic"
+                    link_to_unmanaged_namespace "farmer-bus"
+                    add_subscriptions [
+                        subscription {
+                            name "sub1"
+                            add_filters [Rule.CreateCorrelationFilter ("filter1", ["header1", "headervalue1"])]
+                        }
+                    ]
+                }
+            compareResourcesToJson [ svcBus; topicWithUnmanagedNamespace ] "service-bus.json"
         }
         
         test "VirtualWan" {

--- a/src/Tests/test-data/service-bus.json
+++ b/src/Tests/test-data/service-bus.json
@@ -8,7 +8,7 @@
       "apiVersion": "2017-04-01",
       "dependsOn": [],
       "location": "northeurope",
-      "name": "farmerbus",
+      "name": "farmer-bus",
       "sku": {
         "capacity": 1,
         "name": "Premium",
@@ -20,9 +20,9 @@
     {
       "apiVersion": "2017-04-01",
       "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces', 'farmerbus')]"
+        "[resourceId('Microsoft.ServiceBus/namespaces', 'farmer-bus')]"
       ],
-      "name": "farmerbus/queue1",
+      "name": "farmer-bus/queue1",
       "properties": {
         "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S"
       },
@@ -31,18 +31,52 @@
     {
       "apiVersion": "2017-04-01",
       "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces', 'farmerbus')]"
+        "[resourceId('Microsoft.ServiceBus/namespaces', 'farmer-bus')]"
       ],
-      "name": "farmerbus/topic1",
+      "name": "farmer-bus/topic1",
       "properties": {},
       "type": "Microsoft.ServiceBus/namespaces/topics"
     },
     {
       "apiVersion": "2017-04-01",
       "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmerbus', 'topic1')]"
+        "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmer-bus', 'topic1')]"
       ],
-      "name": "farmerbus/topic1/sub1",
+      "name": "farmer-bus/topic1/sub1",
+      "properties": {},
+      "resources": [
+        {
+          "apiVersion": "2017-04-01",
+          "dependsOn": [
+            "sub1"
+          ],
+          "name": "filter1",
+          "properties": {
+            "correlationFilter": {
+              "properties": {
+                "header1": "headervalue1"
+              }
+            },
+            "filterType": "CorrelationFilter"
+          },
+          "type": "Rules"
+        }
+      ],
+      "type": "Microsoft.ServiceBus/namespaces/topics/subscriptions"
+    },
+    {
+      "apiVersion": "2017-04-01",
+      "dependsOn": [],
+      "name": "farmer-bus/unmanaged-topic",
+      "properties": {},
+      "type": "Microsoft.ServiceBus/namespaces/topics"
+    },
+    {
+      "apiVersion": "2017-04-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmer-bus', 'unmanaged-topic')]"
+      ],
+      "name": "farmer-bus/unmanaged-topic/sub1",
       "properties": {},
       "resources": [
         {


### PR DESCRIPTION
This PR improves on #617

The changes in this PR are as follows:

* Builders.ServiceBus TopicConfig now implements IBuilder and topicBuilder supports link_to_unmanaged_namespace

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
