### PR TITLE
Add support for creating all required resource groups before deploying

### DIFF
--- a/src/Farmer/Arm/ResourceGroup.fs
+++ b/src/Farmer/Arm/ResourceGroup.fs
@@ -25,8 +25,13 @@ type ResourceGroupDeployment =
                 | _ -> ()
           ] |> List.distinct
     member this.RequiredResourceGroups = 
-        this.Name.Value :: (this.Resources |> List.collect (function | :? ResourceGroupDeployment as rg -> rg.RequiredResourceGroups | _ ->  []))
-        |> List.distinct
+        let nestedRgs = 
+            this.Resources 
+            |> List.collect 
+                (function 
+                | :? ResourceGroupDeployment as rg -> rg.RequiredResourceGroups 
+                | _ ->  [])
+        List.distinct (this.Name.Value :: nestedRgs)        
     member this.Template = 
         { Parameters = this.Parameters
           Outputs = this.Outputs |> Map.toList

--- a/src/Farmer/Arm/ResourceGroup.fs
+++ b/src/Farmer/Arm/ResourceGroup.fs
@@ -24,6 +24,9 @@ type ResourceGroupDeployment =
                 | :? IParameters as p -> yield! p.SecureParameters
                 | _ -> ()
           ] |> List.distinct
+    member this.RequiredResourceGroups = 
+        this.Name.Value :: (this.Resources |> List.collect (function | :? ResourceGroupDeployment as rg -> rg.RequiredResourceGroups | _ ->  []))
+        |> List.distinct
     member this.Template = 
         { Parameters = this.Parameters
           Outputs = this.Outputs |> Map.toList

--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -53,6 +53,9 @@ type ResourceGroupConfig =
               PostDeployTasks = 
                     this.Resources 
                     |> List.choose (function | :? IPostDeploy as pd -> Some pd |_ -> None)
+              RequiredResourceGroups =
+                    this.Resources
+                    |> List.collect (function | :? ResourceGroupDeployment as rg -> rg.RequiredResourceGroups | _ -> [])
               Tags = this.Tags }
     interface IBuilder with
         member this.ResourceId = this.ResourceId

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -230,8 +230,7 @@ let private prepareForDeployment parameters resourceGroupName (deployment:IDeplo
         |> List.distinct
         |> List.mapi (fun i x -> i,x)
     for (i,rg) in resourceGroups do
-        let status = if resourceGroups.Tail.IsEmpty then "" else $" ({i+1}/{resourceGroups.Length})"
-        printfn "Creating resource group %s%s..." rg status
+        printfn $"Creating resource group {rg} ({i+1}/{resourceGroups.Length})..." 
         do! Az.createResourceGroup deployment.Deployment.Location.ArmValue deployment.Deployment.Tags rg
 
     return

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -319,6 +319,7 @@ type Deployment =
     { Location : Location
       Template : ArmTemplate
       PostDeployTasks : IPostDeploy list
+      RequiredResourceGroups: string list
       Tags: Map<string,string> }
     interface IDeploymentSource with
         member this.Deployment = this

--- a/src/Tests/Helpers.fs
+++ b/src/Tests/Helpers.fs
@@ -12,6 +12,7 @@ let createSimpleDeployment parameters =
           Parameters = parameters |> List.map SecureParameter
           Resources = []
       }
+      RequiredResourceGroups = []
       Tags = Map.empty
     }
 let convertTo<'T> = Serialization.toJson >> Serialization.ofJson<'T>


### PR DESCRIPTION
The changes in this PR are as follows:

* Deploy: When using nested resource group deployments, all required resourece groups will be created

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

The functionality changed is not covered in the documentation/unit tests anywhere and would be hard to test without affecting 
a live subscription