### PR TITLE
Initial support for creating dashboards

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+##vNext
+* Dashboards: Initial support for creating dashboards
+
 ## 1.6.9
 * Resource Groups: Support for creating resource groups for deployments targeting a subscription.
 * WebApp: Slots now inherit user assigned identities from their owning webApp

--- a/docs/content/api-overview/resources/dashboard.md
+++ b/docs/content/api-overview/resources/dashboard.md
@@ -1,0 +1,111 @@
+---
+title: "Dashboard"
+date: 2021-08-09T07:00:46+01:00
+weight: 1
+chapter: false
+---
+
+#### Overview
+
+Dashboards are a focused and organized view of your cloud resources in the Azure portal. Use dashboards as a workspace where you can monitor resources and quickly launch tasks for day-to-day operations. 
+
+* Microsoft.Portal dashboards (`Microsoft.Portal/dashboards`)
+
+#### Builder Keywords
+
+| Keyword | Purpose |
+|-|-|
+| name | Sets the name of the dashboard. |
+| title | Sets the visible title of the dashboard. Default: Same as name |
+| metadata | Sets the metadata for the dashboard. Pre-defined DashboardMetadata objects: EmptyMetadata, CustomMetadata and Cache24h |
+| add_markdown_part | Create markdown lens part for the dashboard |
+| add_video_part | Create video part for the dashboard |
+| add_virtual_machine_icon | Create virtual machine status part for the dashboard |
+| add_metrics_chart | Create metrics results part for the resource given in parameters |
+| add_webtest_results_part |  Create webtest results part for the dashboard |
+| add_monitor_chart | Create metrics results part for the resource given in parameters |
+| add_custom_lens | Create your own lens part for the dashboard |
+
+#### Example
+
+This example generally follows the simple example of https://docs.microsoft.com/en-us/azure/azure-portal/azure-portal-dashboards-structure
+
+```fsharp
+open Farmer
+open Farmer.Builders
+
+let vm = vm { name "foo"; username "foo" }
+let vmId = (vm :> IBuilder).ResourceId
+let dash = dashboard { 
+    name "myDashboard" 
+    title "Monitoring"
+    depends_on vm
+    add_markdown_part (
+        {| x = 0; y = 0; rowSpan = 2; colSpan = 3 |},
+        {| title = ""; subtitle = ""; content = "## Azure Virtual Machines Overview\r\nNew team members should watch this video to get familiar with Azure Virtual Machines." |}
+    )
+    add_markdown_part (
+        {| x = 3; y = 0; rowSpan = 4; colSpan = 8 |},
+        {| title = "Test VM Dashboard"; subtitle = "Contoso"; content = "This is the team dashboard for the test VM we use on our team. Here are some useful links:\r\n\r\n1. [Getting started](https://www.contoso.com/tsgs)\r\n1. [Troubleshooting guide](https://www.contoso.com/tsgs)\r\n1. [Architecture docs](https://www.contoso.com/tsgs)" |}
+    )
+    add_video_part (
+        {| x = 3; y = 0; rowSpan = 4; colSpan = 8 |},
+        {| title = ""; subtitle = ""; url = "https://www.youtube.com/watch?v=YcylDIiKaSU&list=PLLasX02E8BPCsnETz0XAMfpLR1LIBqpgs&index=4" |}
+    )
+    add_metrics_chart (
+        {| x = 0; y = 4; rowSpan = 3; colSpan = 11 |},
+        {| interval = Farmer.Arm.Dashboard.ChartDurationInterval.OneHour; 
+            metrics = [ Farmer.Arm.Dashboard.ChartResources.PercentageCPU ]; 
+            resourceId = vmId |}
+    )
+    add_virtual_machine_icon ({| x = 9; y = 7; rowSpan = 2; colSpan = 2 |}, vmId)
+}
+```
+
+You can also create more complex custom dashboards:
+
+```fsharp
+let chartTitle = "my DB monitor"
+let valueToMonitor = "dtu_consumption_percent", "DTU percentage"
+let databaseResourceId = "test"
+let lineColor = "#47BDF5"
+let dashboard2 = dashboard { 
+    name "myDashboard" 
+    title "DB-Monitoring"
+    add_monitor_chart({| x = 0; y = 0; rowSpan = 6; colSpan = 10 |},
+        ({| chartSettings = {| title = chartTitle
+                               openBladeOnClick = {| openBlade = true |}
+                               visualization = {| chartType = 2; legendVisualization = null; disablePinning = true;
+                                                  axisVisualization = {| y = {| isVisible = true |} |} |}
+                               metrics = [ {| resourceMetadata = {| id = databaseResourceId |}
+                                              name = fst valueToMonitor
+                                              aggregationType = 3
+                                              metricVisualization = {| displayName = snd valueToMonitor;
+                                                                       color = lineColor; resourceDisplayName = null |} |} ] |} :> obj |> Some
+            chartInputs = [ {| title = chartTitle
+                               ariaLabel = null; filterCollection = null; grouping = null;
+                               visualization = {| axisVisualization = null; legendVisualization = null; chartType = null|}
+                               resolvedBladeToOpenOnClick = {| openBlade = true |}
+                               timespan = {| relative = {| duration = 3600000 |} |}
+                               timeContext = {| options = {| useDashboardTimeRange = false; grain = 1 |}
+                                                relative = {| duration = 3600000 |} |}
+                               metrics = [ {| resourceMetadata = {| id = databaseResourceId; kind = "v12.0,user" |}
+                                              name = fst valueToMonitor; metricVisualization = null;
+                                              aggregationType = 3; thresholds = []
+                                                |} ]
+                               itemDataModel = {| id = $"defaultAiChartDiv{System.Guid.NewGuid()}"; grouping = null; chartHeight = 1;
+                                                  priorPeriod = false; horizontalBars = true; showOther = false; palette = "multiColor";
+                                                  jsonDefinitionId = ""; yAxisOptions = {| options = 1 |}; 
+                                                  appliedISOGrain = Farmer.Arm.Dashboard.ChartDurationInterval.OneMinute;
+                                                  title = chartTitle; titleKind = "Auto"
+                                                  visualization = {| chartType = 2; legend = null; axis = null |}
+                                                  metrics = [
+                                                     {| id = {| resourceDefinition = {| id = databaseResourceId; name = null |}
+                                                                name = {| id = fst valueToMonitor; displayName = snd valueToMonitor |} |}
+                                                        metricAggregation = 3; color = lineColor; unit = 5; useSIConversions = false; displaySIUnit = true
+                                                    |} ]
+                                                |} |} ]
+            filters = {| MsPortalFx_TimeRange = {| model = {| format = "local"; granularity = "auto"; relative = "60m" |} |} |} :> obj |> Some
+        |}))
+}
+```

