### PR TITLE
Minor addition: Dynamic list of outputs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 Release Notes
 =============
-## vNext
+## 1.6.11
 * DNS Zone: Added configuration member of NameServers
+* Resource groups: Added outputs keyword
 
 ## 1.6.10
 * Azure SQL Server: geo_replicate parameter to geo-replicate the server databases

--- a/docs/content/api-overview/resources/resource-group.md
+++ b/docs/content/api-overview/resources/resource-group.md
@@ -15,6 +15,7 @@ The Resource Group builder is always the top-level element of your deployment. I
 | add_resource | Adds a resource to the template. |
 | add_resources | Adds a collection of resources to the template. |
 | output | Creates an output value that will be returned by the ARM template. Since Farmer does not require variables, and the only parameters supported are secure strings, these will typically be an ARM expressions that are generated at deployment-time, such as the publishing password of a web app or the fully-qualified domain name of a SQL instance etc. |
+| outputs | Create multiple outputs. |
 | add_tag | Add a tag to the resource group for top-level instances or to the deployment for nested resource groups |
 | add_tags | Add multiple tags to the resource group for top-level instances or to the deployment for nested resource groups |
 | name | the name of the resource group (only used for nested resource group deployments) |

--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -93,6 +93,11 @@ type ResourceGroupBuilder() =
         | Some outputValue -> this.Output(state, outputName, outputValue)
         | None -> state
 
+    [<CustomOperation "outputs">]
+    member __.Outputs (state, outputs) : ResourceGroupConfig =  { state with Outputs = Map.merge outputs state.Outputs }
+    member this.Outputs (state:ResourceGroupConfig, outputs) = this.Outputs(state, outputs |> List.map(fun (k:string, ResourceName r) -> k,r))
+    member this.Outputs (state:ResourceGroupConfig, outputs) = this.Outputs(state, outputs |> List.map(fun (k, a:ArmExpression) -> k,a.Eval()))
+
     /// Sets the default location of all resources.
     [<CustomOperation "location">]
     member __.Location (state, location) : ResourceGroupConfig = { state with Location = location }


### PR DESCRIPTION
If you create dynamic amount of resources, you'd probably want to add a dynamic list of `outputs`, for example:
```fsharp
let deployment = arm {
    location deployLocation
    add_resources virtualMachines
    outputs [
        virtualMachines
        |> List.filter(fun v -> v.PublicIp.IsSome)
        |> List.map(fun v -> $"ip-{v.Name.Value}", v.PublicIpId.Value.ArmExpression)
    ]
}
```

This minor addition adds the outputs-keyword.
