### PR TITLE
Availability tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* Support for App Insights - Availability tests, VS WebTests
 
 ## 1.6.8
 * SQL Azure and Postgres: `add_firewall_rules` to take list of rules

--- a/docs/content/api-overview/resources/availability-tests.md
+++ b/docs/content/api-overview/resources/availability-tests.md
@@ -1,0 +1,49 @@
+---
+title: "App Insights - Availability Tests"
+date: 2021-08-06T07:00:00+01:00
+weight: 1
+chapter: false
+---
+
+#### Overview
+The App Insights - Availability Tests builder is used to create Application Insights Availability Tests. You will need an Application Insights instance to run the tests.
+The tests can be just pinging the website and expecting response code of 200, or they can be recored Visual Studio WebTests as custom XML strings.
+
+* Application Insights (`Microsoft.Insights/webtests`)
+
+#### Builder Keywords
+
+| Keyword | Purpose |
+|-|-|
+| name | Sets the name of the App Insights instance. |
+| link_to_app_insights | Name or resource of the App Insight instance. |
+| web_test | AvailabilityTest.WebsiteUrl Uri to website, or AvailabilityTest.CustomWebtestXml string |
+| locations | List of locations where the site is pinged. These are not format of Farmer.Location but AvailabilityTest.TestSiteLocation.  |
+| timeout | Timeout if the test is not responding. Default: 120 seconds. |
+| frequency | Frequency how often the test is run. Default: 900 seconds. |
+
+#### Example
+
+```fsharp
+open Farmer
+open Farmer.Builders
+
+let ai = appInsights { name "ai" }
+let myAvailabilityTest =
+    availabilityTest {
+        name "avTest"
+        link_to_app_insights ai
+        timeout 60<Seconds>
+        frequency 800<Seconds>
+        locations [ 
+            AvailabilityTest.TestSiteLocation.NorthEurope
+            AvailabilityTest.TestSiteLocation.WestEurope
+            AvailabilityTest.TestSiteLocation.CentralUS
+            AvailabilityTest.TestSiteLocation.UKSouth
+        ]
+        web_test (
+            "https://mywebsite.com" 
+            |> System.Uri 
+            |> AvailabilityTest.WebsiteUrl)
+    }
+```

--- a/src/Farmer/Arm/AvailabilityTest.fs
+++ b/src/Farmer/Arm/AvailabilityTest.fs
@@ -1,0 +1,84 @@
+[<AutoOpen>]
+module Farmer.Arm.InsightsAvailabilityTest
+
+open Farmer
+
+let availabilitytest = ResourceType("Microsoft.Insights/webtests", "2015-05-01")
+
+type AvailabilityTest =
+    { Name : ResourceName
+      AppInsightsName : ResourceName
+      Timeout : int<Seconds>
+      VisitFrequency : int<Seconds>
+      Location : Location
+      Locations : AvailabilityTest.TestSiteLocation list
+      WebTest : AvailabilityTest.WebTestType option }
+    interface IArmResource with
+        member this.ResourceId = availabilitytest.resourceId this.Name
+        member this.JsonModel =
+            if this.AppInsightsName = ResourceName.Empty then
+                failwith $"AvailabilityTest {this.Name} needs to be attached to an Application Insights."
+            else
+            match this.WebTest with
+            | None -> failwith $"AvailabilityTest {this.Name} Webtest value has to be defined."
+            | Some webTest ->
+                let appInsightResource = $"[concat('hidden-link:', resourceId('{components.Type}', '{this.AppInsightsName.Value}'))]"
+                let testString =
+                    match webTest with
+                    | AvailabilityTest.CustomWebtestXml xml -> xml
+                    | AvailabilityTest.WebsiteUrl websiteUrl -> 
+                        $"""<WebTest xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010"
+                                Name="{this.Name.Value}"
+                                Id="{System.Guid.NewGuid()}"
+                                Enabled="True"
+                                CssProjectStructure=""
+                                CssIteration=""
+                                Timeout="{this.Timeout}"
+                                WorkItemIds=""
+                                Description=""
+                                CredentialUserName=""
+                                CredentialPassword=""
+                                PreAuthenticate="True"
+                                Proxy="default"
+                                StopOnError="False"
+                                RecordedResultFile=""
+                                ResultsLocale="">
+                                <Items>
+                                    <Request
+                                        Method="GET"
+                                        Guid="{System.Guid.NewGuid()}"
+                                        Version="1.1"
+                                        Url="{websiteUrl}"
+                                        ThinkTime="0"
+                                        Timeout="{this.Timeout}"
+                                        ParseDependentRequests="True"
+                                        FollowRedirects="True"
+                                        RecordResult="True"
+                                        Cache="False"
+                                        ResponseTimeGoal="0"
+                                        Encoding="utf-8"
+                                        ExpectedHttpStatusCode="200"
+                                        ExpectedResponseUrl=""
+                                        ReportingName=""
+                                        IgnoreHttpStatusCode="False" />
+                                </Items>
+                            </WebTest>"""
+                {| availabilitytest.Create(this.Name) with
+                    location = this.Location.ArmValue
+                    dependsOn = [
+                        Farmer.ResourceId.create(components, this.AppInsightsName).Eval()
+                    ]
+                    tags = Farmer.Serialization.ofJson ("{\"" + appInsightResource + "\": \"Resource\"}")
+                    properties =
+                    {|  SyntheticMonitorId = $"{this.Name.Value.ToLower()}-{this.AppInsightsName.Value.ToLower()}"
+                        Name = this.Name.Value
+                        Enabled = true
+                        Frequency = this.VisitFrequency
+                        Timeout = this.Timeout
+                        Kind ="ping"
+                        RetryEnabled = true
+                        Locations = this.Locations |> List.map(fun (AvailabilityTest.AvailabilityTestSite lo) -> {| Id = lo.ArmValue |})
+                        Configuration =
+                        {|  WebTest = System.Text.RegularExpressions.Regex.Replace(testString.Replace("\r\n","").Replace("\n",""), @"\s+", " ") |}
+                    |}
+                |} :> _

