### PR TITLE
Adding a list of firewall rules to database

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes
 ## 1.6.7
 * Container Groups: Reference Azure container registry credentials.
 * DNS Zone: Support for adding records to existing zones.
+* SQL Azure and Postgres: add_firewall_rules to take list of rules
 
 ## 1.6.6
 * Azure Firewall: Support for 'link_to_firewall_policy' to link to a builder as well as a resource.

--- a/docs/content/api-overview/resources/postgresql.md
+++ b/docs/content/api-overview/resources/postgresql.md
@@ -34,6 +34,7 @@ parameter for the admin account password.
 | Server | add_database (name:string) | Adds a database with name of `name` |
 | Server | enable_azure_firewall | Enables firewall access to all Azure services |
 | Server | add_firewall_rule (name:string, start ip:string, end ip:string) | Adds a firewall rule to the server |
+| Server | add_firewall_rules (rules:(string*string*sting)list) | As add_firewall_rule but a list of rules |
 
 #### PostgreSQLDb Builder keywords
 | Applies To | Keyword | Purpose |

--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -15,6 +15,7 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 |-|-|
 | server_name | Sets the name of the SQL server. |
 | add_firewall_rule | Adds a custom firewall rule given a name, start and end IP address range. |
+| add_firewall_rules | As add_firewall_rule but a list of rules |
 | enable_azure_firewall | Adds a firewall rule that enables access to other Azure services. |
 | admin_username | Sets the admin username of the server. |
 | elastic_pool_name | Sets the name of the elastic pool, if required. If not set, Farmer will generate a name for you. |

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -278,6 +278,15 @@ type PostgreSQLBuilder() =
                    Start = IPAddress.Parse startRange
                    End = IPAddress.Parse endRange |}
                 :: state.FirewallRules }
+    /// Adds a custom firewall rules given a name, start and end IP address range.
+    [<CustomOperation "add_firewall_rules">]
+    member _.AddFirewallRules(state:PostgreSQLConfig, listOfRules:(string*string*string) list) =
+        let newRules =
+            listOfRules |> List.map(fun (name, startRange, endRange) ->
+                {| Name = ResourceName name
+                   Start = IPAddress.Parse startRange
+                   End = IPAddress.Parse endRange |})
+        { state with FirewallRules = newRules @ state.FirewallRules }
 
     /// Adds a firewall rule that enables access to other Azure services.
     [<CustomOperation "enable_azure_firewall">]

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -190,6 +190,15 @@ type SqlServerBuilder() =
                    Start = makeIp startRange
                    End = makeIp endRange |}
                 :: state.FirewallRules }
+    /// Adds a firewall rules that enables access to a specific IP Address range.
+    [<CustomOperation "add_firewall_rules">]
+    member __.AddFirewallRules(state:SqlAzureConfig, listOfRules:(string*string*string) list) =
+        let newRules =
+            listOfRules |> List.map(fun (name, startRange, endRange) ->
+                {| Name = ResourceName name
+                   Start = makeIp startRange
+                   End = makeIp endRange |})
+        { state with FirewallRules = newRules @ state.FirewallRules }
     /// Adds a firewall rule that enables access to other Azure services.
     [<CustomOperation "enable_azure_firewall">]
     member this.UseAzureFirewall(state:SqlAzureConfig) =

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -121,6 +121,19 @@ let tests = testList "SQL Server" [
         Expect.equal model.EndIpAddress "255.255.255.255" "Incorrect end IP"
     }
 
+    test "SQL Firewall is correctly configured with list" {
+        let sql =
+            sqlServer {
+                name "server"
+                admin_username "isaac"
+                add_firewall_rules [ "Rule", "0.0.0.0", "255.255.255.255" ]
+                add_databases [ sqlDb { name "db" } ]
+            }
+        let model : Models.FirewallRule = sql |> getResourceAtIndex client.SerializationSettings 2
+        Expect.equal model.StartIpAddress "0.0.0.0" "Incorrect start IP"
+        Expect.equal model.EndIpAddress "255.255.255.255" "Incorrect end IP"
+    }
+
     test "Validation occurs on account name" {
         let check (v:string) m = Expect.equal (SqlAccountName.Create v) (Error ("SQL account names " + m))
 


### PR DESCRIPTION
This is a small PR.
It only adds `add_firewall_rules` to add list of rules to database firewalls, instead of a single rule.

I wanted to call `add_firewall_rule` dynamically not-yet-defined list of around 15 rules.
So first I tried to call `yield! myList |> List.map add_firewall_rule` but the compiler is not happy, __.For is not defined for this builder or whatever.

add_firewall_rule takes a 3 arguments, so it cannot be easily overloaded with 1 argument.
And it wouldn't be grammatically correct anyway. So that's why the new add_firewall_rules.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ x ] **Tested my code** end-to-end against a live Azure subscription.
* [ x ] **Updated the documentation** in the docs folder for the affected changes.
* [ x ] **Written unit tests** against the modified code that I have made.
* [ x ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ x ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

