### PR TITLE
Bugfix for the ARM deployment quickstart example

### DIFF
--- a/docs/content/quickstarts/quickstart-3.md
+++ b/docs/content/quickstarts/quickstart-3.md
@@ -21,6 +21,7 @@ Modify the application you created at the end of [quickstart #2](quickstart-2/#t
 ```fsharp
 deployment
 |> Deploy.execute "myResourceGroup" Deploy.NoParameters
+|> ignore
 ```
 
 > Note that the Web Application and Storage Account names should be *globally* unique; they must be **unique across Azure** i.e. someone else can't have another web app or storage account with the same name!
@@ -56,4 +57,5 @@ let deployment = arm {
 
 deployment
 |> Deploy.execute "myResourceGroup" Deploy.NoParameters
+|> ignore
 ```


### PR DESCRIPTION
Deploy.execute returns Map<string,string>, which has to be ignored

