### PR TITLE
Virtual network NSG and private link policy support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes
 * Functions: Added support for deployment slots
 * KeyVault: Enable VaultUri configuration member for use as output parameter.
 * KeyVault: Fix emitted `enablePurgeProtection`.
+* Virtual Network: Specify the network security group for a subnet.
 * Virtual Network: Subnet support for enabling or disabling Private Link Service Network Policies to allow assigning the IP for a private endpoint connection.
 * WebApp: Added support for deployment slots
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes
 * Functions: Added support for deployment slots
 * KeyVault: Enable VaultUri configuration member for use as output parameter.
 * KeyVault: Fix emitted `enablePurgeProtection`.
+* Virtual Network: Subnet support for enabling or disabling Private Link Service Network Policies to allow assigning the IP for a private endpoint connection.
 * WebApp: Added support for deployment slots
 
 ## 1.6.5

--- a/docs/content/api-overview/resources/vnet.md
+++ b/docs/content/api-overview/resources/vnet.md
@@ -43,7 +43,8 @@ The Virtual Network module contains four builders
 | add_delegations                         | Adds one or more delegations to this subnet.                           |
 | add_service_endpoints                   | Adds one or more service endpoints to this subnet.                     |
 | associate_service_endpoint_policies     | Associates a subnet with an existing service policy.                   |
-| private_endpoints                       | Enable or disable support for private endpoints, default is `Disabled` |
+| allow_private_endpoints                 | Enable or disable support for private endpoints, default is `Disabled` |
+| private_link_service_network_policies   | Enable or disable support for private link service network polices, default is `Disabled` |
 
 ##### Automatically build out an address space: `addressSpace`
 
@@ -62,7 +63,8 @@ The Virtual Network module contains four builders
 | add_delegations                         | Adds service delegations for the subnet.                               |
 | add_service_endpoints                   | Adds service endpoints for the subnet.                                 |
 | add_service_endpoint_policies           | Associates the service endpoint policies with the subnet.              |
-| private_endpoints                       | Enable or disable support for private endpoints, default is `Disabled` |
+| allow_private_endpoints                 | Enable or disable support for private endpoints, default is `Disabled` |
+| private_link_service_network_policies   | Enable or disable support for private link service network polices, default is `Disabled` |
 
 #### Configuration Members
 

--- a/docs/content/api-overview/resources/vnet.md
+++ b/docs/content/api-overview/resources/vnet.md
@@ -40,6 +40,8 @@ The Virtual Network module contains four builders
 | --------------------------------------- | ---------------------------------------------------------------------- |
 | name                                    | Name of the subnet resource                                            |
 | prefix                                  | Subnet prefix in CIDR notation (e.g. 192.168.100.0/24)                 |
+| network_security_group                  | Specify the network security group from the same deployment.           |
+| link_to_network_security_group          | Specify an existing network security group for this subnet.            |
 | add_delegations                         | Adds one or more delegations to this subnet.                           |
 | add_service_endpoints                   | Adds one or more service endpoints to this subnet.                     |
 | associate_service_endpoint_policies     | Associates a subnet with an existing service policy.                   |
@@ -60,6 +62,8 @@ The Virtual Network module contains four builders
 | --------------------------------------- | ---------------------------------------------------------------------- |
 | name                                    | Specifies the name of the subnet to build.                             |
 | size                                    | Specifies the size of the subnet to build, default is /24.             |
+| network_security_group                  | Specify the network security group from the same deployment.           |
+| link_to_network_security_group          | Specify an existing network security group for the subnet.             |
 | add_delegations                         | Adds service delegations for the subnet.                               |
 | add_service_endpoints                   | Adds service endpoints for the subnet.                                 |
 | add_service_endpoint_policies           | Associates the service endpoint policies with the subnet.              |

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -48,7 +48,8 @@ type Subnet =
       Delegations : SubnetDelegation list
       ServiceEndpoints : (Network.EndpointServiceType * Location list) list
       AssociatedServiceEndpointPolicies : ResourceId list 