--- a/src/Farmer/Builders/Builders.AvailabilityTest.fs
+++ b/src/Farmer/Builders/Builders.AvailabilityTest.fs
@@ -1,0 +1,54 @@
+﻿[<AutoOpen>]
+module Farmer.Builders.AppInsightsAvailabilityTest
+
+open Farmer
+open Farmer.Arm.InsightsAvailabilityTest
+
+type AvailabilityTestProperties =
+    { Name: ResourceName
+      AppInsightsName: ResourceName
+      Timeout : int<Seconds>
+      VisitFrequency : int<Seconds>
+      Locations : AvailabilityTest.TestSiteLocation list
+      WebTest : AvailabilityTest.WebTestType option }
+    interface IBuilder with
+        member this.ResourceId = availabilitytest.resourceId this.Name
+        member this.BuildResources location = [
+            { Name = this.Name
+              AppInsightsName = this.AppInsightsName
+              Location = location
+              Timeout = this.Timeout
+              VisitFrequency = this.VisitFrequency
+              Locations = this.Locations
+              WebTest = this.WebTest }
+        ]
+
+type AvailabilityTestBuilder() =
+    member __.Yield _ =
+        { Name = ResourceName.Empty
+          AppInsightsName = ResourceName.Empty
+          Timeout = 120<Seconds>
+          VisitFrequency = 900<Seconds>
+          Locations = List.empty
+          WebTest = None }
+    [<CustomOperation "name">]
+    /// Sets the name of the App Insights instance.
+    member __.Name(state:AvailabilityTestProperties, name) = { state with Name = ResourceName name }
+    [<CustomOperation "timeout">]
+    /// Sets the name of the App Insights instance.
+    member __.Timeout(state:AvailabilityTestProperties, seconds) = { state with Timeout = seconds }
+    [<CustomOperation "frequency">]
+    /// Sets the name of the App Insights instance.
+    member __.Frequency(state:AvailabilityTestProperties, frequency) = { state with VisitFrequency = frequency }
+    [<CustomOperation "locations">]
+    /// Sets the name of the App Insights instance.
+    member __.Locations(state:AvailabilityTestProperties, locations) = { state with Locations = locations }
+    [<CustomOperation "web_test">]
+    /// Sets the name of the App Insights instance.
+    member __.WebTest(state:AvailabilityTestProperties, webtest) = { state with WebTest = Some webtest }
+    [<CustomOperation "link_to_app_insights">]
+    member this.LinkToAi (state:AvailabilityTestProperties, name) = { state with AppInsightsName = name } 
+    member this.LinkToAi (state:AvailabilityTestProperties, name) = this.LinkToAi (state, ResourceName name)
+    member this.LinkToAi (state:AvailabilityTestProperties, config:AppInsightsConfig) = this.LinkToAi (state, config.Name)
+
+let availabilityTest = AvailabilityTestBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1724,6 +1724,34 @@ module VirtualHub =
                     | Managed resId
                     | Unmanaged resId -> resId.Eval()
 
