### PR TITLE
DNS zone and record 'depends_on' support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ Release Notes
 ## 1.6.7
 * Container Groups: Reference Azure container registry credentials.
 * DNS Zone: Support for adding records to existing zones.
+* DNS Zone: zone and record 'depends_on' support.
 
 ## 1.6.6
 * Azure Firewall: Support for 'link_to_firewall_policy' to link to a builder as well as a resource.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ Release Notes
 * Container Groups: Reference Azure container registry credentials.
 * DNS Zone: Support for adding records to existing zones.
 * DNS Zone: zone and record 'depends_on' support.
+* DNS Zone: DNS record 'target_resource' fix to emit correct resource Id.
 
 ## 1.6.6
 * Azure Firewall: Support for 'link_to_firewall_policy' to link to a builder as well as a resource.

--- a/docs/content/api-overview/resources/dns.md
+++ b/docs/content/api-overview/resources/dns.md
@@ -45,6 +45,7 @@ The following items are currently unsupported:
 | Keyword | Purpose |
 |-|-|
 | name | Sets the name of the domain. |
+| depends_on | Deploy this DNS zone after another resource is successfully deployed. |
 | zone_type | Sets the zone type. |
 | add_records | Adds DNS Zone records (see below). |
 
@@ -53,6 +54,7 @@ Each Record type has its own custom builder. All builders share the following co
 | Keyword | Purpose |
 |-|-|
 | name | Sets the name of the record set (default to `@`). |
+| depends_on | Deploy this DNS record after another resource is successfully deployed. |
 | ttl | Sets the time-to-live of the record set. |
 | link_to_dns_zone | Add the record to a DNS zone in the same deployment. |
 | link_to_unmanaged_dns_zone | Add the record to an existing DNS zone. |

--- a/docs/content/api-overview/resources/dns.md
+++ b/docs/content/api-overview/resources/dns.md
@@ -54,6 +54,7 @@ Each Record type has its own custom builder. All builders share the following co
 |-|-|
 | name | Sets the name of the record set (default to `@`). |
 | ttl | Sets the time-to-live of the record set. |
+| link_to_dns_zone | Add the record to a DNS zone in the same deployment. |
 | link_to_unmanaged_dns_zone | Add the record to an existing DNS zone. |
 
 In addition, each record builder has its own custom keywords:

--- a/src/Farmer/Arm/Dns.fs
+++ b/src/Farmer/Arm/Dns.fs
@@ -30,12 +30,13 @@ type DnsRecordType with
 
 type DnsZone =
     { Name : ResourceName
+      Dependencies : Set<ResourceId>
       Properties : {| ZoneType : string |} }
 
     interface IArmResource with
         member this.ResourceId = zones.resourceId this.Name
         member this.JsonModel =