-      PrivateEndpointNetworkPolicies: FeatureFlag option }
+      PrivateEndpointNetworkPolicies: FeatureFlag option
+      PrivateLinkServiceNetworkPolicies: FeatureFlag option }
 
 type VirtualNetwork =
     { Name : ResourceName
@@ -89,6 +90,7 @@ type VirtualNetwork =
                                            subnet.AssociatedServiceEndpointPolicies
                                            |> List.map (fun policyId -> {| id = policyId.ArmExpression.Eval() |})
                                    privateEndpointNetworkPolicies = subnet.PrivateEndpointNetworkPolicies |> Option.map (fun x->x.ArmValue) |> Option.defaultValue Unchecked.defaultof<_>
+                                   privateLinkServiceNetworkPolicies = subnet.PrivateLinkServiceNetworkPolicies |> Option.map (fun x->x.ArmValue) |> Option.defaultValue Unchecked.defaultof<_>
                                 |}
                             |})
                     |}

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -38,20 +38,20 @@ type SubnetBuilder() =
     member _.Prefix(state:SubnetConfig, prefix) = { state with Prefix = IPAddressCidr.parse prefix }
     /// Sets the network security group for subnet
     [<CustomOperation "network_security_group">]
-    member _.NetworkSecurityGroup(state:SubnetConfig, nsg:string) =
-        { state with NetworkSecurityGroup = Some (Managed (Farmer.Arm.NetworkSecurityGroup.networkSecurityGroups.resourceId (ResourceName nsg))) }
-    member _.NetworkSecurityGroup(state:SubnetConfig, nsg:ResourceName) =
-        { state with NetworkSecurityGroup = Some (Managed (Farmer.Arm.NetworkSecurityGroup.networkSecurityGroups.resourceId nsg)) }
+    member _.NetworkSecurityGroup(state:SubnetConfig, nsg:IArmResource) =
+        { state with NetworkSecurityGroup = Some (Managed nsg.ResourceId) }
     member _.NetworkSecurityGroup(state:SubnetConfig, nsg:ResourceId) =
         { state with NetworkSecurityGroup = Some (Managed nsg) }
+    member _.NetworkSecurityGroup(state:SubnetConfig, nsg:NsgConfig) =
+        { state with NetworkSecurityGroup = Some (Managed (nsg :> IBuilder).ResourceId) }
     /// Links the subnet to an existing network security group.
     [<CustomOperation "link_to_network_security_group">]
-    member _.LinkToNetworkSecurityGroup(state:SubnetConfig, nsg:string) =
-        { state with NetworkSecurityGroup = Some (Unmanaged (Farmer.Arm.NetworkSecurityGroup.networkSecurityGroups.resourceId (ResourceName nsg))) }
-    member _.LinkToNetworkSecurityGroup(state:SubnetConfig, nsg:ResourceName) =
-        { state with NetworkSecurityGroup = Some (Unmanaged (Farmer.Arm.NetworkSecurityGroup.networkSecurityGroups.resourceId nsg)) }
+    member _.LinkToNetworkSecurityGroup(state:SubnetConfig, nsg:IArmResource) =
+        { state with NetworkSecurityGroup = Some (Unmanaged (nsg.ResourceId)) }
     member _.LinkToNetworkSecurityGroup(state:SubnetConfig, nsg:ResourceId) =
         { state with NetworkSecurityGroup = Some (Unmanaged nsg) }
+    member _.LinkToNetworkSecurityGroup(state:SubnetConfig, nsg:NsgConfig) =
+        { state with NetworkSecurityGroup = Some (Unmanaged (nsg :> IBuilder).ResourceId) }
     /// Sets the network prefix in CIDR notation
     [<CustomOperation "add_delegations">]
     member _.AddDelegations(state:SubnetConfig, delegations) = { state with Delegations = state.Delegations @ delegations }
@@ -130,20 +130,20 @@ type SubnetSpecBuilder () =
         { state with Size = size }
     /// Sets the network security group for subnet
     [<CustomOperation "network_security_group">]
