### PR TITLE
Azure Firewall support for link_to_policy linking to builder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 
 ## 1.6.6
+* Azure Firewall: Support for 'link_to_firewall_policy' to link to a builder as well as a resource.
 * Container Groups: Support for 'depends_on' to add dependencies.
 * Functions: Added support for deployment slots
 * KeyVault: Enable VaultUri configuration member for use as output parameter.

--- a/src/Farmer/Builders/Builders.AzureFirewall.fs
+++ b/src/Farmer/Builders/Builders.AzureFirewall.fs
@@ -65,6 +65,8 @@ type AzureFirewallBuilder() =
     [<CustomOperation "link_to_firewall_policy">]
     member this.LinkToFirewallPolicy (state:AzureFirewallConfig, firewallPolicy:IArmResource) =
         { state with FirewallPolicy = Some (Managed firewallPolicy.ResourceId) }
+    member this.LinkToFirewallPolicy (state:AzureFirewallConfig, firewallPolicy:IBuilder) =
+        { state with FirewallPolicy = Some (Managed firewallPolicy.ResourceId) }
     /// The unmanaged virtualHub to which the firewall belongs. 
     [<CustomOperation "link_to_unmanaged_vhub">]
     member this.LinkToUnmanagedVirtualHub (state:AzureFirewallConfig, resourceId) =

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -15,6 +15,7 @@ let allTests =
                 AppInsights.tests
                 if notEnv "BUILD_REASON" "PullRequest" then
                     AzCli.tests
+                AzureFirewall.tests
                 Bastion.tests
                 BingSearch.tests
                 Cdn.tests

--- a/src/Tests/AzureFirewall.fs
+++ b/src/Tests/AzureFirewall.fs
@@ -1,0 +1,35 @@
+module AzureFirewall
+
+open System
+open Expecto
+open Farmer
+open Farmer.Arm.AzureFirewall
+open Farmer.Builders
+
+let tests = testList "Azure Firewall" [
+    test "Link to builder" {
+        let existingFwPolicy =
+            { new IBuilder with
+                member _.ResourceId = azureFirewallPolicies.resourceId "existing-firewall-policy"
+                member _.BuildResources _ = []
+            }
+        let vwan = vwan {
+            name "my-vwan"
+            standard_vwan
+        }
+        let vhub = vhub {
+            name "my-vhub"
+            address_prefix (IPAddressCidr.parse "100.73.255.0/24")
+            link_to_vwan vwan
+        }
+        let fw = azureFirewall {
+            name "azfw"
+            sku AzureFirewall.SkuName.AZFW_Hub AzureFirewall.SkuTier.Standard
+            public_ip_reservation_count 2
+            link_to_vhub vhub
+            link_to_firewall_policy existingFwPolicy
+        }
+        Expect.equal fw.FirewallPolicy.Value.ResourceId (azureFirewallPolicies.resourceId "existing-firewall-policy") "Expected to be linked to existing FW policy"
+        Expect.isEmpty fw.Dependencies "Expected not to depend on any resources since it links to an existing policy"
+    }
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -10,6 +10,7 @@
     <Content Include="test-data\*.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="Helpers.fs" />
     <Compile Include="AppInsights.fs" />
+    <Compile Include="AzureFirewall.fs" />
     <Compile Include="DiagnosticSettings.fs" />
     <Compile Include="Common.fs" />
     <Compile Include="Functions.fs" />


### PR DESCRIPTION
The changes in this PR are as follows:

* Azure Firewall: Support for 'link_to_firewall_policy' to link to a builder as well as a resource.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
