### PR TITLE
ACI on vnet - specify IP config name

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## vNext
+* Container Groups: Use `ip_config` to name the IP configuration for a container group's subnet.
+
 ## 1.6.10
 * Azure SQL Server: geo_replicate parameter to geo-replicate the server databases
 * App Insights: Support for Availability tests, VS WebTests

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -67,6 +67,8 @@ The Network Profile builder (`networkProfile`) is used to define a network profi
 | vnet | Resource name of the virtual network to connect (if created in the same deployment). |
 | link_to_vnet | Resource name of an existing virtual network to connect. |
 | subnet | Name of the subnet in the virtual network where the container group should attach. |
+| ip_config | Name of the IP configuration and subnet in the virtual network where the container group should attach. |
+| add_ip_configs | Adds multiple IP configurations to connect the container group to multiple subnets. |
 
 #### Liveness Probe Builder
 The Liveness Probe builder (`liveness`) is used to define a liveness probe for a container instance to determine if it is healthy.

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -306,7 +306,7 @@ type NetworkProfile =
       Location : Location
       Dependencies : ResourceId Set
       ContainerNetworkInterfaceConfigurations :
-        {| IpConfigs : {| SubnetName : ResourceName |} list
+        {| IpConfigs : {| Name : ResourceName;  SubnetName : ResourceName |} list
         |} list
       VirtualNetwork : ResourceId
       Tags: Map<string,string> }
@@ -323,7 +323,7 @@ type NetworkProfile =
                                 {| ipConfigurations =
                                    containerIfConfig.IpConfigs
                                    |> List.mapi (fun index ipConfig ->
-                                    {| name = $"ipconfig{index + 1}"
+                                    {| name = (ipConfig.Name.IfEmpty $"ipconfig{index + 1}").Value
                                        properties =
                                         {| subnet =
                                             {| id =


### PR DESCRIPTION
The changes in this PR are as follows:

* Container Groups: Use `ip_config` to name the IP configuration for a container group's subnet.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.