### PR TITLE
Enable VaultUri as output parameter for Key Vault.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.6.6
 * KeyVault: Enable VaultUri configuration member for use as output parameter.
+* KeyVault: Fix emitted `enablePurgeProtection`.
 
 ## 1.6.5
 * Azure Firewall: Bug fix for link_to_vhub and added depends_on to builder

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.6
+* KeyVault: Enable VaultUri configuration member for use as output parameter.
+
 ## 1.6.5
 * Azure Firewall: Bug fix for link_to_vhub and added depends_on to builder
 * Functions: Add support for keyvault reference user identity

--- a/docs/content/api-overview/resources/keyvault.md
+++ b/docs/content/api-overview/resources/keyvault.md
@@ -74,6 +74,12 @@ The Key Vault builder contains access policies, secrets, and configuration infor
 | add_tag | Adds a tag to the key vault. |
 | add_tags | Adds multiple tags to the key vault. |
 
+#### Configuration Members
+
+| Member | Purpose |
+|-|-|
+| VaultUri | Gets the ARM expression path to the key vault's URI. |
+
 #### Utilities
 * The KeyVault module comes with a set of utility functions to quickly create access policies if you do not wish to use the `AccessPolicy` builder, in the `Farmer.KeyVault.AccessPolicy` module which enable creating an access policy for a `PrincipalId` or an `ObjectId` which will have the GET Secret permission.
 * In addition, the `AccessPolicy` module also contains helpers to search for users or groups in active directory (*requires Azure CLI installed*), as well as their Object IDs. These can be used to rapidly create Access Policies for specific users.
@@ -125,4 +131,10 @@ let vault =
         add_secret "simpleSecret"
         add_secrets [ "firstSecret"; "secondSecret"]
     }
+
+arm {
+    add_resource vault
+    output "vault-uri" vault.VaultUri
+}
+
 ```

--- a/samples/scripts/keyvault.fsx
+++ b/samples/scripts/keyvault.fsx
@@ -1,4 +1,4 @@
-#r "../../src/Farmer/bin/Debug/net5.0/Farmer.dll"
+#r "nuget:Farmer"
 
 open Farmer
 open Farmer.Builders
@@ -57,9 +57,10 @@ let vault =
 vault.Policies
 
 let deployment = arm {
-    add_resource vault
     location Location.NorthEurope
+    add_resource vault
+    output "vault_uri" vault.VaultUri
 }
 
 deployment
-|> Writer.quickWrite "output"
+|> Writer.quickWrite (System.IO.Path.GetFileNameWithoutExtension __SOURCE_FILE__)

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -99,7 +99,7 @@ type Vault =
                         | Some SoftDeletionOnly ->
                             Nullable true
                        createMode = this.CreateMode |> Option.map(fun m -> m.ToString().ToLower()) |> Option.toObj
-                       enablePurgeProtection = this.PurgeProtection
+                       enablePurgeProtection = this.PurgeProtection |> Option.toNullable
                        vaultUri = this.Uri |> Option.map string |> Option.toObj
                        accessPolicies = [|
                         for policy in this.AccessPolicies do

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -95,6 +95,13 @@ type KeyVaultConfig =
       Uri : Uri option
       Secrets : SecretConfig list
       Tags: Map<string,string>  }
+
+      /// References the Key Vault URI after deployment.
+      member this.VaultUri =
+        let kvUriId = ResourceId.create(vaults, this.Name)
+        $"reference({kvUriId.ArmExpression.Value}).vaultUri"
+        |> ArmExpression.create
+
       interface IBuilder with
         member this.ResourceId = vaults.resourceId this.Name
         member this.BuildResources location = [

--- a/src/Tests/KeyVault.fs
+++ b/src/Tests/KeyVault.fs
@@ -112,7 +112,7 @@ let tests = testList "KeyVault" [
         let enableRbac = jobj.SelectToken("resources[0].properties.enableRbacAuthorization")
         Expect.isTrue (enableRbac.Value<bool>()) "RBAC was not enabled on the key vault"
     }
-    ftest "Get Vault URI from output" {
+    test "Get Vault URI from output" {
         let kv = keyVault {
             name "my-test-kv-9876"
         }
@@ -126,5 +126,20 @@ let tests = testList "KeyVault" [
         let jobj = JObject.Parse(json)
         let kvUri = jobj.SelectToken("outputs.kv-uri.value")
         Expect.equal (string kvUri) "[reference(resourceId('Microsoft.KeyVault/vaults', 'my-test-kv-9876')).vaultUri]" "Vault URI not set properly in output"
+    }
+    test "Key Vault with purge protection emits correct value" {
+        let kv = keyVault {
+            name "my-test-kv-9876"
+            enable_soft_delete_with_purge_protection
+        }
+        let json =
+            let template = 
+                arm {
+                    add_resource kv
+                }
+            template.Template |> Writer.toJson
+        let jobj = JObject.Parse(json)
+        let purgeProtection = jobj.SelectToken("resources[0].properties.enablePurgeProtection")
+        Expect.equal (purgeProtection |> string |> Boolean.Parse) true "Purge protection not enabled"
     }
 ]

--- a/src/Tests/KeyVault.fs
+++ b/src/Tests/KeyVault.fs
@@ -83,7 +83,7 @@ let tests = testList "KeyVault" [
         let kvName = jobj.SelectToken("resources[0].name")
         Expect.equal kvName (JValue.CreateString "my-test-kv-9876abcd" :> JToken) "Incorrect name set on key vault"
     }
-    
+
     test "Create a key vault with RBAC enabled" {
         let kv = keyVault {
             name "my-test-kv-9876rbac"
@@ -111,5 +111,20 @@ let tests = testList "KeyVault" [
         let jobj = JObject.Parse(json)
         let enableRbac = jobj.SelectToken("resources[0].properties.enableRbacAuthorization")
         Expect.isTrue (enableRbac.Value<bool>()) "RBAC was not enabled on the key vault"
+    }
+    ftest "Get Vault URI from output" {
+        let kv = keyVault {
+            name "my-test-kv-9876"
+        }
+        let json =
+            let template = 
+                arm {
+                    add_resource kv
+                    output "kv-uri" kv.VaultUri
+                }
+            template.Template |> Writer.toJson
+        let jobj = JObject.Parse(json)
+        let kvUri = jobj.SelectToken("outputs.kv-uri.value")
+        Expect.equal (string kvUri) "[reference(resourceId('Microsoft.KeyVault/vaults', 'my-test-kv-9876')).vaultUri]" "Vault URI not set properly in output"
     }
 ]


### PR DESCRIPTION
This PR closes #665

The changes in this PR are as follows:

* KeyVault: Enable VaultUri configuration member for use as output parameter.
* KeyVault: Fix emitted `enablePurgeProtection`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.