-    member _.NetworkSecurityGroup(state:SubnetBuildSpec, nsg:string) =
-        { state with NetworkSecurityGroup = Some (Managed (Farmer.Arm.NetworkSecurityGroup.networkSecurityGroups.resourceId (ResourceName nsg))) }
-    member _.NetworkSecurityGroup(state:SubnetBuildSpec, nsg:ResourceName) =
-        { state with NetworkSecurityGroup = Some (Managed (Farmer.Arm.NetworkSecurityGroup.networkSecurityGroups.resourceId nsg)) }
+    member _.NetworkSecurityGroup(state:SubnetBuildSpec, nsg:IArmResource) =
+        { state with NetworkSecurityGroup = Some (Managed (nsg.ResourceId)) }
     member _.NetworkSecurityGroup(state:SubnetBuildSpec, nsg:ResourceId) =
         { state with NetworkSecurityGroup = Some (Managed nsg) }
+    member _.NetworkSecurityGroup(state:SubnetBuildSpec, nsg:NsgConfig) =
+        { state with NetworkSecurityGroup = Some (Managed (nsg :> IBuilder).ResourceId) }
     /// Links the subnet to an existing network security group.
     [<CustomOperation "link_to_network_security_group">]
-    member _.LinkToNetworkSecurityGroup(state:SubnetBuildSpec, nsg:string) =
-        { state with NetworkSecurityGroup = Some (Unmanaged (Farmer.Arm.NetworkSecurityGroup.networkSecurityGroups.resourceId (ResourceName nsg))) }
-    member _.LinkToNetworkSecurityGroup(state:SubnetBuildSpec, nsg:ResourceName) =
-        { state with NetworkSecurityGroup = Some (Unmanaged (Farmer.Arm.NetworkSecurityGroup.networkSecurityGroups.resourceId nsg)) }
+    member _.LinkToNetworkSecurityGroup(state:SubnetBuildSpec, nsg:IArmResource) =
+        { state with NetworkSecurityGroup = Some (Unmanaged (nsg.ResourceId)) }
     member _.LinkToNetworkSecurityGroup(state:SubnetBuildSpec, nsg:ResourceId) =
         { state with NetworkSecurityGroup = Some (Unmanaged nsg) }
+    member _.LinkToNetworkSecurityGroup(state:SubnetBuildSpec, nsg:NsgConfig) =
+        { state with NetworkSecurityGroup = Some (Unmanaged (nsg :> IBuilder).ResourceId) }
     /// Adds any services to delegate this subnet
     [<CustomOperation "add_delegations">]
     member _.AddDelegations(state:SubnetBuildSpec, delegations) =

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -106,6 +106,7 @@ type VmConfig =
                   Subnets = [
                       { Name = subnetName.Name
                         Prefix = this.SubnetPrefix
+                        NetworkSecurityGroup = None
                         Delegations = []
                         ServiceEndpoints = []
                         AssociatedServiceEndpointPolicies = []

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -109,7 +109,8 @@ type VmConfig =
                         Delegations = []
                         ServiceEndpoints = []
                         AssociatedServiceEndpointPolicies = []
-                        PrivateEndpointNetworkPolicies = None }
+                        PrivateEndpointNetworkPolicies = None
+                        PrivateLinkServiceNetworkPolicies = None }
                   ]
                   Tags = this.Tags
                 }

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -111,6 +111,7 @@
     <Compile Include="Builders/Builders.Redis.fs" />
     <Compile Include="Builders/Builders.KeyVault.fs" />
     <Compile Include="Builders/Builders.Bastion.fs" />
+    <Compile Include="Builders\Builders.NetworkSecurityGroup.fs" />
     <Compile Include="Builders/Builders.VirtualNetwork.fs" />
     <Compile Include="Builders\Builders.LoadBalancer.fs" />
     <Compile Include="Builders/Builders.Vm.fs" />
@@ -134,7 +135,6 @@
     <Compile Include="Builders/Builders.VirtualNetworkGateway.fs" />
     <Compile Include="Builders/Builders.EventGrid.fs" />
     <Compile Include="Builders/Builders.StaticWebApp.fs" />
