### PR TITLE
Adds 'depends_on' support for container groups

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.6
+* Container Groups: Support for 'depends_on' to add dependencies.
+
 ## 1.6.5
 * Azure Firewall: Bug fix for link_to_vhub and added depends_on to builder
 * Functions: Add support for keyvault reference user identity

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -11,55 +11,87 @@ The Container Group builder is used to create Azure Container Group instances.
 * Container Group (`Microsoft.ContainerInstance/containerGroups`)
 * Network Profile (`Microsoft.Network/networkProfiles`)
 
-#### Builder Keywords
-| Applies To        | Keyword | Purpose |
-|-------------------|---------|------------------------------------------|
-| containerInstance | name    | Sets the name of the container instance. |
-| containerInstance | image   | Sets the container image. |
-| containerInstance | command | Sets the commands to execute within the container instance in exec form. |
-| containerInstance | add_ports | Sets the ports the container exposes. |
-| containerInstance | cpu_cores | Sets the maximum CPU cores the container may use. |
-| containerInstance | memory | Sets the maximum gigabytes of memory the container may use. |
-| containerInstance | env_vars | Sets a list of environment variables for the container. |
-| containerInstance | add_volume_mount | Adds a volume mount on a container from a volume in the container group. |
-| containerInstance | probes | Adds liveliness and readiness probes to a container. |
-| initContainer | name | Sets the name of the init container. |
-| initContainer | image | Sets the init container image. |
-| initContainer | command | Sets the commands to execute within the init container in exec form. |
-| initContainer | env_vars | Sets a list of environment variables for the init container. |
-| initContainer | add_volume_mount | Adds a volume mount on an init container from a volume in the container group. |
-| containerGroup | name | Sets the name of the container group. |
-| containerGroup | add_instances | Adds container instances to the group. |
-| containerGroup | operating_system | Sets the OS type (default Linux). |
-| containerGroup | restart_policy | Sets the restart policy (default Always) |
-| containerGroup | public_dns | Sets the DNS host label when using a public IP. |
-| containerGroup | private_ip | Indicates the container should use a system-assigned private IP address for use in a virtual network. |
-| containerGroup | network_profile | Name of a network profile resource for the subnet in a virtual network where the container group will attach. |
-| containerGroup | add_identity | Adds a managed identity to the the container group. |
-| containerGroup | system_identity | Activates the system identity of the container group. |
-| containerGroup | add_registry_credentials | Adds a container image registry credential with a secure parameter for the password. |
-| containerGroup | add_tcp_port | Adds a TCP port to be externally accessible. |
-| containerGroup | add_udp_port | Adds a UDP port to be externally accessible. |
-| containerGroup | add_volumes | Adds volumes to a container group so they are accessible to containers. |
-| containerGroup | depends_on | Specifies the resource or resource ID of resources that must exist before the container group is created. |
-| liveliness | http | Sets the http GET URI on a container liveliness check. |
-| liveliness | exec | Sets a command to execute on a container liveliness check. |
-| liveliness | initial_delay_seconds | Sets a delay after container startup before the first check - default is 0 seconds. |
-| liveliness | period_seconds | Sets the period between running checks - default is 10 seconds. |
-| liveliness | failure_threshold | Sets the number of times a check can fail before the container is considered unhealthy and will be restarted - default is 3. |
-| liveliness | success_threshold | Sets the number of times a check must succeed before the container is considered healthy - default is 1. |
-| liveliness | timeout_seconds | Sets the number of seconds a check is allowed to run before considering the check a failure - default is 1 second. |
-| readiness | http | Sets the http GET URI on a container readiness check. |
-| readiness | exec | Sets a command to execute on a container readiness check. |
-| readiness | initial_delay_seconds | Sets a delay after container startup before the readiness check - default is 0 seconds. |
-| readiness | period_seconds | Sets the period between running checks - default is 10 seconds. |
-| readiness | failure_threshold | Sets the number of times a check can fail before the container is considered unhealthy and will be restarted - default is 3. |
-| readiness | success_threshold | Sets the number of times a check must succeed before the container is considered healthy - default is 1. |
-| readiness | timeout_seconds | Sets the number of seconds a check is allowed to run before considering the check a failure - default is 1 second. |
-| networkProfile | name | Name of the container network profile for connecting a container group to a virtual network. |
-| networkProfile | vnet | Resource name of the virtual network to connect (if created in the same deployment). |
-| networkProfile | link_to_vnet | Resource name of an existing virtual network to connect. |
-| networkProfile | subnet | Name of the subnet in the virtual network where the container group should attach. |
+#### Container Group Builder
+The Container Group builder (`containerGroup`) defines a Container Group.
+
+| Keyword | Purpose |
+|-|-|
+| name | Sets the name of the container group. |
+| add_instances | Adds container instances to the group. |
+| operating_system | Sets the OS type (default Linux). |
+| restart_policy | Sets the restart policy (default Always) |
+| public_dns | Sets the DNS host label when using a public IP. |
+| private_ip | Indicates the container should use a system-assigned private IP address for use in a virtual network. |
+| network_profile | Name of a network profile resource for the subnet in a virtual network where the container group will attach. |
+| add_identity | Adds a managed identity to the the container group. |
+| system_identity | Activates the system identity of the container group. |
+| add_registry_credentials | Adds a container image registry credential with a secure parameter for the password. |
+| add_tcp_port | Adds a TCP port to be externally accessible. |
+| add_udp_port | Adds a UDP port to be externally accessible. |
+| add_volumes | Adds volumes to a container group so they are accessible to containers. |
+| depends_on | Specifies the resource or resource ID of resources that must exist before the container group is created. |
+
+#### Container Instance Builder
+The Container Instance builder (`containerInstance`) is used to define one or more containers to add to the group.
+
+| Keyword | Purpose |
+|-|-|
+| name    | Sets the name of the container instance. |
+| image   | Sets the container image. |
+| command | Sets the commands to execute within the container instance in exec form. |
+| add_ports | Sets the ports the container exposes. |
+| cpu_cores | Sets the maximum CPU cores the container may use. |
+| memory | Sets the maximum gigabytes of memory the container may use. |
+| env_vars | Sets a list of environment variables for the container. |
+| add_volume_mount | Adds a volume mount on a container from a volume in the container group. |
+| probes | Adds liveliness and readiness probes to a container. |
+
+#### Init Container Instance Builder
+The Init Container builder (`initContainer`) is used to define one or more init containers which must fully start before the rest of the containers in the group.
+
+| Keyword | Purpose |
+|-|-|
+| name | Sets the name of the init container. |
+| image | Sets the init container image. |
+| command | Sets the commands to execute within the init container in exec form. |
+| env_vars | Sets a list of environment variables for the init container. |
+| add_volume_mount | Adds a volume mount on an init container from a volume in the container group. |
+
+#### Network Profile Builder
+The Network Profile builder (`networkProfile`) is used to define a network profile to connect the container group to a subnet on a virtual network.
+
+| Keyword | Purpose |
+|-|-|
+| name | Name of the container network profile for connecting a container group to a virtual network. |
+| vnet | Resource name of the virtual network to connect (if created in the same deployment). |
+| link_to_vnet | Resource name of an existing virtual network to connect. |
+| subnet | Name of the subnet in the virtual network where the container group should attach. |
+
+#### Liveness Probe Builder
+The Liveness Probe builder (`liveness`) is used to define a liveness probe for a container instance to determine if it is healthy.
+
+| Keyword | Purpose |
+|-|-|
+| http | Sets the http GET URI on a container liveliness check. |
+| exec | Sets a command to execute on a container liveliness check. |
+| initial_delay_seconds | Sets a delay after container startup before the first check - default is 0 seconds. |
+| period_seconds | Sets the period between running checks - default is 10 seconds. |
+| failure_threshold | Sets the number of times a check can fail before the container is considered unhealthy and will be restarted - default is 3. |
+| success_threshold | Sets the number of times a check must succeed before the container is considered healthy - default is 1. |
+| timeout_seconds | Sets the number of seconds a check is allowed to run before considering the check a failure - default is 1 second. |
+
+#### Readiness Probe Builder
+The Readiness Probe builder (`readiness`) is used to define a readiness probe for a container instance to determine if it is ready to accept requests.
+
+| Keyword | Purpose |
+|-|-|
+| http | Sets the http GET URI on a container readiness check. |
+| exec | Sets a command to execute on a container readiness check. |
+| initial_delay_seconds | Sets a delay after container startup before the readiness check - default is 0 seconds. |
+| period_seconds | Sets the period between running checks - default is 10 seconds. |
+| failure_threshold | Sets the number of times a check can fail before the container is considered unhealthy and will be restarted - default is 3. |
+| success_threshold | Sets the number of times a check must succeed before the container is considered healthy - default is 1. |
+| timeout_seconds | Sets the number of seconds a check is allowed to run before considering the check a failure - default is 1 second. |
 
 #### Example
 ```fsharp

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -41,6 +41,7 @@ The Container Group builder is used to create Azure Container Group instances.
 | containerGroup | add_tcp_port | Adds a TCP port to be externally accessible. |
 | containerGroup | add_udp_port | Adds a UDP port to be externally accessible. |
 | containerGroup | add_volumes | Adds volumes to a container group so they are accessible to containers. |
+| containerGroup | depends_on | Specifies the resource or resource ID of resources that must exist before the container group is created. |
 | liveliness | http | Sets the http GET URI on a container liveliness check. |
 | liveliness | exec | Sets a command to execute on a container liveliness check. |
 | liveliness | initial_delay_seconds | Sets a delay after container startup before the first check - default is 0 seconds. |

--- a/samples/scripts/container-instance.fsx
+++ b/samples/scripts/container-instance.fsx
@@ -43,7 +43,7 @@ let template = arm {
                     memory 0.5<Gb>
                     cpu_cores 0.2
                     probes [
-                        liveliness {
+                        liveness {
                             http "http://localhost:80/index.html"
                             initial_delay_seconds 15
                         }

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -63,7 +63,7 @@ type ContainerGroup =
            Memory : float<Gb>
            EnvironmentVariables: Map<string, EnvVar>
            VolumeMounts : Map<string,string>
-           LivelinessProbe : ContainerProbe option
+           LivenessProbe : ContainerProbe option
            ReadinessProbe : ContainerProbe option
         |} list
       OperatingSystem : OS
@@ -144,7 +144,7 @@ type ContainerGroup =
                                               | SecureEnvValue value ->
                                                 {| name = key; value = null; secureValue = value.ArmExpression.Eval() |}
                                       ]
-                                      livenessProbe = container.LivelinessProbe |> Option.map (fun p -> p.JsonModel |> box) |> Option.defaultValue null
+                                      livenessProbe = container.LivenessProbe |> Option.map (fun p -> p.JsonModel |> box) |> Option.defaultValue null
                                       readinessProbe = container.ReadinessProbe |> Option.map (fun p -> p.JsonModel |> box) |> Option.defaultValue null
                                       resources =
                                        {| requests =

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -89,7 +89,9 @@ type ContainerGroupConfig =
       /// Managed identity for the container group.
       Identity : ManagedIdentity
       /// Tags for the container group.
-      Tags: Map<string,string> }
+      Tags: Map<string,string>
+      /// Additional dependencies.
+      Dependencies: Set<ResourceId> }
     member private this.ResourceId = containerGroups.resourceId this.Name
     member this.SystemIdentity = SystemIdentity this.ResourceId
     interface IBuilder with
@@ -125,7 +127,8 @@ type ContainerGroupConfig =
               IpAddress = this.IpAddress
               NetworkProfile = this.NetworkProfile
               Volumes = this.Volumes
-              Tags = this.Tags }
+              Tags = this.Tags
+              Dependencies = this.Dependencies }
         ]
 
 type ContainerProbeType = LivelinessProbe | ReadinessProbe
@@ -180,7 +183,8 @@ type ContainerGroupBuilder() =
           NetworkProfile = None
           Instances = []
           Volumes = Map.empty
-          Tags = Map.empty }
+          Tags = Map.empty
+          Dependencies = Set.empty }
     member this.Run (state:ContainerGroupConfig) =
         // Automatically apply all public-facing ports to the container group itself.
         state.Instances
@@ -237,6 +241,7 @@ type ContainerGroupBuilder() =
 
     interface IIdentity<ContainerGroupConfig> with member _.Add state updater = { state with Identity = updater state.Identity }
     interface ITaggable<ContainerGroupConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependable<ContainerGroupConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 /// Creates an image registry credential with a generated SecureParameter for the password.
 let registry (server:string) (username:string) =

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -47,8 +47,8 @@ type ContainerInstanceConfig =
       Memory : float<Gb>
       /// Environment variables for the container
       EnvironmentVariables : Map<string, EnvVar>
-      /// Liveliness probe for checking the container's health.
-      LivelinessProbe : ContainerProbe option
+      /// Liveness probe for checking the container's health.
+      LivenessProbe : ContainerProbe option
       /// Readiness probe to wait for the container to be ready to accept requests.
       ReadinessProbe : ContainerProbe option
       /// Volume mounts for the container
@@ -108,7 +108,7 @@ type ContainerGroupConfig =
                        Cpu = instance.Cpu
                        Memory = instance.Memory
                        EnvironmentVariables = instance.EnvironmentVariables
-                       LivelinessProbe = instance.LivelinessProbe
+                       LivenessProbe = instance.LivenessProbe
                        ReadinessProbe = instance.ReadinessProbe
                        VolumeMounts = instance.VolumeMounts |}
               ]
@@ -131,7 +131,7 @@ type ContainerGroupConfig =
               Dependencies = this.Dependencies }
         ]
 
-type ContainerProbeType = LivelinessProbe | ReadinessProbe
+type ContainerProbeType = LivenessProbe | ReadinessProbe
 type ContainerProbeConfig =
     { ProbeType : ContainerProbeType
       Probe : ContainerProbe }
@@ -258,7 +258,7 @@ type ContainerInstanceBuilder() =
           Cpu = 1.0
           Memory = 1.5<Gb>
           EnvironmentVariables = Map.empty
-          LivelinessProbe = None
+          LivenessProbe = None
           ReadinessProbe = None
           VolumeMounts = Map.empty }
     /// Sets the name of the container instance.
@@ -302,13 +302,13 @@ type ContainerInstanceBuilder() =
     [<CustomOperation "command_line">]
     member _.CommandLine (state:ContainerInstanceConfig, command) =
         { state with Command = state.Command @ command }
-    /// Set readiness and liveliness probes on the container.
+    /// Set readiness and liveness probes on the container.
     [<CustomOperation "probes">]
     member _.Probes (state:ContainerInstanceConfig, probes:(ContainerProbeConfig) seq) =
         { state with
-            LivelinessProbe =
+            LivenessProbe =
                 probes
-                |> Seq.tryFind(fun p -> p.ProbeType = ContainerProbeType.LivelinessProbe)
+                |> Seq.tryFind(fun p -> p.ProbeType = ContainerProbeType.LivenessProbe)
                 |> Option.map (fun p -> p.Probe)
             ReadinessProbe =
                 probes
@@ -361,8 +361,10 @@ type ProbeBuilder (probeType:ContainerProbeType) =
     member _.TimeoutSeconds (state:(ContainerProbeConfig), delay:int) =
         { state with Probe = { state.Probe with TimeoutSeconds = delay |> Some } }
 
-let liveliness = ProbeBuilder(LivelinessProbe)
+let liveness = ProbeBuilder(LivenessProbe)
 let readiness = ProbeBuilder(ReadinessProbe)
+[<System.Obsolete "Compatibility only due to spelling error - please use 'liveness'">]
+let liveliness = ProbeBuilder(LivenessProbe)
 
 type InitContainerBuilder() =
     member _.Yield _ =

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -305,7 +305,7 @@ let tests = testList "Container Group" [
         Expect.hasLength deployment.Template.Parameters 1 "Should have a secure parameter for secret volume"
         Expect.equal (deployment.Template.Parameters.Head.ArmExpression.Eval()) "[parameters('secret-foo')]" "Generated incorrect secure parameter."
     }
-    test "Container with liveliness and readiness probes" {
+    test "Container with liveness and readiness probes" {
 
         let cg =
             containerGroup {
@@ -315,9 +315,9 @@ let tests = testList "Container Group" [
                         name "nginx"
                         image "nginx:1.17.6-alpine"
                         probes [
-                            liveliness {
+                            liveness {
                                 http "https://whatever.com:8080/healthcheck"
-                                period_seconds 30 // Wait 30 seconds between each liveliness check
+                                period_seconds 30 // Wait 30 seconds between each liveness check
                                 failure_threshold 10 // After 10 tries, consider this unhealthy
                             }
                             readiness {
@@ -329,13 +329,13 @@ let tests = testList "Container Group" [
                     }
                 ]
             } |> asAzureResource
-        let livelinessProbe = cg.Containers.[0].LivenessProbe
-        Expect.isNotNull livelinessProbe "Resulting container should have a liveliness probe"
-        Expect.equal livelinessProbe.HttpGet.Path "/healthcheck" "Incorrect path on liveliness http probe"
-        Expect.equal livelinessProbe.HttpGet.Port 8080 "Incorrect port on liveliness http probe"
-        Expect.equal livelinessProbe.HttpGet.Scheme "https" "Incorrect scheme on liveliness http probe"
-        Expect.equal livelinessProbe.PeriodSeconds.Value 30 "Incorrect period on liveliness probe"
-        Expect.equal livelinessProbe.FailureThreshold.Value 10 "Incorrect failure threshold on liveliness probe"
+        let livenessProbe = cg.Containers.[0].LivenessProbe
+        Expect.isNotNull livenessProbe "Resulting container should have a liveness probe"
+        Expect.equal livenessProbe.HttpGet.Path "/healthcheck" "Incorrect path on liveness http probe"
+        Expect.equal livenessProbe.HttpGet.Port 8080 "Incorrect port on liveness http probe"
+        Expect.equal livenessProbe.HttpGet.Scheme "https" "Incorrect scheme on liveness http probe"
+        Expect.equal livenessProbe.PeriodSeconds.Value 30 "Incorrect period on liveness probe"
+        Expect.equal livenessProbe.FailureThreshold.Value 10 "Incorrect failure threshold on liveness probe"
         let readinessProbe = cg.Containers.[0].ReadinessProbe
         Expect.isNotNull readinessProbe "Resulting container should have a readiness probe"
         Expect.equal readinessProbe.HttpGet.Path "/healthcheck" "Incorrect path on readiness http probe"


### PR DESCRIPTION
The changes in this PR are as follows:

* Adds 'depends_on' support to container groups
* Correct spelling error for container instance 'liveness' probe
* Documentation cleanup for container groups - separate builder sections

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.