### PR TITLE
Web App workaround for identity=None ARM regression

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.6.1
+* Web App: Workaround ARM regression when Identity is set to "None".
+
 ## 1.6.0
 * Added support for nesting resource groups
 * Storage: Support for firewall to restrict storage account network access to virtual network subnets, IP addresses, and CIDR prefixes.

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -2,6 +2,7 @@
 module Farmer.Arm.Web
 
 open Farmer
+open Farmer.Identity
 open Farmer.WebApp
 open System
 
@@ -166,7 +167,9 @@ type Site =
             let dependencies = this.Dependencies + (Set this.Identity.Dependencies)
             {| sites.Create(this.Name, this.Location, dependencies, this.Tags) with
                  kind = this.Kind
-                 identity = this.Identity |> ManagedIdentity.toArmJson
+                 identity =
+                     if this.Identity = ManagedIdentity.Empty then Unchecked.defaultof<_>
+                     else this.Identity |> ManagedIdentity.toArmJson
                  properties =
                     {| serverFarmId = this.ServicePlan.Eval()
                        httpsOnly = this.HTTPSOnly

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -48,8 +48,7 @@ let tests = testList "Functions tests" [
     }
     test "Handles identity correctly" {
         let f : Site = functions { name "" } |> getResourceAtIndex 0
-        Expect.equal f.Identity.Type (Nullable ManagedServiceIdentityType.None) "Incorrect default managed identity"
-        Expect.isNull f.Identity.UserAssignedIdentities "Incorrect default managed identity"
+        Expect.isNull f.Identity "Default managed identity should be null"
 
         let f : Site = functions { system_identity } |> getResourceAtIndex 0
         Expect.equal f.Identity.Type (Nullable ManagedServiceIdentityType.SystemAssigned) "Should have system identity"

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -204,8 +204,7 @@ let tests = testList "Web App Tests" [
 
     test "Handles identity correctly" {
         let wa : Site = webApp { name "" } |> getResourceAtIndex 0
-        Expect.equal wa.Identity.Type (Nullable ManagedServiceIdentityType.None) "Incorrect default managed identity"
-        Expect.isNull wa.Identity.UserAssignedIdentities "Should be no user assigned identities"
+        Expect.isNull wa.Identity  "Default managed identity should be null"
 
         let wa : Site = webApp { system_identity } |> getResourceAtIndex 0
         Expect.equal wa.Identity.Type (Nullable ManagedServiceIdentityType.SystemAssigned) "Should have system identity"

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -22,9 +22,6 @@
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', 'isaacdiagsuperweb-farm')]"
       ],
-      "identity": {
-        "type": "None"
-      },
       "kind": "app",
       "location": "northeurope",
       "name": "isaacdiagsuperweb",

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -101,9 +101,6 @@
         "[resourceId('Microsoft.Insights/components', 'farmerwebapp1979-ai')]",
         "[resourceId('Microsoft.Web/serverfarms', 'farmerwebapp1979-farm')]"
       ],
-      "identity": {
-        "type": "None"
-      },
       "kind": "app",
       "location": "northeurope",
       "name": "farmerwebapp1979",
@@ -213,9 +210,6 @@
         "[resourceId('Microsoft.Storage/storageAccounts', 'farmerfuncs1979storage')]",
         "[resourceId('Microsoft.Web/serverfarms', 'farmerfuncs1979-farm')]"
       ],
-      "identity": {
-        "type": "None"
-      },
       "kind": "functionapp",
       "location": "northeurope",
       "name": "farmerfuncs1979",


### PR DESCRIPTION
The changes in this PR are as follows:

* Web App: Workaround ARM regression when Identity is set to "None".

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
