### PR TITLE
Add support for setting min_tls_version for SQL Azure.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes
 * Storage: Support for minimum TLS version.
 * Virtual Machine: Support for customData on osProfile Properties 
 * WebApp: Added support for PrivateEndpoints
+* SQL Azure: Support for minimum TLS version.
 
 ## 1.6.1
 * Web App: Workaround ARM regression when Identity is set to "None".

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,10 +3,10 @@ Release Notes
 
 ## 1.6.2
 * Functions: Support Elastic Premium SKUs for Functions service plans.
+* SQL Azure: Support for minimum TLS version.
 * Storage: Support for minimum TLS version.
 * Virtual Machine: Support for customData on osProfile Properties 
 * WebApp: Added support for PrivateEndpoints
-* SQL Azure: Support for minimum TLS version.
 
 ## 1.6.1
 * Web App: Workaround ARM regression when Identity is set to "None".

--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -21,6 +21,7 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 | elastic_pool_sku | Sets the sku of the elastic pool, if required. If not set, Farmer will default to Basic 50. |
 | elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database. |
 | elastic_pool_capacity | Sets the optional disk size in MB for the elastic pool for each database. |
+| min_tls_version | Sets the minium TLS version for the SQL server |
 
 #### SQL Server Configuration Members
 | Member | Purpose |

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -17,6 +17,7 @@ type Server =
     { ServerName : SqlAccountName
       Location : Location
       Credentials : {| Username : string; Password : SecureParameter |}
+      MinTlsVersion : TlsVersion option
       Tags: Map<string,string> }
     interface IParameters with
         member this.SecureParameters = [ this.Credentials.Password ]
@@ -27,7 +28,13 @@ type Server =
                 properties =
                  {| administratorLogin = this.Credentials.Username
                     administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
-                    version = "12.0" |}
+                    version = "12.0"
+                    minimalTlsVersion = 
+                        match this.MinTlsVersion with
+                        | Some Tls10 -> "1.0"
+                        | Some Tls11 -> "1.1"
+                        | Some Tls12 -> "1.2"
+                        | None -> null |}
             |} :> _
 
 module Servers =

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -18,6 +18,7 @@ type SqlAzureDbConfig =
 type SqlAzureConfig =
     { Name : SqlAccountName
       AdministratorCredentials : {| UserName : string; Password : SecureParameter |}
+      MinTlsVersion : TlsVersion option
       FirewallRules : {| Name : ResourceName; Start : IPAddress; End : IPAddress |} list
       ElasticPoolSettings :
         {| Name : ResourceName option
@@ -56,6 +57,7 @@ type SqlAzureConfig =
               Credentials =
                 {| Username = this.AdministratorCredentials.UserName
                    Password = this.AdministratorCredentials.Password |}
+              MinTlsVersion = this.MinTlsVersion
               Tags = this.Tags
             }
 
@@ -151,6 +153,7 @@ type SqlServerBuilder() =
                Capacity = None |}
           Databases = []
           FirewallRules = []
+          MinTlsVersion = None
           Tags = Map.empty  }
     member __.Run state : SqlAzureConfig =
         { state with
@@ -198,6 +201,11 @@ type SqlServerBuilder() =
             AdministratorCredentials =
                 {| state.AdministratorCredentials with
                     UserName = username |} }
+
+    /// Set minimum TLS version
+    [<CustomOperation "min_tls_version">]
+    member _.SetMinTlsVersion(state:SqlAzureConfig, minTlsVersion) =
+        { state with MinTlsVersion = Some minTlsVersion }
     interface ITaggable<SqlAzureConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let sqlServer = SqlServerBuilder()

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -132,4 +132,21 @@ let tests = testList "SQL Server" [
         check "-zz" "cannot start with a dash ('-zz')" "Start with dash"
         check "zz-" "cannot end with a dash ('zz-')" "End with dash"
     }
+    test "Sets Min TLS version correctly" {
+        let sql = sqlServer {
+            name "server"
+            admin_username "isaac"
+            add_databases [
+                sqlDb {
+                    name "db"
+                    sku DtuSku.S0
+                }
+            ]
+            min_tls_version Tls12
+        }
+
+        let model : Models.Server = sql |> getResourceAtIndex client.SerializationSettings 0
+        Expect.equal model.Name "server" "Incorrect Server name"
+        Expect.equal model.MinimalTlsVersion "1.2" "Min TLS version is wrong"
+    }
 ]


### PR DESCRIPTION
This PR closes #652

The changes in this PR are as follows:

* add setting for min_tls_version for SQL Azure


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
