### PR TITLE
DNS zone support for referencing NS records from a subdomain's zone

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ Release Notes
 ## 1.6.11
 * Container Groups: Use `ip_config` to name the IP configuration for a container group's subnet.
 * DNS Zone: Added configuration member of NameServers
-* DNS Zone: Support for delegating a subdomain to another DNS Zone
+* DNS Zone: Support for delegating a subdomain to another DNS Zone with `add_nsd_reference`.
 * Resource groups: Added `outputs` keyword
 * Virtual Machine: Added configuration member PublicIpAddress
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 ## vNext
 * DNS Zone: Added configuration member of NameServers
+* DNS Zone: Support for delegating a subdomain to another DNS Zone
 
 ## 1.6.10
 * Azure SQL Server: geo_replicate parameter to geo-replicate the server databases

--- a/docs/content/api-overview/resources/dns.md
+++ b/docs/content/api-overview/resources/dns.md
@@ -99,6 +99,7 @@ In addition, each record builder has its own custom keywords:
 | Keyword | Purpose |
 |-|-|
 | add_nsd_names | Add NS values to this record set. (Subdomain NameServers) |
+| reference_nsd_names | Reference NS records from another DNS Zone. (Subdomain NameServers) |
 
 #### PTR Record Builder Keywords
 
@@ -133,8 +134,7 @@ In addition, each record builder has its own custom keywords:
 
 #### Example
 ```fsharp
-#r @"./libs/Newtonsoft.Json.dll"
-#r @"../../src/Farmer/bin/Debug/netstandard2.0/Farmer.dll"
+#r "nuget: Farmer"
 
 open Farmer
 open Farmer.Builders

--- a/docs/content/api-overview/resources/dns.md
+++ b/docs/content/api-overview/resources/dns.md
@@ -99,7 +99,7 @@ In addition, each record builder has its own custom keywords:
 | Keyword | Purpose |
 |-|-|
 | add_nsd_names | Add NS values to this record set. (Subdomain NameServers) |
-| reference_nsd_names | Reference NS records from another DNS Zone. (Subdomain NameServers) |
+| add_nsd_reference | Reference NS records from another DNS Zone. (Subdomain NameServers) |
 
 #### PTR Record Builder Keywords
 

--- a/src/Farmer/Builders/Builders.Dns.fs
+++ b/src/Farmer/Builders/Builders.Dns.fs
@@ -225,7 +225,7 @@ type DnsNsRecordBuilder() =
         | NsRecords.Records existingNsdNames ->
             { state with NsdNames = NsRecords.Records(existingNsdNames @ nsdNames) }
 
-    /// Ensure no nsd records were already added that will be overwritten byt he reference.
+    /// Ensure no nsd records were already added that will be overwritten by the reference.
     member private this.validateNsdReference (state:NsRecordProperties) =
         match state.NsdNames with
         | NsRecords.Records records when records <> [] ->

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1599,11 +1599,16 @@ module Dns =
           ExpireTime : int64 option
           MinimumTTL : int64 option }
 
+    [<RequireQualifiedAccess>]
+    type NsRecords =
+        | Records of string list
+        | SourceZone of ResourceId
+
     type DnsRecordType =
         | A of TargetResource : ResourceId option * ARecords : string list
         | AAAA of TargetResource : ResourceId option * AaaaRecords : string list
         | CName of TargetResource : ResourceId option * CNameRecord : string option
-        | NS of NsRecords : string list
+        | NS of NsRecords
         | PTR of PtrRecords : string list
         | TXT of TxtRecords : string list
         | MX of {| Preference : int; Exchange : string |} list

--- a/src/Tests/Dns.fs
+++ b/src/Tests/Dns.fs
@@ -250,7 +250,7 @@ let tests = testList "DNS Zone" [
                         name "subdomain"
                         link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "farmer.com")
                         ttl (int (TimeSpan.FromDays 2.).TotalSeconds)
-                        reference_nsd_names subdomainZone
+                        add_nsd_reference subdomainZone
                     }
                 ]
             }
@@ -268,7 +268,7 @@ let tests = testList "DNS Zone" [
                         name "subdomain"
                         link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "farmer.com")
                         ttl (int (TimeSpan.FromDays 2.).TotalSeconds)
-                        reference_nsd_names (ResourceId.create (Farmer.Arm.Dns.zones, ResourceName "subdomain.farmer.com", "res-group", fakeSubId))
+                        add_nsd_reference (ResourceId.create (Farmer.Arm.Dns.zones, ResourceName "subdomain.farmer.com", "res-group", fakeSubId))
                     }
                 ]
             }


### PR DESCRIPTION
The changes in this PR are as follows:

* DNS Zone: Support for delegating a subdomain to another DNS Zone

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.