--- a/src/Farmer/Arm/Dashboard.fs
+++ b/src/Farmer/Arm/Dashboard.fs
@@ -3,7 +3,7 @@ module Farmer.Arm.Dashboard
 
 open Farmer
 
-let dashboard = ResourceType("Microsoft.Portal/dashboards", "2015-08-01-preview")
+let dashboard = ResourceType("Microsoft.Portal/dashboards", "2020-09-01-preview")
 
 type DashboardMetadata =
 | EmptyMetadata
@@ -127,11 +127,6 @@ type Dashboard =
         member this.ResourceId = dashboard.resourceId this.Name
         member this.JsonModel =
 
-            let lensesPartsObjJson =
-                // Parts-list is not array, instead it's "parts": { "0": { }, "1": { }, ... }
-                let lensesJsons = this.LensParts |> List.mapi(fun idx item -> $"\"{idx}\": {item |> Farmer.Serialization.toJson }")
-                ("{" + System.String.Join(",", lensesJsons) + "}") |> Farmer.Serialization.ofJson
-
             let dahsboardTitle = 
                 match this.Title with
                 | Some title -> title
@@ -158,6 +153,6 @@ type Dashboard =
                                            |} |} |}
                                     |}
                                 |} :> _
-                          lenses = {| ``0`` = {| order = "0"; parts = lensesPartsObjJson |} |}
+                          lenses = [ {| order = "0"; parts = this.LensParts |} ]
                        |}
                 |} :> _

