### PR TITLE
NameServers for DNS zone

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* DNS Zone: Added configuration member of NameServers
 
 ## 1.6.10
 * Azure SQL Server: geo_replicate parameter to geo-replicate the server databases

--- a/docs/content/api-overview/resources/dns.md
+++ b/docs/content/api-overview/resources/dns.md
@@ -125,6 +125,12 @@ In addition, each record builder has its own custom keywords:
 | retry_time | Sets the retry time for the record in seconds |
 | serial_number | Sets the serial number for the record |
 
+#### Configuration Members
+
+| Member | Purpose |
+|-|-|
+| NameServers | Gets the ARM expression path to the NameServers. When evaluated, will return a JSON array as string.
+
 #### Example
 ```fsharp
 #r @"./libs/Newtonsoft.Json.dll"

--- a/docs/content/api-overview/resources/dns.md
+++ b/docs/content/api-overview/resources/dns.md
@@ -98,7 +98,7 @@ In addition, each record builder has its own custom keywords:
 
 | Keyword | Purpose |
 |-|-|
-| add_nsd_names | Add NS values to this record set. |
+| add_nsd_names | Add NS values to this record set. (Subdomain NameServers) |
 
 #### PTR Record Builder Keywords
 

--- a/src/Farmer/Builders/Builders.Dns.fs
+++ b/src/Farmer/Builders/Builders.Dns.fs
@@ -404,11 +404,25 @@ type DnsSoaRecordBuilder() =
     /// Enable support for additional dependencies.
     interface IDependable<SoaRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
+type DnsZone =
+    static member getNameServers (resourceId:ResourceId) =
+        ArmExpression
+            .reference(zones, resourceId)
+            .Map(fun r -> r + ".nameServers")
+            .WithOwner(resourceId)
+        |> ArmExpression.string
+            
+    static member getNameServers (name:ResourceName, ?resourceGroup) =
+        DnsZone.getNameServers(ResourceId.create (zones, name, ?group = resourceGroup))
+        
 type DnsZoneConfig =
     { Name : ResourceName
       Dependencies : Set<ResourceId>
       ZoneType : DnsZoneType
       Records : DnsZoneRecordConfig list }
+
+    /// Gets the ARM expression path to the NameServers. When evaluated, will return a JSON array as string. E.g.: """["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."]"""
+    member this.NameServers = DnsZone.getNameServers this.Name
 
     interface IBuilder with
         member this.ResourceId = zones.resourceId this.Name

--- a/src/Farmer/Builders/Builders.Dns.fs
+++ b/src/Farmer/Builders/Builders.Dns.fs
@@ -181,7 +181,7 @@ type DnsNsRecordBuilder() =
     member _.RecordName(state:NsRecordProperties, name) = { state with Name = name }
     member this.RecordName(state:NsRecordProperties, name:string) = this.RecordName(state, ResourceName name)
 
-    /// Add NSD names
+    /// Add NSD names (Subdomain NameServers)
     [<CustomOperation "add_nsd_names">]
     member _.RecordNsdNames(state:NsRecordProperties, nsdNames) = { state with NsdNames = state.NsdNames @ nsdNames }
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -117,6 +117,11 @@ type ArmExpression =
         |> sprintf "concat(%s)"
         |> ArmExpression.create
 
+    static member string (value:ArmExpression) =
+        value.Value
+        |> sprintf "string(%s)"
+        |> ArmExpression.create
+
 type ResourceId with
     member this.ArmExpression =
         match this.Type.Type with

--- a/src/Tests/Dns.fs
+++ b/src/Tests/Dns.fs
@@ -213,4 +213,18 @@ let tests = testList "DNS Zone" [
         let tmAresourceId = jobj.SelectToken("resources[?(@.name=='farmer.com/tm-cname')].properties.targetResource.id") |> string
         Expect.equal tmAresourceId "[resourceId('Microsoft.Network/trafficManagerProfiles', 'my-tm')]" "Incorrect ID on target resource"
     }
+    test "DNS zone get NameServers" {
+        let zone =
+            dnsZone { name "farmer.com" }
+        
+        let template =
+            arm {
+                add_resources [ zone ]
+                output "nameservers" zone.NameServers
+            }
+        let expected = "[string(reference(resourceId('Microsoft.Network/dnsZones', 'farmer.com'), '2018-05-01').nameServers)]"
+        let jobj = template.Template |> Writer.toJson |> JObject.Parse
+        let nsArm = jobj.SelectToken("outputs.nameservers.value").ToString()
+        Expect.equal nsArm expected "Nameservers not gotten"
+    }
 ]


### PR DESCRIPTION
This PR closes #733

The changes in this PR are as follows:

* DNS Zone: Added configuration member of NameServers

You will need that when you deploy a DNS, as the nameservers has to be configured to take the DNS in use.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
