### PR TITLE
Merge identities for slots

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.6.9
+* WebApp: Slots now inherit user assigned identities from their owning webApp
 
 ## 1.6.8
 * SQL Azure and Postgres: `add_firewall_rules` to take list of rules


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Slots inherit userAssignedIdentities from their owning webApp

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] ~~**Updated the documentation** in the docs folder for the affected changes.~~
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
* No existsing documentation covers this level of detail