### PR TITLE
add_resource option

### DIFF
--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -114,6 +114,18 @@ type ResourceGroupBuilder() =
     member _.AddResource (state:ResourceGroupConfig, input:IBuilder) = ResourceGroupBuilder.AddResources(state, input.BuildResources state.Location)
     member _.AddResource (state:ResourceGroupConfig, input:Builder) = ResourceGroupBuilder.AddResources(state, input state.Location)
     member _.AddResource (state:ResourceGroupConfig, input:IArmResource) = ResourceGroupBuilder.AddResources(state, [ input ])
+    member _.AddResource (state:ResourceGroupConfig, input:IBuilder option) = 
+        match input with
+        | Some inp -> ResourceGroupBuilder.AddResources(state, inp.BuildResources state.Location)
+        | None -> state
+    member _.AddResource (state:ResourceGroupConfig, input:Builder option) = 
+        match input with
+        | Some inp -> ResourceGroupBuilder.AddResources(state, inp state.Location)
+        | None -> state
+    member _.AddResource (state:ResourceGroupConfig, input:IArmResource option) = 
+        match input with
+        | Some inp -> ResourceGroupBuilder.AddResources(state, [ inp ])
+        | None -> state
 
     [<CustomOperation "add_resources">]
     member this.AddResources(state:ResourceGroupConfig, input:IBuilder list) =


### PR DESCRIPTION
ResourceGroup:
`add_resource` was missing option-overloads. There are already ones in `output`, so just copy&pasted those.

This is to make conditional resources simple to deploy.

For example:
```fsharp
let myProductionResource =
    match env with
    | "production" -> Some resource
    | "test" -> None

let deployment = arm {
    location deployLocation
    add_resource myProductionResource
}
```

