### PR TITLE
Fixed WebApp app_insights_auto_name keyword name in the documentation

### DIFF
--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -19,7 +19,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | name | Sets the name of the web app. |
 | Web App | link_to_service_plan | Instructs Farmer to link this webapp to a Farmer service plan configuration defined elsewhere in your application, rather than creating a new one. |
 | Web App | link_to_unmanaged_service_plan | Instructs Farmer to link this webapp to an existing service plan that is externally managed, rather than creating a new one. |
-| Web App | app_insights_auto_name | Sets the name of the automatically-created app insights instance. |
+| Web App | app_insights_name | Sets the name of the automatically-created app insights instance. |
 | Web App | app_insights_off | Removes any automatic app insights creation, configuration and settings for this webapp. |
 | Web App | link_to_app_insights | Instructs Farmer to link this webapp to a Farmer App Insights configuration defined elsewhere in your application, rather than creating a new one. |
 | Web App | link_to_unmanaged_app_insights | Instructs Farmer to link this webapp to an existing app insights instance that is externally managed, rather than creating a new one. |


### PR DESCRIPTION
The webapp keyword `app_insights_auto_name` does not exist in v1.6.6, it should be `app_insights_name` instead. [Unless I missed something!]

The changes in this PR are as follows:

* Renamed keyword `app_insights_auto_name` -> `app_insights_name` in the documentation

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
Documentation change only
