### PR TITLE
Geo-replication for SQL databases

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 Release Notes
 =============
-## vNext
+## 1.6.10
 * Azure SQL Server: geo_replicate parameter to geo-replicate the server databases
 
 ## 1.6.9

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## vNext
+* Azure SQL Server: geo_replicate parameter to geo-replicate the server databases
+
 ## 1.6.9
 * Resource Groups: Support for creating resource groups for deployments targeting a subscription.
 * WebApp: Slots now inherit user assigned identities from their owning webApp

--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -23,6 +23,7 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 | elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database. |
 | elastic_pool_capacity | Sets the optional disk size in MB for the elastic pool for each database. |
 | min_tls_version | Sets the minium TLS version for the SQL server |
+| geo_replicate | Geo-replicate all the databases in this server to another location, having NameSuffix after original server and database names. |
 
 #### SQL Server Configuration Members
 | Member | Purpose |

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -131,7 +131,7 @@ type SqlAzureConfig =
 
                     let primaryDatabaseFullId =
                         ArmExpression.create(
-                            $"concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().id, '/providers/Microsoft.Sql/servers/', '{this.Name.ResourceName.Value}', '/databases/','{database.Name.Value}')"
+                            $"concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/', '{this.Name.ResourceName.Value}', '/databases/','{database.Name.Value}')"
                         ).Eval()
 
                     {| apiVersion = "2021-02-01-preview"


### PR DESCRIPTION
This PR adds geo-replication support for SQL database, so that the geo-replicated database location is different, but the resource group stays the same. So it fixes the issues in script in #683 where the deployment had to be done in multiple parts and still have different resource groups.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