--- a/src/Farmer/Arm/Dashboard.fs
+++ b/src/Farmer/Arm/Dashboard.fs
@@ -1,0 +1,163 @@
+[<AutoOpen>]
+module Farmer.Arm.Dashboard
+
+open Farmer
+
+let dashboard = ResourceType("Microsoft.Portal/dashboards", "2015-08-01-preview")
+
+type DashboardMetadata =
+| EmptyMetadata
+| CustomMetadata of obj
+| Cache24h 
+
+type LensMetadata = {
+    ``type`` : string
+    inputs : obj list
+    settings : obj
+    filters : obj option
+    asset : {| idInputName : string;  ``type`` : string |} option
+    isAdapter : bool option
+    defaultMenuItemId : string option
+}
+
+type LensPart = {
+    position : {| x : int; y : int; rowSpan : int; colSpan : int; |}
+    metadata : LensMetadata
+}
+
+type ChartDurationInterval =
+| ISO8601DurationFormat of string
+    static member OneHour = ISO8601DurationFormat "PT1H"
+    static member FiveMinutes = ISO8601DurationFormat "PT5M"
+    static member OneMinute = ISO8601DurationFormat "PT1M"
+
+type ChartResources = 
+| ChartResouce of string
+    static member PercentageCPU = ChartResouce "Percentage CPU"
+    static member DiskReadOperationsPerSec = ChartResouce "Disk Read Operations/Sec"
+    static member DiskWriteOperationsPerSec = ChartResouce "Disk Write Operations/Sec"
+    static member DiskReadBytes = ChartResouce "Disk Read Bytes"
+    static member DiskWriteBytes = ChartResouce "Disk Write Bytes"
+    static member NetworkIn = ChartResouce "Network In"
+    static member NetworkOut = ChartResouce "Network Out"
+
+/// Generates a MarkdownPart
+let generateMarkdownPart (markdownProperties:{|title:string; subtitle:string; content:string|}) = {
+    ``type`` = "Extension[azure]/HubsExtension/PartType/MarkdownPart"
+    inputs = List.empty
+    settings = {| content = markdownProperties.content; title = markdownProperties.title; subtitle = markdownProperties.subtitle |} :> obj
+    filters = None
+    asset = None 
+    isAdapter = None
+    defaultMenuItemId = None
+}
+
+/// Generates a VideoPart
+let generateVideoPart (videoProperties:{|title:string; subtitle:string; url:string|}) = {
+    ``type`` = "Extension[azure]/HubsExtension/PartType/VideoPart"
+    inputs = List.empty
+    settings = {| content = {| settings = {| title = videoProperties.title; subtitle = videoProperties.subtitle; src = videoProperties.url; autoplay= false |} |} |} :> obj
+    filters = None
+    asset = None 
+    isAdapter = None
+    defaultMenuItemId = None
+}
+
+/// Generates a virtualMachinePart
+let generateVirtualMachinePart (vmId:ResourceId) = {
+    ``type`` = "Extension/Microsoft_Azure_Compute/PartType/VirtualMachinePart"
+    inputs = [ {| name = "id"; value = vmId.ArmExpression.Eval() |} :> obj ]
+    settings = None
+    filters = None
+    asset = Some {| idInputName = "id"; ``type`` = "VirtualMachine" |}
+    isAdapter = None
+    defaultMenuItemId = Some "overview"
+}
+
+/// Generates a virtualMachinePart
+let generateWebtestResultPart (applicationInsightsName:string) = {
+    ``type`` = "Extension/AppInsightsExtension/PartType/AllWebTestsResponseTimeFullGalleryAdapterPart"
+    inputs = [ {| name = "ComponentId"; value = {| Name = applicationInsightsName; SubscriptionId = "[ subscription().subscriptionId ]"; ResourceGroup = "[ resourceGroup().id ]" |} |} ]
+    settings = None
+    filters = None
+    asset = Some {| idInputName = "ComponentId"; ``type`` = "ApplicationInsights" |}
+    isAdapter = Some true
+    defaultMenuItemId = None
+}
+
+/// Generates a MetricsChartPart for a resource given in parameters
+let generateMetricsChartPart (chartProperties:{| resourceId:ResourceId; metrics: ChartResources list; interval : ChartDurationInterval |}) = {
+    ``type`` = "Extension/Microsoft_Azure_Monitoring/PartType/MetricsChartPart"
+    inputs = [ {| name = "queryInputs"
+                  value = {| id = chartProperties.resourceId.ArmExpression.Eval(); chartType = 0;
+                             timespan = {| duration = match chartProperties.interval with | ISO8601DurationFormat dur -> dur
+                                           start = null; ``end`` = null |}
+                             metrics = chartProperties.metrics |> List.map(function 
+                                            ChartResouce m -> {| name = m; resourceId = chartProperties.resourceId.ArmExpression.Eval() |})
+                          |} |}  ]
+    settings = None
+    filters = None
+    asset = None
+    isAdapter = None
+    defaultMenuItemId = None
+}
+
+/// Generates a MonitorChartPart
+let generateMonitorChartPart (chartProperties : {| chartInputs:obj list; chartSettings: obj option; filters : obj option |}) = {
+    ``type`` = "Extension/HubsExtension/PartType/MonitorChartPart"
+    inputs = [ box <| {| name = "sharedTimeRange"; isOptional = true |};
+               box <| {| name = "options"
+                         value = {| v2charts = true
+                                    charts = [ chartProperties.chartInputs ] |} |} ]
+    settings = Some ({| content = {| options = {| chart = chartProperties.chartSettings |} |} |})
+    filters = chartProperties.filters
+    asset = None
+    isAdapter = None
+    defaultMenuItemId = None
+}
+
+type Dashboard =
+    { Name : ResourceName
+      Title : string option
+      Location : Location
+      Metadata : DashboardMetadata
+      LensParts : LensPart list
+      Dependencies : Set<ResourceId> }
+    interface IArmResource with
+        member this.ResourceId = dashboard.resourceId this.Name
+        member this.JsonModel =
+
+            let lensesPartsObjJson =
+                // Parts-list is not array, instead it's "parts": { "0": { }, "1": { }, ... }
+                let lensesJsons = this.LensParts |> List.mapi(fun idx item -> $"\"{idx}\": {item |> Farmer.Serialization.toJson }")
+                ("{" + System.String.Join(",", lensesJsons) + "}") |> Farmer.Serialization.ofJson
+
+            let dahsboardTitle = 
+                match this.Title with
+                | Some title -> title
+                | None -> this.Name.Value
+
+            {| dashboard.Create(this.Name, this.Location, dependsOn = this.Dependencies) with
+                   tags = {| ``hidden-title`` = dahsboardTitle |}
+                   id = ArmExpression.create(
+                           $"concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Portal/dashboards/', '{this.Name.Value}')"
+                       ).Eval()
+                   properties =
+                       {| metadata =
+                            match this.Metadata with
+                            | EmptyMetadata -> {||} :> obj
+                            | CustomMetadata metad -> metad
+                            | Cache24h -> 
+                                {| model =
+                                    {| timeRange =
+                                         {| ``type`` = "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"; value = {| relative = {| duration = 24; timeUnit = 1 |} |} |}
+                                       filterLocale = {| value = "en-us" |}
+                                       filters =
+                                          {| value = {| MsPortalFx_TimeRange = {| model = {| format = "utc"; granularity = "auto"; relative = "24h" |}
+                                                                                  displayCache = {| name = "UTC Time"; value = "Past 24 hours" |}
+                                           |} |} |}
+                                    |}
+                                |} :> _
+                          lenses = {| ``0`` = {| order = "0"; parts = lensesPartsObjJson |} |}
+                       |}
+                |} :> _

