### PR TITLE
Subscription msg TTL, max queue and topic size

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 1.6.4
+* Service bus: Support max queue and topic sizes.
+* Service bus: Set default message TTL for subscriptions.
+
 ## 1.6.3
 * Container Service (AKS): Support basic SKU for the cluster's load balancer (default is standard).
 * Container Service (AKS): Support for private Kubernetes API access.

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -22,7 +22,8 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Queue | enable_dead_letter_on_message_expiration | Enables dead lettering of messages that expire. |
 | Queue | enable_partition | Enables partition support on the queue. |
 | Queue | link_to_namespace | Link this queue to an existing namespace instead of creating a new one. |
-| Queue | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes. |
+| Queue | max_queue_size | Maximum size for the queue in Megabytes e.g. `1024<Mb>`. |
+| Queue | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan or a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes. |
 | Queue | message_ttl_days | Time To Live (TTL) value for messages in days. |
 | Queue | add_authorization_rule | Adds an authorization rule to the queue. |
 | Subscription | name | The name of the subscription. |
@@ -34,13 +35,15 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Subscription | enable_partition | Enables partition support on the queue. |
 | Subscription | forward_to | Specifies a queue or topic to automatically forward messages delivered to this subscription. |
 | Subscription | link_to_namespace | Link this queue to an existing namespace instead of creating a new one. |
+| Subscription | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan or a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes. |
 | Subscription | add_filters | Adds multiple filters to a subscription |
 | Subscription | add_sql_filter | Adds a filter to a subscription using SQL syntax. |
 | Subscription | add_correlation_filter | Adds a filter to a subscription using header value correlation. |
 | Topic | name | The name of the topic. |
 | Topic | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for. |
 | Topic | enable_partition | Enables partition support on the topic. |
-| Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes, or as an integer days e.g. `4<Days>`. |
+| Topic | max_topic_size | Maximum size for the topic in Megabytes e.g. `1024<Mb>`. |
+| Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan or a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes, or as an integer days e.g. `4<Days>`. |
 | Topic | link_to_unmanaged_namespace | Instead of creating or modifying a namespace, configure this topic to point to another unmanaged namespace instance. |
 | Namespace | sku | The ServiceBusNamespaceSku e.g. Standard |
 | Namespace | namespace_name | The name of the namespace that holds the queue. |

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -74,6 +74,7 @@ module Namespaces =
           DeadLetteringOnMessageExpiration : bool option
           DefaultMessageTimeToLive : IsoDateTime
           MaxDeliveryCount : int option
+          MaxSizeInMegabytes : int<Mb> option
           EnablePartitioning : bool option}
         interface IArmResource with
             member this.ResourceId = queues.resourceId (this.Namespace/this.Name)
@@ -90,6 +91,7 @@ module Namespaces =
                         requiresSession = this.Session |> Option.toNullable
                         deadLetteringOnMessageExpiration = this.DeadLetteringOnMessageExpiration |> Option.toNullable
                         maxDeliveryCount = this.MaxDeliveryCount |> Option.toNullable
+                        maxSizeInMegabytes = this.MaxSizeInMegabytes |> Option.toNullable
                         enablePartitioning = this.EnablePartitioning |> Option.toNullable |}
                 |} :> _
     type QueueAuthorizationRule =
@@ -122,7 +124,8 @@ module Namespaces =
           Namespace : ResourceId
           DuplicateDetectionHistoryTimeWindow : IsoDateTime option
           DefaultMessageTimeToLive : IsoDateTime option
-          EnablePartitioning : bool option }
+          EnablePartitioning : bool option
+          MaxSizeInMegabytes : int<Mb> option }
         interface IArmResource with
             member this.ResourceId = topics.resourceId (this.Namespace.Name, this.Name)
             member this.JsonModel =
@@ -134,7 +137,8 @@ module Namespaces =
                                | Some _ -> Nullable true
                                | None -> Nullable()
                            duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
-                           enablePartitioning = this.EnablePartitioning |> Option.toNullable |}
+                           enablePartitioning = this.EnablePartitioning |> Option.toNullable
+                           maxSizeInMegabytes = this.MaxSizeInMegabytes |> Option.toNullable |}
                 |} :> _
 
 type Namespace =


### PR DESCRIPTION
The changes in this PR are as follows:

* Service bus: Support max queue and topic sizes.
* Service bus: Set default message TTL for subscriptions.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.