+module AvailabilityTest =
+    /// Availability test types: WebsiteUrl or CustomWebtestXml
+    type WebTestType =
+    /// Raw Visual Stuido WebTest XML
+    | CustomWebtestXml of string
+    /// URL of website that the test will ping
+    | WebsiteUrl of System.Uri
+
+    /// Availability test sites, from where the webtest is run
+    type TestSiteLocation =
+    | AvailabilityTestSite of Farmer.Location
+        static member NorthCentralUS = Farmer.Location "us-il-ch1-azr" |> AvailabilityTestSite
+        static member WestEurope = Farmer.Location "emea-nl-ams-azr" |> AvailabilityTestSite
+        static member SoutheastAsia = Farmer.Location "apac-sg-sin-azr" |> AvailabilityTestSite
+        static member WestUS = Farmer.Location "us-ca-sjc-azr" |> AvailabilityTestSite
+        static member SouthCentralUS = Farmer.Location "us-tx-sn1-azr" |> AvailabilityTestSite
+        static member EastUS = Farmer.Location "us-va-ash-azr" |> AvailabilityTestSite
+        static member EastAsia = Farmer.Location "apac-hk-hkn-azr" |> AvailabilityTestSite
+        static member NorthEurope = Farmer.Location "emea-gb-db3-azr" |> AvailabilityTestSite
+        static member JapanEast = Farmer.Location "apac-jp-kaw-edge" |> AvailabilityTestSite
+        static member AustraliaEast = Farmer.Location "emea-au-syd-edge" |> AvailabilityTestSite
+        static member FranceCentralSouth = Farmer.Location "emea-ch-zrh-edge" |> AvailabilityTestSite
+        static member FranceCentral = Farmer.Location "emea-fr-pra-edge" |> AvailabilityTestSite
+        static member UKSouth = Farmer.Location "emea-ru-msa-edge" |> AvailabilityTestSite
+        static member UKWest = Farmer.Location "emea-se-sto-edge" |> AvailabilityTestSite
+        static member BrazilSouth = Farmer.Location "latam-br-gru-edge" |> AvailabilityTestSite
+        static member CentralUS = Farmer.Location "us-fl-mia-edge" |> AvailabilityTestSite
+
 namespace Farmer.DiagnosticSettings
 
 open Farmer

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -84,6 +84,7 @@
     <Compile Include="Arm/DocumentDb.fs" />
     <Compile Include="Arm/EventHub.fs" />
     <Compile Include="Arm/Insights.fs" />
+    <Compile Include="Arm\AvailabilityTest.fs" />
     <Compile Include="Arm/KeyVault.fs" />
     <Compile Include="Arm\LoadBalancer.fs" />
     <Compile Include="Arm/RoleAssignment.fs" />
@@ -125,6 +126,7 @@
     <Compile Include="Builders/Builders.Vm.fs" />
     <Compile Include="Builders/Builders.ServicePlan.fs" />
     <Compile Include="Builders/Builders.AppInsights.fs" />
+    <Compile Include="Builders\Builders.AvailabilityTest.fs" />
     <Compile Include="Builders/Builders.WebApp.fs" />
     <Compile Include="Builders/Builders.Functions.fs" />
     <Compile Include="Builders/Builders.Sql.fs" />

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -13,6 +13,7 @@ let allTests =
         testList "All Tests" [
             testList "Builders" [
                 AppInsights.tests
+                AppInsightsAvailability.tests
                 if notEnv "BUILD_REASON" "PullRequest" then
                     AzCli.tests
                 AzureFirewall.tests

--- a/src/Tests/AvailabilityTests.fs
+++ b/src/Tests/AvailabilityTests.fs
@@ -1,0 +1,34 @@
+module AppInsightsAvailability
+
+open Expecto
+open Farmer
+open Farmer.Builders
+
+let tests = testList "AvailabilityTests" [
+
+    test "Create an availability test" {
+        let ai = appInsights { name "ai" }
+        let availabilityTest =
+            availabilityTest {
+                name "avTest"
+                link_to_app_insights ai
+                timeout 60<Seconds>
+                frequency 800<Seconds>
+                locations [ AvailabilityTest.TestSiteLocation.CentralUS ]
+                web_test (
+                    "https://google.com" 
+                    |> System.Uri 
+                    |> AvailabilityTest.WebsiteUrl)
+            }
+
+        let template = arm { add_resources [ availabilityTest; ai ] }
+        let jsn = template.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        let hasWebTest = jobj.SelectToken("resources[?(@.name=='avTest')].properties.Configuration.WebTest")
+        Expect.isNotNull hasWebTest "WebTest context missing"
+        let availabilityLocation = jobj.SelectToken("resources[?(@.name=='avTest')].properties.Locations[0].Id")
+        Expect.equal (availabilityLocation.ToString()) "us-fl-mia-edge" "WebTest location incorrect"
+        let dependsAi = jobj.SelectToken("resources[?(@.name=='avTest')].dependsOn")
+        Expect.isNotNull dependsAi "AppInsights dependency missing"
+    }
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -10,6 +10,7 @@
     <Content Include="test-data\*.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="Helpers.fs" />
     <Compile Include="AppInsights.fs" />
+    <Compile Include="AvailabilityTests.fs" />
     <Compile Include="AzureFirewall.fs" />
     <Compile Include="DiagnosticSettings.fs" />
     <Compile Include="Common.fs" />


### PR DESCRIPTION
This PR brings Microsoft.Insights/webtest Availability Test support to farmer,
as briefly implemented from #710 but now as native Farmer builder resource, to be more convenient for the end-user.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit test** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