--- a/src/Farmer/Builders/Builders.Dashboard.fs
+++ b/src/Farmer/Builders/Builders.Dashboard.fs
@@ -1,0 +1,86 @@
+﻿[<AutoOpen>]
+module Farmer.Builders.Dashboard
+
+open Farmer
+open Farmer.Arm.Dashboard
+
+type DashboardConfig =
+    { Name : ResourceName
+      Title : string option
+      Metadata : DashboardMetadata
+      LensParts : LensPart list
+      Dependencies : Set<ResourceId> }
+    interface IBuilder with
+        member this.ResourceId = dashboard.resourceId this.Name
+        member this.BuildResources location = [
+            { Name = this.Name
+              Title = this.Title
+              Location = location
+              Metadata = this.Metadata
+              LensParts = this.LensParts
+              Dependencies = this.Dependencies }
+        ]
+
+type DashboardBuilder() =
+    member __.Yield _ =
+        { Name = ResourceName.Empty
+          Title = None
+          Metadata = DashboardMetadata.EmptyMetadata
+          LensParts = List.empty
+          Dependencies = Set.empty }
+    [<CustomOperation "name">]
+    /// Sets the name of the dashboard.
+    member __.Name(state:DashboardConfig, name) = { state with Name = ResourceName name }
+
+    [<CustomOperation "title">]
+    /// Sets the visible title for the dashboard. Default: Same as name.
+    member __.Title(state:DashboardConfig, title) = { state with Title = Some title }
+
+    [<CustomOperation "metadata">]
+    /// Sets the metadata for the dashboard. Pre-defined DashboardMetadata objects: EmptyMetadata, CustomMetadata and Cache24h
+    member __.Metadata(state:DashboardConfig, metadata) = { state with Metadata = metadata }
+
+    [<CustomOperation "add_custom_lens">]
+    /// Create your own lens part for the dashboard
+    member __.CustomLens(state:DashboardConfig, lens) = { state with LensParts = lens :: state.LensParts }
+
+    [<CustomOperation "add_markdown_part">]
+    /// Create markdown lens part for the dashboard
+    member __.MarkdownPart(state:DashboardConfig, (position, markdownPart)) = 
+        let markdown = generateMarkdownPart markdownPart
+        { state with LensParts = ({ position = position; metadata = markdown}) :: state.LensParts }
+
+    [<CustomOperation "add_video_part">]
+    /// Create video part for the dashboard
+    member __.VideoPart(state:DashboardConfig, (position, videoPart)) = 
+        let videopart = generateVideoPart videoPart
+        { state with LensParts = ({ position = position; metadata = videopart}) :: state.LensParts }
+
+    [<CustomOperation "add_virtual_machine_icon">]
+    /// Create virtual machine status part for the dashboard
+    member __.VirtualMachinePart(state:DashboardConfig, (position, virtualMachineId)) = 
+        let vmPart = generateVirtualMachinePart virtualMachineId
+        { state with LensParts = ({ position = position; metadata = vmPart}) :: state.LensParts }
+
+    [<CustomOperation "add_webtest_results_part">]
+    /// Create webtest results part for the dashboard
+    member __.WebtestResultPart(state:DashboardConfig, (position, virtualMachineName)) = 
+        let vmPart = generateWebtestResultPart virtualMachineName
+        { state with LensParts = ({ position = position; metadata = vmPart}) :: state.LensParts }
+
+    [<CustomOperation "add_metrics_chart">]
+    /// Create metrics results part for the resource given in parameters
+    member __.MetricsChartPart(state:DashboardConfig, (position, metricsChart)) = 
+        let metricsChartPart = generateMetricsChartPart metricsChart
+        { state with LensParts = ({ position = position; metadata = metricsChartPart}) :: state.LensParts }
+
+    [<CustomOperation "add_monitor_chart">]
+    /// Create metrics results part for the resource given in parameters
+    member __.MonitorChartPart(state:DashboardConfig, (position, monitorChart)) = 
+        let monitorChartPart = generateMonitorChartPart monitorChart
+        { state with LensParts = ({ position = position; metadata = monitorChartPart}) :: state.LensParts }
+
+    /// Enable support for additional dependencies.
+    interface IDependable<DashboardConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+
+let dashboard = DashboardBuilder()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -101,6 +101,7 @@
     <Compile Include="Arm/TrafficManager.fs" />
     <Compile Include="Arm/AzureFirewall.fs" />
     <Compile Include="Arm/VirtualHub.fs" />