-    <Compile Include="Builders/Builders.NetworkSecurityGroup.fs" />
     <Compile Include="Builders/Builders.Databricks.fs" />
     <Compile Include="Builders/Builders.DiagnosticSetting.fs" />
     <Compile Include="Builders/Builders.VirtualWan.fs" />

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -242,12 +242,12 @@ let tests = testList "Network Tests" [
                         subnetSpec {
                             name webSubnet
                             size 24
-                            network_security_group myNsg.Name
+                            network_security_group myNsg
                         }
                         subnetSpec {
                             name appsSubnet
                             size 24
-                            network_security_group myNsg.Name
+                            network_security_group myNsg
                         }
                         subnetSpec {
                             name noNsgSubnet
@@ -283,7 +283,7 @@ let tests = testList "Network Tests" [
                         subnetSpec {
                             name webSubnet
                             size 24
-                            link_to_network_security_group "my-nsg"
+                            link_to_network_security_group (networkSecurityGroups.resourceId "my-nsg")
                         }
                     ]
                 }

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -124,6 +124,7 @@ let tests = testList "Network Tests" [
                     name servicesSubnet
                     prefix "10.28.0.0/24"
                     allow_private_endpoints Enabled
+                    private_link_service_network_policies Disabled
                 }
             ]
         }
@@ -131,6 +132,7 @@ let tests = testList "Network Tests" [
         Expect.hasLength builtVnet.AddressSpace.AddressPrefixes 1 "Incorrect number of address spaces"
         Expect.hasLength builtVnet.Subnets 1 "Incorrect number of subnets"
         Expect.equal builtVnet.Subnets.[0].PrivateEndpointNetworkPolicies "Disabled" "Incorrect PrivateEndpointNetworkPolicies"
+        Expect.equal builtVnet.Subnets.[0].PrivateLinkServiceNetworkPolicies "Disabled" "PrivateLinkServiceNetworkPolicies should be enabled"
     }
     test "Automatically carved subnets with private endpoint support" {
         let vnetName = "my-vnet"
@@ -146,6 +148,7 @@ let tests = testList "Network Tests" [
                             name servicesSubnet
                             size 24
                             allow_private_endpoints Enabled
+                            private_link_service_network_policies Disabled
                         }
                     ]
                 }
@@ -155,6 +158,7 @@ let tests = testList "Network Tests" [
         Expect.equal generatedVNet.Subnets.[0].Name servicesSubnet "Incorrect name for services subnet"
         Expect.equal generatedVNet.Subnets.[0].AddressPrefix "10.28.0.0/24" "Incorrect prefix for services subnet"
         Expect.equal generatedVNet.Subnets.[0].PrivateEndpointNetworkPolicies "Disabled" "Incorrect PrivateEndpointNetworkPolicies"
+        Expect.equal generatedVNet.Subnets.[0].PrivateLinkServiceNetworkPolicies "Disabled" "Incorrect PrivateEndpointNetworkPolicies"
     }
     test "Two VNets with bidirectional peering" {
         let vnet1 = vnet { name "vnet1" }

--- a/src/Tests/test-data/load-balancer.json
+++ b/src/Tests/test-data/load-balancer.json
@@ -6,6 +6,7 @@
   "resources": [
     {
       "apiVersion": "2020-07-01",
+      "dependsOn": [],
       "location": "northeurope",
       "name": "my-vnet",
       "properties": {

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -718,6 +718,7 @@
             },
             {
               "apiVersion": "2020-07-01",
+              "dependsOn": [],
               "location": "uksouth",
               "name": "farmervm-vnet",
               "properties": {

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -107,6 +107,7 @@
     },
     {
       "apiVersion": "2020-07-01",
+      "dependsOn": [],
       "location": "northeurope",
       "name": "isaacsVM-vnet",
       "properties": {


### PR DESCRIPTION
The changes in this PR are as follows:

* Virtual Network: Specify the network security group for a subnet.
* Virtual Network: Subnet support for enabling or disabling Private Link Service Network Policies to allow assigning the IP for a private endpoint connection.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.