-            {| zones.Create(this.Name, Location.Global) with
+            {| zones.Create(this.Name, Location.Global, this.Dependencies) with
                 properties = {| zoneType = this.Properties.ZoneType |}
             |} :> _
 

--- a/src/Farmer/Arm/Dns.fs
+++ b/src/Farmer/Arm/Dns.fs
@@ -64,7 +64,7 @@ module DnsRecords =
                         | A (Some targetResource, _)
                         | CName (Some targetResource, _)
                         | AAAA (Some targetResource, _)  ->
-                            "targetResource", box {| id = targetResource.Value |}
+                            "targetResource", box {| id = targetResource.ArmExpression.Eval() |}
                         | _ ->
                             ()
 

--- a/src/Farmer/Arm/Dns.fs
+++ b/src/Farmer/Arm/Dns.fs
@@ -53,7 +53,7 @@ module DnsRecords =
             | Managed id -> this.Dependencies |> Set.add id
             | Unmanaged _ -> this.Dependencies
         interface IArmResource with
-            member this.ResourceId = this.Type.ResourceType.resourceId (this.Zone.Name/this.Name)
+            member this.ResourceId = this.Type.ResourceType.resourceId (this.Zone.Name, this.Name)
 
             member this.JsonModel =
                 {| this.Type.ResourceType.Create(this.Zone.Name/this.Name, dependsOn = this.dependsOn) with

--- a/src/Farmer/Builders/Builders.Dns.fs
+++ b/src/Farmer/Builders/Builders.Dns.fs
@@ -44,15 +44,16 @@ type DnsZoneRecordConfig =
             | None -> failwith "DNS record must be linked to a zone."
 
 type CNameRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; CName : string option; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceName option }
-type ARecordProperties =  { Name: ResourceName; Ipv4Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceName option  }
-type AaaaRecordProperties =  { Name: ResourceName; Ipv6Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceName option }
-type NsRecordProperties =  { Name: ResourceName; NsdNames : string list; TTL: int option; Zone: LinkedResource option }
-type PtrRecordProperties =  { Name: ResourceName; PtrdNames : string list; TTL: int option; Zone: LinkedResource option; }
-type TxtRecordProperties =  { Name: ResourceName; TxtValues : string list; TTL: int option; Zone: LinkedResource option; }
-type MxRecordProperties =  { Name: ResourceName; MxValues : {| Preference : int; Exchange : string |} list; TTL: int option; Zone: LinkedResource option; }
-type SrvRecordProperties =  { Name: ResourceName; SrvValues : SrvRecord list; TTL: int option; Zone: LinkedResource option; }
+type ARecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv4Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceName option  }
+type AaaaRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv6Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceName option }
+type NsRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; NsdNames : string list; TTL: int option; Zone: LinkedResource option }
+type PtrRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; PtrdNames : string list; TTL: int option; Zone: LinkedResource option; }
+type TxtRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; TxtValues : string list; TTL: int option; Zone: LinkedResource option; }
+type MxRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; MxValues : {| Preference : int; Exchange : string |} list; TTL: int option; Zone: LinkedResource option; }
+type SrvRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; SrvValues : SrvRecord list; TTL: int option; Zone: LinkedResource option; }
 type SoaRecordProperties =
     { Name: ResourceName
+      Dependencies: Set<ResourceId>
       Host : string option
       Email : string option
       SerialNumber : int64 option
@@ -93,12 +94,13 @@ type DnsCNameRecordBuilder() =
     member _.LinkToDnsZone(state:CNameRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
     member _.LinkToDnsZone(state:CNameRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
     member _.LinkToDnsZone(state:CNameRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
     /// Enable support for additional dependencies.
     interface IDependable<CNameRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     
 type DnsARecordBuilder() =
-    member _.Yield _ = { ARecordProperties.Ipv4Addresses = []; Name = ResourceName "@"; TTL = None; Zone = None; TargetResource = None }
-    member _.Run(state : ARecordProperties)  = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, A(state.TargetResource, state.Ipv4Addresses))
+    member _.Yield _ = { ARecordProperties.Ipv4Addresses = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None; TargetResource = None }
+    member _.Run(state : ARecordProperties)  = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, A(state.TargetResource, state.Ipv4Addresses), state.Dependencies)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -119,11 +121,20 @@ type DnsARecordBuilder() =
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
-    member _.LinkToDnsZone(state:ARecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+    member _.LinkToUnmanagedDnsZone(state:ARecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+
+    /// Builds a record for an existing DNS zone that is managed by this Farmer deployment.
+    [<CustomOperation "link_to_dns_zone">]
+    member _.LinkToDnsZone(state:ARecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
+    member _.LinkToDnsZone(state:ARecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
+    member _.LinkToDnsZone(state:ARecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<ARecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsAaaaRecordBuilder() =
-    member _.Yield _ = { AaaaRecordProperties.Ipv6Addresses = []; Name = ResourceName "@"; TTL = None; Zone = None; TargetResource = None }
-    member _.Run(state : AaaaRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, AAAA(state.TargetResource, state.Ipv6Addresses))
+    member _.Yield _ = { AaaaRecordProperties.Ipv6Addresses = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None; TargetResource = None }
+    member _.Run(state : AaaaRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, AAAA(state.TargetResource, state.Ipv6Addresses), state.Dependencies)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -144,11 +155,20 @@ type DnsAaaaRecordBuilder() =
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
-    member _.LinkToDnsZone(state:AaaaRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+    member _.LinkToUnmanagedDnsZone(state:AaaaRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+
+    /// Builds a record for an existing DNS zone that is managed by this Farmer deployment.
+    [<CustomOperation "link_to_dns_zone">]
+    member _.LinkToDnsZone(state:AaaaRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
+    member _.LinkToDnsZone(state:AaaaRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
+    member _.LinkToDnsZone(state:AaaaRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<AaaaRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsNsRecordBuilder() =
-    member _.Yield _ = { NsRecordProperties.NsdNames = []; Name = ResourceName "@"; TTL = None; Zone = None }
-    member _.Run(state : NsRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, NS state.NsdNames)
+    member _.Yield _ = { NsRecordProperties.NsdNames = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None }
+    member _.Run(state : NsRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, NS state.NsdNames, state.Dependencies)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -165,11 +185,20 @@ type DnsNsRecordBuilder() =
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
-    member _.LinkToDnsZone(state:NsRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+    member _.LinkToUnmanagedDnsZone(state:NsRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+
+    /// Builds a record for an existing DNS zone that is managed by this Farmer deployment.
+    [<CustomOperation "link_to_dns_zone">]
+    member _.LinkToDnsZone(state:NsRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
+    member _.LinkToDnsZone(state:NsRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
+    member _.LinkToDnsZone(state:NsRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<NsRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsPtrRecordBuilder() =
-    member __.Yield _ = { PtrRecordProperties.PtrdNames = []; Name = ResourceName "@"; TTL = None; Zone = None }
-    member __.Run(state : PtrRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, PTR state.PtrdNames)
+    member __.Yield _ = { PtrRecordProperties.PtrdNames = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None }
+    member __.Run(state : PtrRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, PTR state.PtrdNames, state.Dependencies)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -186,11 +215,20 @@ type DnsPtrRecordBuilder() =
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
-    member _.LinkToDnsZone(state:PtrRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+    member _.LinkToUnmanagedDnsZone(state:PtrRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+
+    /// Builds a record for an existing DNS zone that is managed by this Farmer deployment.
+    [<CustomOperation "link_to_dns_zone">]
+    member _.LinkToDnsZone(state:PtrRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
+    member _.LinkToDnsZone(state:PtrRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
+    member _.LinkToDnsZone(state:PtrRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<PtrRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsTxtRecordBuilder() =
-    member _.Yield _ = { TxtRecordProperties.Name = ResourceName "@"; TxtValues = []; TTL = None; Zone = None; }
-    member _.Run(state : TxtRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, TXT state.TxtValues)
+    member _.Yield _ = { TxtRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; TxtValues = []; TTL = None; Zone = None; }
+    member _.Run(state : TxtRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, TXT state.TxtValues, state.Dependencies)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -207,11 +245,20 @@ type DnsTxtRecordBuilder() =
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
-    member _.LinkToDnsZone(state:TxtRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+    member _.LinkToUnmanagedDnsZone(state:TxtRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+
+    /// Builds a record for an existing DNS zone that is managed by this Farmer deployment.
+    [<CustomOperation "link_to_dns_zone">]
+    member _.LinkToDnsZone(state:TxtRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
+    member _.LinkToDnsZone(state:TxtRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
+    member _.LinkToDnsZone(state:TxtRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<TxtRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsMxRecordBuilder() =
-    member _.Yield _ = { MxRecordProperties.Name = ResourceName "@"; MxValues = []; TTL = None; Zone = None }
-    member _.Run(state : MxRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, MX state.MxValues)
+    member _.Yield _ = { MxRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; MxValues = []; TTL = None; Zone = None }
+    member _.Run(state : MxRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, MX state.MxValues, state.Dependencies)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -230,11 +277,20 @@ type DnsMxRecordBuilder() =
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
-    member _.LinkToDnsZone(state:MxRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+    member _.LinkToUnmanagedDnsZone(state:MxRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+
+    /// Builds a record for an existing DNS zone that is managed by this Farmer deployment.
+    [<CustomOperation "link_to_dns_zone">]
+    member _.LinkToDnsZone(state:MxRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
+    member _.LinkToDnsZone(state:MxRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
+    member _.LinkToDnsZone(state:MxRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<MxRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsSrvRecordBuilder() =
-    member _.Yield _ = { SrvRecordProperties.Name = ResourceName "@"; SrvValues = []; TTL = None; Zone = None; }
-    member _.Run(state : SrvRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, SRV state.SrvValues)
+    member _.Yield _ = { SrvRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; SrvValues = []; TTL = None; Zone = None; }
+    member _.Run(state : SrvRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, SRV state.SrvValues, state.Dependencies)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -252,11 +308,21 @@ type DnsSrvRecordBuilder() =
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
-    member _.LinkToDnsZone(state:SrvRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+    member _.LinkToUnmanagedDnsZone(state:SrvRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+
+    /// Builds a record for an existing DNS zone that is managed by this Farmer deployment.
+    [<CustomOperation "link_to_dns_zone">]
+    member _.LinkToDnsZone(state:SrvRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
+    member _.LinkToDnsZone(state:SrvRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
+    member _.LinkToDnsZone(state:SrvRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<SrvRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsSoaRecordBuilder() =
     member _.Yield _ =
         { SoaRecordProperties.Name = ResourceName "@"
+          Dependencies = Set.empty
           Host = None
           Email = None
           SerialNumber = None
@@ -276,7 +342,7 @@ type DnsSoaRecordBuilder() =
               RetryTime = state.RetryTime
               ExpireTime = state.ExpireTime
               MinimumTTL = state.MinimumTTL }
-        DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, SOA value)
+        DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, SOA value, state.Dependencies)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -321,7 +387,16 @@ type DnsSoaRecordBuilder() =
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
-    member _.LinkToDnsZone(state:NsRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+    member _.LinkToUnmanagedDnsZone(state:SoaRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
+
+    /// Builds a record for an existing DNS zone that is managed by this Farmer deployment.
+    [<CustomOperation "link_to_dns_zone">]
+    member _.LinkToDnsZone(state:SoaRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
+    member _.LinkToDnsZone(state:SoaRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
+    member _.LinkToDnsZone(state:SoaRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<SoaRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsZoneConfig =
     { Name : ResourceName

--- a/src/Farmer/Builders/Builders.Dns.fs
+++ b/src/Farmer/Builders/Builders.Dns.fs
@@ -43,9 +43,9 @@ type DnsZoneRecordConfig =
                 ]
             | None -> failwith "DNS record must be linked to a zone."
 
-type CNameRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; CName : string option; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceName option }
-type ARecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv4Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceName option  }
-type AaaaRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv6Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceName option }
+type CNameRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; CName : string option; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option }
+type ARecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv4Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option  }
+type AaaaRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv6Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option }
 type NsRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; NsdNames : string list; TTL: int option; Zone: LinkedResource option }
 type PtrRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; PtrdNames : string list; TTL: int option; Zone: LinkedResource option; }
 type TxtRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; TxtValues : string list; TTL: int option; Zone: LinkedResource option; }
@@ -83,7 +83,9 @@ type DnsCNameRecordBuilder() =
 
     /// Sets the target resource of the record.
     [<CustomOperation "target_resource">]
-    member _.RecordTargetResource(state:CNameRecordProperties, targetResource) = { state with TargetResource = Some targetResource }
+    member _.RecordTargetResource(state:CNameRecordProperties, targetResource:ResourceId) = { state with TargetResource = Some targetResource }
+    member _.RecordTargetResource(state:CNameRecordProperties, targetResource:IArmResource) = { state with TargetResource = Some targetResource.ResourceId }
+    member _.RecordTargetResource(state:CNameRecordProperties, targetResource:IBuilder) = { state with TargetResource = Some targetResource.ResourceId }
 
     /// Builds a record for an existing DNS zone that is not managed by this Farmer deployment.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
@@ -117,7 +119,9 @@ type DnsARecordBuilder() =
 
     /// Sets the target resource of the record.
     [<CustomOperation "target_resource">]
-    member _.RecordTargetResource(state:ARecordProperties, targetResource) = { state with TargetResource = Some targetResource }
+    member _.RecordTargetResource(state:ARecordProperties, targetResource:ResourceId) = { state with TargetResource = Some targetResource }
+    member _.RecordTargetResource(state:ARecordProperties, targetResource:IArmResource) = { state with TargetResource = Some targetResource.ResourceId }
+    member _.RecordTargetResource(state:ARecordProperties, targetResource:IBuilder) = { state with TargetResource = Some targetResource.ResourceId }
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
@@ -151,7 +155,9 @@ type DnsAaaaRecordBuilder() =
 
     /// Sets the target resource of the record.
     [<CustomOperation "target_resource">]
-    member _.RecordTargetResource(state:AaaaRecordProperties, targetResource) = { state with TargetResource = Some targetResource }
+    member _.RecordTargetResource(state:AaaaRecordProperties, targetResource:ResourceId) = { state with TargetResource = Some targetResource }
+    member _.RecordTargetResource(state:AaaaRecordProperties, targetResource:IArmResource) = { state with TargetResource = Some targetResource.ResourceId }
+    member _.RecordTargetResource(state:AaaaRecordProperties, targetResource:IBuilder) = { state with TargetResource = Some targetResource.ResourceId }
 
     /// Builds a record for an existing DNS zone.
     [<CustomOperation "link_to_unmanaged_dns_zone">]

--- a/src/Farmer/Builders/Builders.Dns.fs
+++ b/src/Farmer/Builders/Builders.Dns.fs
@@ -29,7 +29,7 @@ type DnsZoneRecordConfig =
         member this.ResourceId =
             match this.Zone with
             | Some zone ->
-                this.Type.ResourceType.resourceId (zone.Name/this.Name)
+                this.Type.ResourceType.resourceId (zone.Name, this.Name)
             | None -> failwith "DNS record must be linked to a zone to properly assign the resourceId."
         member this.BuildResources _ =
             match this.Zone with

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1599,9 +1599,9 @@ module Dns =
           MinimumTTL : int64 option }
 
     type DnsRecordType =
-        | A of TargetResource : ResourceName option * ARecords : string list
-        | AAAA of TargetResource : ResourceName option * AaaaRecords : string list
-        | CName of TargetResource : ResourceName option * CNameRecord : string option
+        | A of TargetResource : ResourceId option * ARecords : string list
+        | AAAA of TargetResource : ResourceId option * AaaaRecords : string list
+        | CName of TargetResource : ResourceId option * CNameRecord : string option
         | NS of NsRecords : string list
         | PTR of PtrRecords : string list
         | TXT of TxtRecords : string list

--- a/src/Tests/Dns.fs
+++ b/src/Tests/Dns.fs
@@ -126,8 +126,8 @@ let tests = testList "DNS Zone" [
             { ResourceId.Type = ResourceType ("Microsoft.Network/dnsZones/A", "2018-05-01")
               ResourceGroup = None
               Subscription = None
-              Name = ResourceName "farmer.com/arm"
-              Segments = [] }
+              Name = ResourceName "farmer.com"
+              Segments = [ ResourceName "arm" ] }
         Expect.equal template.Resources.[0].ResourceId expectedARecordType "Incorrect resourceId generated from standalone record builder"
     }
     test "DNS zone depends_on emits 'dependsOn'" {

--- a/src/Tests/Dns.fs
+++ b/src/Tests/Dns.fs
@@ -171,6 +171,7 @@ let tests = testList "DNS Zone" [
             arm {
                 add_resources [ zone; first; second ]
             }
+        template |> Writer.quickWrite "dns-cname"
         let jobj = template.Template |> Writer.toJson |> JObject.Parse
         let firstDependsOn = jobj.SelectToken("resources[?(@.name=='farmer.com/first')].dependsOn") :?> JArray |> Seq.map string
         Expect.hasLength firstDependsOn 1 "first 'CNAME' record dependsOn zone only."
@@ -178,6 +179,6 @@ let tests = testList "DNS Zone" [
         let secondDependsOn = jobj.SelectToken("resources[?(@.name=='farmer.com/second')].dependsOn") :?> JArray |> Seq.map string
         Expect.hasLength secondDependsOn 2 "second 'CNAME' record linked to first 'CNAME' record dependsOn."
         Expect.contains secondDependsOn "[resourceId('Microsoft.Network/dnsZones', 'farmer.com')]" "Missing dependency on zone"
-        Expect.contains secondDependsOn "[resourceId('Microsoft.Network/dnsZones/CNAME', 'farmer.com/first')]" "Missing dependency on first 'CNAME' record"
+        Expect.contains secondDependsOn "[resourceId('Microsoft.Network/dnsZones/CNAME', 'farmer.com', 'first')]" "Missing dependency on first 'CNAME' record"
     }
 ]


### PR DESCRIPTION
This PR fixes #689 

The changes in this PR are as follows:

* DNS Zone: zone and record 'depends_on' support.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.