### PR TITLE
Adds support for private AKS clusters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+## 1.6.3
+
+* Container Service (AKS): Support basic SKU for the cluster's load balancer (default is standard).
+* Container Service (AKS): Support for private Kubernetes API access.
+* Container Service (AKS): Support for restricting IP ranges for Kubernetes API access.
+
 ## 1.6.2
 * Functions: Support Elastic Premium SKUs for Functions service plans.
 * SQL Azure: Support for minimum TLS version.

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -11,12 +11,13 @@ The AKS Cluster builder is used to create AKS clusters.
 * Container Service (`Microsoft.ContainerService/managedClusters`)
 
 #### AKS Builder Keywords
-The AKS Builder constructs AKS clusters.
+The AKS builder (`aks`) constructs AKS clusters.
 
 | Keyword | Purpose |
 |-|-|
 | name | Sets the name of the AKS cluster. |
 | dns_prefix | Sets the DNS prefix of the AKS cluster. |
+| enable_private_cluster | Restricts the cluster's Kubernetes API to only be accessible from private networks. |
 | enable_rbac | Enable Kubernetes Role-Based Access Control. |
 | add_agent_pools | Adds agent pools to the AKS cluster. |
 | add_agent_pool | Adds an agent pool to the AKS cluster. |
@@ -27,9 +28,10 @@ The AKS Builder constructs AKS clusters.
 | service_principal_client_id | Sets the client id of the service principal for the AKS cluster. |
 | service_principal_use_msi | Enables the AKS cluster to use the managed identity service principal instead of an external client secret. |
 | windows_username | Sets the windows admin username for the AKS cluster. |
+| add_api_server_authorized_ip_ranges | Adds IP address CIDR ranges to be allowed Kubernetes API access. |
 
 #### Agent Pool Builder keywords
-The Agent Pool Builder constructs agent pools which are inserted into the AKS cluster.
+The Agent Pool builder (`agentPool`) constructs agent pools in the AKS cluster.
 
 | Keyword | Purpose |
 |-|-|
@@ -43,14 +45,22 @@ The Agent Pool Builder constructs agent pools which are inserted into the AKS cl
 | vm_size | Sets the size of the VM's in the agent pool. |
 | vnet | Sets the name of a virtual network in the same region where this AKS cluster should be attached. |
 
+#### Kubenet Builder
+The Kubenet builder (`kubenetNetworkProfile`) creates Kubenet network profiles on the AKS cluster.
+
+| Keyword | Purpose |
+|-|-|
+| load_balancer_sku | SKU for the Load Balancer - defaults to 'Standard' |
+
 #### CNI Builder
-The CNI builder helps create network profiles on the AKS cluster.
+The CNI builder (`azureCniNetworkProfile`) creates Azure CNI network profiles on the AKS cluster.
 
 | Keyword | Purpose |
 |-|-|
 | docker_bridge | Sets the docker bridge CIDR to a network other than the default 17.17.0.1/16. |
 | dns_service | Sets the DNS service IP - must be within the service CIDR, default is the second address in the service CIDR. |
 | service_cidr | Sets the service cidr to a network other than the default 10.224.0.0/16. |
+| load_balancer_sku | SKU for the Load Balancer - defaults to 'Standard' |
 
 #### Example
 ```fsharp

--- a/src/Farmer/Arm/ContainerService.fs
+++ b/src/Farmer/Arm/ContainerService.fs
@@ -26,14 +26,18 @@ type ManagedCluster =
       DnsPrefix : string
       EnableRBAC : bool
       Identity : ManagedIdentity
+      ApiServerAccessProfile :
+       {| AuthorizedIPRanges : string list
+          EnablePrivateCluster : bool option |} option
       LinuxProfile :
        {| AdminUserName : string
           PublicKeys : string list |} option
       NetworkProfile :
-       {| NetworkPlugin : ContainerService.NetworkPlugin
-          DnsServiceIP : System.Net.IPAddress
-          DockerBridgeCidr : IPAddressCidr
-          ServiceCidr : IPAddressCidr |} option
+       {| NetworkPlugin : ContainerService.NetworkPlugin option
+          DnsServiceIP : System.Net.IPAddress option
+          DockerBridgeCidr : IPAddressCidr option
+          LoadBalancerSku : LoadBalancer.Sku option
+          ServiceCidr : IPAddressCidr option |} option
       WindowsProfile :
         {| AdminUserName : string
            AdminPassword : SecureParameter |} option
@@ -78,6 +82,14 @@ type ManagedCluster =
                                |})
                           dnsPrefix = this.DnsPrefix
                           enableRBAC = this.EnableRBAC
+                          apiServerAccessProfile =
+                              match this.ApiServerAccessProfile with
+                              | Some apiServerProfile ->
+                                  {| authorizedIPRanges = apiServerProfile.AuthorizedIPRanges
+                                     enablePrivateCluster =
+                                        apiServerProfile.EnablePrivateCluster
+                                        |> Option.map box |> Option.toObj |}
+                              | None -> Unchecked.defaultof<_>
                           linuxProfile =
                                 match this.LinuxProfile with
                                 | Some linuxProfile ->
@@ -87,10 +99,11 @@ type ManagedCluster =
                           networkProfile =
                               match this.NetworkProfile with
                               | Some networkProfile ->
-                                    {| dnsServiceIP = networkProfile.DnsServiceIP |> string
-                                       dockerBridgeCidr = networkProfile.DockerBridgeCidr |> IPAddressCidr.format
-                                       networkPlugin = networkProfile.NetworkPlugin.ArmValue
-                                       serviceCidr = networkProfile.ServiceCidr |> IPAddressCidr.format |}
+                                    {| dnsServiceIP = networkProfile.DnsServiceIP |> Option.map string |> Option.toObj
+                                       dockerBridgeCidr = networkProfile.DockerBridgeCidr |> Option.map IPAddressCidr.format |> Option.toObj
+                                       loadBalancerSku = networkProfile.LoadBalancerSku |> Option.map (fun sku -> sku.ArmValue) |> Option.toObj
+                                       networkPlugin = networkProfile.NetworkPlugin |> Option.map (fun plugin -> plugin.ArmValue) |> Option.toObj
+                                       serviceCidr = networkProfile.ServiceCidr |> Option.map IPAddressCidr.format |> Option.toObj |}
                               | None -> Unchecked.defaultof<_>
                           servicePrincipalProfile =
                               {| clientId = this.ServicePrincipalProfile.ClientId

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -61,7 +61,7 @@
     <PackageReference Include="Microsoft.Azure.Management.CognitiveServices" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.Compute" Version="35.2.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ContainerService" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Management.ContainerService" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.DeviceProvisioningServices" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="2.10.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Maps" Version="1.0.2" />


### PR DESCRIPTION
The changes in this PR are as follows:

* Container Service (AKS): Support basic SKU for the cluster's load balancer (default is standard).
* Container Service (AKS): Support for private Kubernetes API access.
* Container Service (AKS): Support for restricted IP ranges for Kubernetes API access.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.