### PR TITLE
Support for creating resource groups in ARM deployment

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 Release Notes
 =============
 ## 1.6.9
+* Resource Groups: Support for creating resource groups for deployments targeting a subscription.
 * WebApp: Slots now inherit user assigned identities from their owning webApp
 
 ## 1.6.8

--- a/docs/content/api-overview/resources/resource-group.md
+++ b/docs/content/api-overview/resources/resource-group.md
@@ -1,6 +1,6 @@
 ---
 title: "Resource Group"
-date: 2020-02-05T08:53:46+01:00
+date: 2021-08-05T17:30:25-04:00
 weight: 1
 chapter: false
 ---
@@ -18,6 +18,9 @@ The Resource Group builder is always the top-level element of your deployment. I
 | add_tag | Add a tag to the resource group for top-level instances or to the deployment for nested resource groups |
 | add_tags | Add multiple tags to the resource group for top-level instances or to the deployment for nested resource groups |
 | name | the name of the resource group (only used for nested resource group deployments) |
+
+#### Utilities
+* The `createResourceGroup` function is used to define a resource group deployment resource by name and location, useful when deploying to a subscription.
 
 #### Example
 ```fsharp

--- a/src/Farmer/Arm/ResourceGroup.fs
+++ b/src/Farmer/Arm/ResourceGroup.fs
@@ -5,6 +5,7 @@ open Farmer
 open Farmer.Writer
 
 let resourceGroupDeployment = ResourceType ("Microsoft.Resources/deployments","2020-10-01")
+let resourceGroups = ResourceType ("Microsoft.Resources/resourceGroups", "2021-04-01")
 
 type DeploymentMode = Incremental|Complete
 
@@ -57,3 +58,16 @@ type ResourceGroupDeployment =
                         expressionEvaluationOptions = {| scope = "Inner" |}
                     |}
             |} :> _
+
+/// Resource Group as a subscription level resource - only for use in deployments targeting a subscription.
+type ResourceGroup =
+    { Name: ResourceName
+      Dependencies: ResourceId Set
+      Location : Location
+      Tags: Map<string,string> }
+    interface IArmResource with
+        member this.JsonModel =
+            {| resourceGroups.Create (this.Name, this.Location, this.Dependencies, this.Tags) with
+                properties = {| |}
+            |} :> _
+        member this.ResourceId = resourceGroups.resourceId this.Name

--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -122,3 +122,10 @@ type ResourceGroupBuilder() =
     interface ITaggable<ResourceGroupConfig> with member _.Add state tags = {state with Tags = state.Tags |> Map.merge tags}
 
 let resourceGroup = ResourceGroupBuilder()
+
+/// Creates a resource group in a subscription level deployment.
+let createResourceGroup (name:string) (location:Location) : ResourceGroup =
+    { Name = ResourceName name
+      Location = location
+      Dependencies = Set.empty
+      Tags = Map.empty }

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -42,6 +42,7 @@ let allTests =
                 Maps.tests
                 NetworkSecurityGroup.tests
                 PostgreSQL.tests
+                ResourceGroup.tests
                 ServiceBus.tests
                 SignalR.tests
                 Sql.tests

--- a/src/Tests/ResourceGroup.fs
+++ b/src/Tests/ResourceGroup.fs
@@ -1,0 +1,16 @@
+module ResourceGroup
+
+open Expecto
+open Farmer
+open Farmer.Arm.ResourceGroup
+open Farmer.Builders
+
+let tests = testList "Resource Group" [
+    test "Creates a resource group" {
+        let rg = createResourceGroup "myRg" Location.EastUS
+        Expect.equal rg.Name.Value "myRg" "Incorrect name on resource group"
+        Expect.equal rg.Location Location.EastUS "Incorrect location on resource group"
+        Expect.equal rg.Dependencies Set.empty "Resource group should have no dependencies"
+        Expect.equal rg.Tags Map.empty "Resource group should have no tags"
+    }
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="Network.fs" />
     <Compile Include="LoadBalancer.fs" />
     <Compile Include="NetworkSecurityGroup.fs" />
+    <Compile Include="ResourceGroup.fs" />
     <Compile Include="Storage.fs" />
     <Compile Include="ServiceBus.fs" />
     <Compile Include="IotHub.fs" />


### PR DESCRIPTION
The changes in this PR are as follows:

* Resource Groups: Support for creating resource groups for deployments targeting a subscription.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.