### PR TITLE
Add webapp keyvault ref identity support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.6.5
+* WebApp: Add support for keyvault reference user identity
+* Functions: Add support for keyvault reference user identity
 
 ## 1.6.4
 * Azure Firewall: Added support for Azure Firewalls

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -39,6 +39,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | docker_ci | Turns on continuous integration of the web app from the Docker source repository using a webhook.
 | Web App | docker_use_azure_registry | Uses the supplied Azure Container Registry name as the source of the Docker image, instead of Docker Hub. You do not need to specify the full url, but just the name of the registry itself.
 | Web App | add_identity | Adds a managed identity to the the Web App. Farmer will automatically set the AZURE_CLIENT_ID application setting to the Client Id of the supplied identity. |
+| Web App | keyvault_identity | Adds a managed identity to the the Web App and sets this identity to be used for [KeyVault References](https://docs.microsoft.com/en-us/azure/app-service/app-service-key-vault-references). Farmer will automatically set the AZURE_CLIENT_ID application setting to the Client Id of the supplied identity.  |
 | Web App | system_identity | Activates the system identity of the Web App. |
 | Web App | enable_cors | Enables CORS support for the app. Either specify `WebApp.AllOrigins` or a list of valid URIs as strings. |
 | Web App | enable_cors_credentials | Allows CORS requests with credentials. |

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -149,6 +149,7 @@ type Site =
       Dependencies : ResourceId Set
       Kind : string
       Identity : Identity.ManagedIdentity
+      KeyVaultReferenceIdentity : UserAssignedIdentity option
       LinuxFxVersion : string option
       AppCommandLine : string option
       NetFrameworkVersion : string option
@@ -195,6 +196,7 @@ type Site =
                     {| serverFarmId = this.ServicePlan.Eval()
                        httpsOnly = this.HTTPSOnly
                        clientAffinityEnabled = match this.ClientAffinityEnabled with Some v -> box v | None -> null
+                       keyVaultReferenceIdentity = this.KeyVaultReferenceIdentity |> Option.map (fun x->x.ResourceId.Eval()) |> Option.defaultValue null
                        siteConfig =
                         {| alwaysOn = this.AlwaysOn
                            appSettings = this.AppSettings |> Map.toList |> List.map(fun (k,v) -> {| name = k; value = v.Value |})

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -33,6 +33,7 @@ module private FunctionsConfig =
           Settings = state.Settings
           Cors = state.Cors
           Identity = state.Identity
+          KeyVaultReferenceIdentity = state.KeyVaultReferenceIdentity
           SecretStore = state.SecretStore
           ZipDeployPath = state.ZipDeployPath
           AlwaysOn = state.AlwaysOn
@@ -47,6 +48,7 @@ module private FunctionsConfig =
             Settings = config.Settings
             Cors = config.Cors
             Identity = config.Identity
+            KeyVaultReferenceIdentity = config.KeyVaultReferenceIdentity
             SecretStore = config.SecretStore
             ZipDeployPath = config.ZipDeployPath
             WorkerProcess = config.WorkerProcess }
@@ -66,6 +68,7 @@ type FunctionsConfig =
       PublishAs : PublishAs
       ExtensionVersion : FunctionsExtensionVersion
       Identity : ManagedIdentity
+      KeyVaultReferenceIdentity : UserAssignedIdentity Option
       SecretStore : SecretStore
       ZipDeployPath : string option
       AlwaysOn : bool
@@ -204,6 +207,7 @@ type FunctionsConfig =
               |> Map
 
               Identity = this.Identity
+              KeyVaultReferenceIdentity = this.KeyVaultReferenceIdentity
               Kind =
                 match this.OperatingSystem with
                 | Windows -> "functionapp"
@@ -320,6 +324,7 @@ type FunctionsBuilder() =
           Settings = Map.empty
           Dependencies = Set.empty
           Identity = ManagedIdentity.Empty
+          KeyVaultReferenceIdentity = None
           PublishAs = Code
           SecretStore = AppService
           Tags = Map.empty

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -80,6 +80,7 @@ module private WebAppConfig =
           Settings = state.Settings
           Cors = state.Cors
           Identity = state.Identity
+          KeyVaultReferenceIdentity = state.KeyVaultReferenceIdentity
           SecretStore = state.SecretStore
           ZipDeployPath = state.ZipDeployPath
           AlwaysOn = state.AlwaysOn
@@ -93,6 +94,7 @@ module private WebAppConfig =
             Settings = config.Settings
             Cors = config.Cors
             Identity = config.Identity
+            KeyVaultReferenceIdentity = config.KeyVaultReferenceIdentity
             SecretStore = config.SecretStore
             ZipDeployPath = config.ZipDeployPath
             AlwaysOn = config.AlwaysOn
@@ -107,6 +109,7 @@ type CommonWebConfig =
       Settings : Map<string, Setting>
       Cors : Cors option
       Identity : Identity.ManagedIdentity
+      KeyVaultReferenceIdentity: UserAssignedIdentity Option
       SecretStore : SecretStore
       ZipDeployPath : string option
       AlwaysOn : bool
@@ -120,6 +123,7 @@ type WebAppConfig =
       Settings : Map<string, Setting>
       Cors : Cors option
       Identity : Identity.ManagedIdentity
+      KeyVaultReferenceIdentity: UserAssignedIdentity Option
       ZipDeployPath : string option
       HTTPSOnly : bool
       HTTP20Enabled : bool option
@@ -214,6 +218,7 @@ type WebAppConfig =
               ClientAffinityEnabled = this.ClientAffinityEnabled
               WebSocketsEnabled = this.WebSocketsEnabled
               Identity = this.Identity
+              KeyVaultReferenceIdentity = this.KeyVaultReferenceIdentity
               Cors = this.Cors
               Tags = this.Tags
               ConnectionStrings = this.ConnectionStrings
@@ -418,6 +423,7 @@ type WebAppBuilder() =
           AppInsights = Some (derived (fun name -> components.resourceId (name-"ai")))
           Settings = Map.empty
           Identity = ManagedIdentity.Empty
+          KeyVaultReferenceIdentity = None
           Cors = None
           OperatingSystem = Windows
           ZipDeployPath = None
@@ -637,6 +643,15 @@ module Extensions =
                 Settings = current.Settings.Add("AZURE_CLIENT_ID", Setting.ExpressionSetting identity.ClientId) }
             |> this.Wrap state
         member this.AddIdentity (state, identity:UserAssignedIdentityConfig) = this.AddIdentity(state, identity.UserAssignedIdentity)
+        [<CustomOperation "keyvault_identity">]
+        member this.AddKeyVaultIdentity (state:'T, identity:UserAssignedIdentity) =
+            let current = this.Get state
+            { current with
+                Identity = current.Identity + identity
+                KeyVaultReferenceIdentity = Some identity
+                Settings = current.Settings.Add("AZURE_CLIENT_ID", Setting.ExpressionSetting identity.ClientId) }
+            |> this.Wrap state
+        member this.AddKeyVaultIdentity (state, identity:UserAssignedIdentityConfig) = this.AddKeyVaultIdentity(state, identity.UserAssignedIdentity)
         [<CustomOperation "system_identity">]
         member this.SystemIdentity (state:'T) =
             let current = this.Get state

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -74,7 +74,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Sql" Version="1.43.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="21.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.TrafficManager" Version="2.5.3" />
-    <PackageReference Include="Microsoft.Azure.Management.WebSites" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.Management.WebSites" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.9.1" />

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -306,6 +306,7 @@ let tests = testList "Web App Tests" [
     test "Supports .NET 5 EAP" {
         let app = webApp { runtime_stack Runtime.DotNet50 }
         let site:Site = app |> getResourceAtIndex 0
+        site.KeyVaultReferenceIdentity
         Expect.equal site.SiteConfig.NetFrameworkVersion "v5.0" "Wrong dotnet version"
     }
     test "Supports private endpoints" {
@@ -317,5 +318,16 @@ let tests = testList "Web App Tests" [
         Expect.equal ep.PrivateLinkServiceConnections.[0].GroupIds.[0] "sites" "Incorrect group ids"
         Expect.equal ep.PrivateLinkServiceConnections.[0].PrivateLinkServiceId "[resourceId('Microsoft.Web/sites', 'farmerWebApp')]" "Incorrect PrivateLinkServiceId"
         Expect.equal ep.Subnet.Id (subnet.ArmExpression.Eval()) "Incorrect subnet id"
+    }
+    test "Supports keyvault reference identity" {
+        let app = webApp { name "farmerWebApp"}
+        let site:Site = app |> getResourceAtIndex 0
+        Expect.isNull site.KeyVaultReferenceIdentity "Keyvault identity should not be set"
+
+        let myId = userAssignedIdentity { name "myFarmerIdentity" }
+        let app = webApp { name "farmerWebApp"; keyvault_identity myId }
+        let site:Site = app |> getResourceAtIndex 0
+        Expect.equal site.KeyVaultReferenceIdentity "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'myFarmerIdentity')]" "Keyvault identity should not be set"
+
     }
 ]


### PR DESCRIPTION
This PR closes #680

The changes in this PR are as follows:

* added keyvault_identity to WebApp and Functions builders
* added `$.properties.keyVaultReferenceIdentity` to `Microsoft.Web/sites` output

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
