### PR TITLE
Added depends_on to azure firewall and bug fixed link_to_vhub

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.5
+* Azure Firewall: Bug fix for link_to_vhub and added depends_on to builder
+
 ## 1.6.4
 * DNS Zone: Added SOA and SRV record support
 * Azure Firewall: Added support for Azure Firewalls

--- a/docs/content/api-overview/resources/azure-firewall.md
+++ b/docs/content/api-overview/resources/azure-firewall.md
@@ -21,7 +21,8 @@ The Azure Firewall builder (`azureFirewall`) is used to create Azure Firewall in
 | azureFirewall           | link_to_firewall_policy | Configure the azure firewall to use a firewall policy deployed by Farmer |
 | azureFirewall           | link_to_unmanaged_vhub | Specify the existing virtual hub to which the azure firewall belongs |
 | azureFirewall           | link_to_vhub | Specify the virtual hub deployed by farmer to which the azure firewall belongs |
-| azureFirewall           | public_ip_reservation_count | Specify The number of Public IP addresses associated with the azure firewall |
+| azureFirewall           | public_ip_reservation_count | Specify the number of Public IP addresses associated with the azure firewall |
+| azureFirewall           | depends_on | Specify resources deployed by farmer the azure firewall depends on |
 
 ### Example
 

--- a/src/Farmer/Builders/Builders.AzureFirewall.fs
+++ b/src/Farmer/Builders/Builders.AzureFirewall.fs
@@ -22,7 +22,7 @@ type AzureFirewallConfig =
       VirtualHub : LinkedResource option
       HubIPAddressSpace : HubIPAddressSpace option
       Sku : Sku
-      Dependencies : ResourceId Set}
+      Dependencies : ResourceId Set }
     interface IBuilder with
         member this.ResourceId = azureFirewalls.resourceId this.Name
         member this.BuildResources location = [
@@ -50,7 +50,7 @@ type AzureFirewallBuilder() =
           FirewallPolicy = None
           VirtualHub = None
           HubIPAddressSpace = None
-          Dependencies = Set.empty}
+          Dependencies = Set.empty }
     /// The name of the firewall.
     [<CustomOperation "name">] member _.Name(state:AzureFirewallConfig, name) = { state with Name = ResourceName name }
     /// The SKU of the firewall.
@@ -91,6 +91,5 @@ type AzureFirewallBuilder() =
         | AZFW_VNet -> ()
         state
     interface IDependable<AzureFirewallConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
-
         
 let azureFirewall = AzureFirewallBuilder()

--- a/src/Farmer/Builders/Builders.AzureFirewall.fs
+++ b/src/Farmer/Builders/Builders.AzureFirewall.fs
@@ -5,6 +5,7 @@ open Farmer
 open Farmer.AzureFirewall
 open Farmer.Arm.AzureFirewall
 open Farmer.Arm.VirtualHub
+open Farmer.Builders.VirtualHub
 
 type HubIPAddressSpace =
     | PublicCount of int
@@ -20,20 +21,22 @@ type AzureFirewallConfig =
       FirewallPolicy : LinkedResource option
       VirtualHub : LinkedResource option
       HubIPAddressSpace : HubIPAddressSpace option
-      Sku : Sku }
+      Sku : Sku
+      Dependencies : ResourceId Set}
     interface IBuilder with
         member this.ResourceId = azureFirewalls.resourceId this.Name
         member this.BuildResources location = [
             { Name = this.Name
               Location = location
-              Dependencies = [
+              Dependencies = Set [
+                yield! this.Dependencies
                 match this.FirewallPolicy with
                 | Some (Managed resId) -> resId // Only generate dependency if this is managed by Farmer (same template)
                 | _ -> ()
                 match this.VirtualHub with
                 | Some (Managed resId) -> resId
                 | _ -> ()
-              ] |> Set.ofList
+              ]
               FirewallPolicy = this.FirewallPolicy |> Option.map (fun x -> match x with | Managed resId | Unmanaged resId -> resId)
               VirtualHub = this.VirtualHub |> Option.map (fun x -> match x with | Managed resId | Unmanaged resId -> resId)
               HubIPAddresses = this.HubIPAddressSpace |> Option.map (fun x -> x.Arm)
@@ -46,7 +49,8 @@ type AzureFirewallBuilder() =
           Sku = {Name = SkuName.AZFW_Hub; Tier = SkuTier.Standard}
           FirewallPolicy = None
           VirtualHub = None
-          HubIPAddressSpace = None }
+          HubIPAddressSpace = None
+          Dependencies = Set.empty}
     /// The name of the firewall.
     [<CustomOperation "name">] member _.Name(state:AzureFirewallConfig, name) = { state with Name = ResourceName name }
     /// The SKU of the firewall.