+    <Compile Include="Arm\Dashboard.fs" />
     <Compile Include="IdentityExtensions.fs" />
 
     <Compile Include="Builders/Extensions.fs" />
@@ -149,6 +150,7 @@
     <Compile Include="Builders/Builders.TrafficManager.fs" />
     <Compile Include="Builders/Builders.VirtualHub.fs" />
     <Compile Include="Builders/Builders.AzureFirewall.fs" />
+    <Compile Include="Builders\Builders.Dashboard.fs" />
     <Compile Include="Aliases.fs" />
   </ItemGroup>
 </Project>

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -55,6 +55,7 @@ let allTests =
                 VirtualNetworkGateway.tests
                 VirtualWan.tests
                 WebApp.tests
+                Dashboards.tests
             ]
             testList "Control" [
                 if (hasEnv "TF_BUILD" "True" && notEnv "BUILD_REASON" "PullRequest") || hasEnv "FARMER_E2E" "True" then

--- a/src/Tests/Dashboards.fs
+++ b/src/Tests/Dashboards.fs
@@ -1,0 +1,103 @@
+module Dashboards
+
+open Expecto
+open Farmer
+open Farmer.Builders
+
+let tests = testList "Dashboards" [
+    test "Create a simple dashboard" {
+        // https://docs.microsoft.com/en-us/azure/azure-portal/azure-portal-dashboards-structure
+
+        let vm = vm { name "foo"; username "foo" }
+        let vmId = (vm :> IBuilder).ResourceId
+        let dash = dashboard { 
+            name "myDashboard" 
+            title "Monitoring"
+            depends_on vm
+            add_markdown_part (
+                {| x = 0; y = 0; rowSpan = 2; colSpan = 3 |},
+                {| title = ""; subtitle = ""; content = "## Azure Virtual Machines Overview\r\nNew team members should watch this video to get familiar with Azure Virtual Machines." |}
+            )
+            add_markdown_part (
+                {| x = 3; y = 0; rowSpan = 4; colSpan = 8 |},
+                {| title = "Test VM Dashboard"; subtitle = "Contoso"; content = "This is the team dashboard for the test VM we use on our team. Here are some useful links:\r\n\r\n1. [Getting started](https://www.contoso.com/tsgs)\r\n1. [Troubleshooting guide](https://www.contoso.com/tsgs)\r\n1. [Architecture docs](https://www.contoso.com/tsgs)" |}
+            )
+            add_video_part (
+                {| x = 3; y = 0; rowSpan = 4; colSpan = 8 |},
+                {| title = ""; subtitle = ""; url = "https://www.youtube.com/watch?v=YcylDIiKaSU&list=PLLasX02E8BPCsnETz0XAMfpLR1LIBqpgs&index=4" |}
+            )
+            add_metrics_chart (
+                {| x = 0; y = 4; rowSpan = 3; colSpan = 11 |},
+                {| interval = Farmer.Arm.Dashboard.ChartDurationInterval.OneHour; 
+                   metrics = [ Farmer.Arm.Dashboard.ChartResources.PercentageCPU ]; 
+                   resourceId = vmId |}
+            )
+            add_virtual_machine_icon ({| x = 9; y = 7; rowSpan = 2; colSpan = 2 |}, vmId)
+        }
+
+        let template = arm { add_resources [ vm; dash ] }
+        let jsn = template.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        let title = jobj.SelectToken("resources[?(@.name=='myDashboard')].tags.hidden-title").ToString()
+        Expect.equal title "Monitoring" "Incorrect title"
+        let lenses = jobj.SelectToken("resources[?(@.name=='myDashboard')].properties.lenses")
+        Expect.isNotNull lenses "Lenses missing"
+    }
+
+    test "Create a dashboard with a complex monitor part" {
+
+        let chartTitle = "my DB monitor"
+        let valueToMonitor = "dtu_consumption_percent", "DTU percentage"
+        let databaseResourceId = "test"
+        let lineColor = "#47BDF5"
+        let dashboard2 = dashboard { 
+            name "myDashboard" 
+            title "DB-Monitoring"
+            add_monitor_chart({| x = 0; y = 0; rowSpan = 6; colSpan = 10 |},
+                ({| chartSettings = {| title = chartTitle
+                                       openBladeOnClick = {| openBlade = true |}
+                                       visualization = {| chartType = 2; legendVisualization = null; disablePinning = true;
+                                                          axisVisualization = {| y = {| isVisible = true |} |} |}
+                                       metrics = [ {| resourceMetadata = {| id = databaseResourceId |}
+                                                      name = fst valueToMonitor
+                                                      aggregationType = 3
+                                                      metricVisualization = {| displayName = snd valueToMonitor;
+                                                                               color = lineColor; resourceDisplayName = null |} |} ] |} :> obj |> Some
+                    chartInputs = [ {| title = chartTitle
+                                       ariaLabel = null; filterCollection = null; grouping = null;
+                                       visualization = {| axisVisualization = null; legendVisualization = null; chartType = null|}
+                                       resolvedBladeToOpenOnClick = {| openBlade = true |}
+                                       timespan = {| relative = {| duration = 3600000 |} |}
+                                       timeContext = {| options = {| useDashboardTimeRange = false; grain = 1 |}
+                                                        relative = {| duration = 3600000 |} |}
+                                       metrics = [ {| resourceMetadata = {| id = databaseResourceId; kind = "v12.0,user" |}
+                                                      name = fst valueToMonitor; metricVisualization = null;
+                                                      aggregationType = 3; thresholds = []
+                                                      |} ]
+                                       itemDataModel = {| id = $"defaultAiChartDiv{System.Guid.NewGuid()}"; grouping = null; chartHeight = 1;
+                                                          priorPeriod = false; horizontalBars = true; showOther = false; palette = "multiColor";
+                                                          jsonDefinitionId = ""; yAxisOptions = {| options = 1 |}; 
+                                                          appliedISOGrain = Farmer.Arm.Dashboard.ChartDurationInterval.OneMinute;
+                                                          title = chartTitle; titleKind = "Auto"
+                                                          visualization = {| chartType = 2; legend = null; axis = null |}
+                                                          metrics = [
+                                                            {| id = {| resourceDefinition = {| id = databaseResourceId; name = null |}
+                                                                       name = {| id = fst valueToMonitor; displayName = snd valueToMonitor |} |}
+                                                               metricAggregation = 3; color = lineColor; unit = 5; useSIConversions = false; displaySIUnit = true
+                                                            |} ]
+                                                      |} |} ]
+                    filters = {| MsPortalFx_TimeRange = {| model = {| format = "local"; granularity = "auto"; relative = "60m" |} |} |} :> obj |> Some
+                |}))
+        }
+
+        let template = arm { add_resources [ dashboard2 ] }
+        let jsn = template.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        System.IO.File.WriteAllText(@"c:\temp\mydash.json", jsn)
+        let title = jobj.SelectToken("resources[?(@.name=='myDashboard')].tags.hidden-title").ToString()
+        Expect.equal title "DB-Monitoring" "Incorrect title"
+        let lenses = jobj.SelectToken("resources[?(@.name=='myDashboard')].properties.lenses")
+        Expect.isNotNull lenses "Lenses missing"
+    }
+
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -54,6 +54,7 @@
     <Compile Include="JsonRegression.fs" />
     <Compile Include="Types.fs" />
     <Compile Include="TrafficManager.fs" />
+    <Compile Include="Dashboards.fs" />
     <Compile Include="AllTests.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR takes an initial step towards creating dashboards with farmer.
Meanwhile creating a dashboard like in the Microsoft [example](https://docs.microsoft.com/en-us/azure/azure-portal/azure-portal-dashboards-structure) is simple, the complex dashboards like in the issue #716 are still needing quite a lot of custom F#-to-ARM-objects. 

I think that it could be simplified by creating some common nice pre-templates, but I didn't want this PR to grow too much. Instead this gets people started with dashboards (if needed) and then the behaviours can be extended in the future PRs if there starts to be common ground of typically needed graphs or other templates.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription. 
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

