### PR TITLE
Elastic Premium service plan SKUs for Functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.6.2
+* Functions: Support Elastic Premium SKUs for Functions service plans.
+
 ## 1.6.1
 * Web App: Workaround ARM regression when Identity is set to "None".
 

--- a/docs/content/api-overview/resources/functions.md
+++ b/docs/content/api-overview/resources/functions.md
@@ -83,3 +83,21 @@ let myFunctions = functions {
     app_insights_off
 }
 ```
+
+#### Example of a Premium Functions app
+```fsharp
+let servicePlan = servicePlan {
+    name "myServicePlan"
+    sku WebApp.Sku.EP1 // Elastic Premium 1
+    max_elastic_workers 25
+}
+
+let functionsApp = functions {
+    name "myFunctionsApp"
+    link_to_service_plan servicePlan
+}
+
+let deployment = arm {
+    add_resources [ servicePlan; functionsApp ]
+}
+```

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -244,6 +244,7 @@ type FunctionsConfig =
                   Sku = Sku.Y1
                   WorkerSize = Serverless
                   WorkerCount = 0
+                  MaximumElasticWorkerCount = None
                   OperatingSystem = this.OperatingSystem
                   Tags = this.Tags }
             | _ ->

--- a/src/Farmer/Builders/Builders.ServicePlan.fs
+++ b/src/Farmer/Builders/Builders.ServicePlan.fs
@@ -10,6 +10,7 @@ type ServicePlanConfig =
       Sku : Sku
       WorkerSize : WorkerSize
       WorkerCount : int
+      MaximumElasticWorkerCount : int option
       OperatingSystem : OS
       Tags : Map<string,string> }
     interface IBuilder with
@@ -21,6 +22,7 @@ type ServicePlanConfig =
             WorkerSize = this.WorkerSize
             OperatingSystem = this.OperatingSystem
             WorkerCount = this.WorkerCount
+            MaximumElasticWorkerCount = this.MaximumElasticWorkerCount
             Tags = this.Tags }
         ]
 
@@ -30,6 +32,7 @@ type ServicePlanBuilder() =
           Sku = Free
           WorkerSize = Small
           WorkerCount = 1
+          MaximumElasticWorkerCount = None
           OperatingSystem = Windows
           Tags = Map.empty }
     [<CustomOperation "name">]
@@ -44,6 +47,9 @@ type ServicePlanBuilder() =
     /// Sets the number of instances on the service plan.
     [<CustomOperation "number_of_workers">]
     member __.NumberOfWorkers(state:ServicePlanConfig, workerCount) = { state with WorkerCount = workerCount }
+    /// Sets the maximum number of elastic workers
+    [<CustomOperation "max_elastic_workers">]
+    member __.MaximumElasticWorkerCount(state:ServicePlanConfig, maxElasticWorkerCount) = { state with MaximumElasticWorkerCount = Some maxElasticWorkerCount }
     [<CustomOperation "operating_system">]
     /// Sets the operating system
     member __.OperatingSystem(state:ServicePlanConfig, os) = { state with OperatingSystem = os }

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -131,6 +131,7 @@ type WebAppConfig =
       Sku : Sku
       WorkerSize : WorkerSize
       WorkerCount : int
+      MaximumElasticWorkerCount : int option
       RunFromPackage : bool
       WebsiteNodeDefaultVersion : string option
       AlwaysOn : bool
@@ -395,6 +396,7 @@ type WebAppConfig =
                   Sku = this.Sku
                   WorkerSize = this.WorkerSize
                   WorkerCount = this.WorkerCount
+                  MaximumElasticWorkerCount = this.MaximumElasticWorkerCount
                   OperatingSystem = this.OperatingSystem
                   Tags = this.Tags}
             | _ ->
@@ -419,6 +421,7 @@ type WebAppBuilder() =
           Sku = Sku.F1
           WorkerSize = Small
           WorkerCount = 1
+          MaximumElasticWorkerCount = None
           RunFromPackage = false
           WebsiteNodeDefaultVersion = None
           AlwaysOn = false

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -534,6 +534,7 @@ module WebApp =
         | Premium of string
         | PremiumV2 of string
         | PremiumV3 of string
+        | ElasticPremium of string
         | Isolated of string
         | Dynamic
         static member D1 = Shared
@@ -553,6 +554,9 @@ module WebApp =
         static member P1V3 = PremiumV3 "P1V3"
         static member P2V3 = PremiumV3 "P2V3"
         static member P3V3 = PremiumV3 "P3V3"
+        static member EP1 = ElasticPremium "EP1"
+        static member EP2 = ElasticPremium "EP2"
+        static member EP3 = ElasticPremium "EP3"
         static member I1 = Isolated "I1"
         static member I2 = Isolated "I2"
         static member I3 = Isolated "I3"

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -24,7 +24,7 @@ let tests = testList "Functions tests" [
         let storage = resources.[2] :?> Storage.StorageAccount
 
         Expect.contains site.Dependencies (storageAccounts.resourceId "foo") "Storage account has not been added a dependency"
-        Expect.equal f.StorageAccountName.ResourceName.Value "foo" "Incorrect storage account  name on site"
+        Expect.equal f.StorageAccountName.ResourceName.Value "foo" "Incorrect storage account name on site"
         Expect.equal storage.Name.ResourceName.Value "foo" "Incorrect storage account name"
     }
     test "Implicitly sets dependency on connection string" {
@@ -111,5 +111,15 @@ let tests = testList "Functions tests" [
         let resources = (f :> IBuilder).BuildResources Location.WestEurope
         let site = resources.[0] :?> Web.Site
         Expect.equal site.AppSettings.["FUNCTIONS_WORKER_RUNTIME"] (LiteralSetting "dotnet-isolated") "Should use dotnet-isolated functions runtime"
+    }
+
+    test "Service plans support Elastic Premium functions" {
+        let sp = servicePlan { name "test"; sku WebApp.Sku.EP2; max_elastic_workers 25 }
+        let resources = (sp :> IBuilder).BuildResources Location.WestEurope
+        let serverFarm = resources.[0] :?> Web.ServerFarm
+
+        Expect.equal serverFarm.Sku (ElasticPremium "EP2") "Incorrect SKU"
+        Expect.equal serverFarm.Kind (Some "elastic") "Incorrect Kind"
+        Expect.equal serverFarm.MaximumElasticWorkerCount (Some 25) "Incorrect worker count"
     }
 ]


### PR DESCRIPTION
This PR closes #512

The changes in this PR are as follows:

* Add Elastic Premium SKUs to service plan.
* Add `max_elastic_workers` keyword to `servicePlan` builder.
* Set service plan kind to "elastic" if an Elastic Premium SKU is used.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
