### PR TITLE
Adds support for MSI as service principal in AKS.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.5.3
+* Container Service (AKS): Support for using managed identity (msi) for the service principal.
 
 ## 1.5.2
 * ServiceBus: TopicConfig implements IBuilder and supports link_to_unmanaged_namespace.

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -25,6 +25,7 @@ The AKS Builder constructs AKS clusters.
 | network_profile | Sets the network profile for the AKS cluster. |
 | linux_profile | Sets the linux profile for the AKS cluster. |
 | service_principal_client_id | Sets the client id of the service principal for the AKS cluster. |
+| service_principal_use_msi | Enables the AKS cluster to use the managed identity service principal instead of an external client secret. |
 | windows_username | Sets the windows admin username for the AKS cluster. |
 
 #### Agent Pool Builder keywords


### PR DESCRIPTION
The changes in this PR are as follows:

* Container Service (AKS): Support for using managed identity (msi) for the service principal.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