@@ -67,8 +71,10 @@ type AzureFirewallBuilder() =
         { state with VirtualHub = Some (Unmanaged resourceId) }
     /// The managed virtualHub to which the firewall belongs
     [<CustomOperation "link_to_vhub">]
-    member this.LinkToVirtualHub (state:AzureFirewallConfig, vhub:IArmResource) =    
-        { state with FirewallPolicy = Some (Managed vhub.ResourceId) }
+    member this.LinkToVirtualHub (state:AzureFirewallConfig, vhub:VirtualHub) =    
+        { state with VirtualHub = Some (Managed (vhub :> IArmResource).ResourceId) }
+    member this.LinkToVirtualHub (state:AzureFirewallConfig, vhub:VirtualHubConfig) =    
+        { state with VirtualHub = Some (Managed (vhub :> IBuilder).ResourceId) }
     /// Configure this firewall to reserve a specified number of public ips.
     /// 0 is not a valid value for AZFW_HUB 
     [<CustomOperation "public_ip_reservation_count">]
@@ -84,6 +90,7 @@ type AzureFirewallBuilder() =
             | Some (PublicCount _) -> ()
         | AZFW_VNet -> ()
         state
-       
+    interface IDependable<AzureFirewallConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+
         
 let azureFirewall = AzureFirewallBuilder()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -139,8 +139,8 @@
     <Compile Include="Builders/Builders.DiagnosticSetting.fs" />
     <Compile Include="Builders/Builders.VirtualWan.fs" />
     <Compile Include="Builders/Builders.TrafficManager.fs" />
-    <Compile Include="Builders/Builders.AzureFirewall.fs" />
     <Compile Include="Builders/Builders.VirtualHub.fs" />
+    <Compile Include="Builders/Builders.AzureFirewall.fs" />
     <Compile Include="Aliases.fs" />
   </ItemGroup>
 </Project>

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -301,11 +301,6 @@ let tests =
                 link_to_vhub vhub
                 depends_on [(vhub :>IBuilder).ResourceId]
             }
-            let template = arm {
-                location Location.NorthEurope
-                add_resources [firewall; vhub; vwan]
-            }
-            template :> IDeploymentSource |> Farmer.Writer.quickWrite "firewall"
             compareResourcesToJson [ firewall; vhub; vwan ] "azure-firewall.json"
         }
     ]

--- a/src/Tests/test-data/azure-firewall.json
+++ b/src/Tests/test-data/azure-firewall.json
@@ -6,7 +6,9 @@
   "resources": [
     {
       "apiVersion": "2020-07-01",
-      "dependsOn": [],
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualHubs', 'farmer_vhub')]"
+      ],
       "location": "northeurope",
       "name": "farmer_firewall",
       "properties": {
@@ -21,10 +23,41 @@
           "tier": "Standard"
         },
         "virtualHub": {
-          "id": "[resourceId('Microsoft.Network/virtualHubs', 'unmanaged-vhub')]"
+          "id": "[resourceId('Microsoft.Network/virtualHubs', 'farmer_vhub')]"
         }
       },
       "type": "Microsoft.Network/azureFirewalls"
+    },
+    {
+      "apiVersion": "2020-07-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualWans', 'farmer-vwan')]"
+      ],
+      "location": "northeurope",
+      "name": "farmer_vhub",
+      "properties": {
+        "addressPrefix": "100.73.255.0/24",
+        "routeTable": {
+          "routes": []
+        },
+        "sku": "Standard",
+        "virtualWan": {
+          "id": "[resourceId('Microsoft.Network/virtualWans', 'farmer-vwan')]"
+        }
+      },
+      "type": "Microsoft.Network/virtualHubs"
+    },
+    {
+      "apiVersion": "2020-07-01",
+      "location": "northeurope",
+      "name": "farmer-vwan",
+      "properties": {
+        "allowBranchToBranchTraffic": true,
+        "disableVpnEncryption": true,
+        "office365LocalBreakoutCategory": "None",
+        "type": "Standard"
+      },
+      "type": "Microsoft.Network/virtualWans"
     }
   ]
 }


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* fixed a bug where link_to_vhub for azure firewall incorrectly set FirewallPolicy instead of vhub in property
* added depends_on to AzureFirewall builder so it can depend on arbitrary resources for Azure timing issues

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
