### PR TITLE
Allow an IArmResource list to be added to a resource group.

### DIFF
--- a/docs/content/api-overview/resources/resource-group.md
+++ b/docs/content/api-overview/resources/resource-group.md
@@ -14,6 +14,7 @@ The Resource Group builder is always the top-level element of your deployment. I
 | location | Sets the default location of all resources. |
 | add_resource | Adds a resource to the template. |
 | add_resources | Adds a collection of resources to the template. |
+| add_arm_resources | Adds a collection of lower-level IArmResources to the template. |
 | output | Creates an output value that will be returned by the ARM template. Since Farmer does not require variables, and the only parameters supported are secure strings, these will typically be an ARM expressions that are generated at deployment-time, such as the publishing password of a web app or the fully-qualified domain name of a SQL instance etc. |
 | outputs | Create multiple outputs. |
 | add_tag | Add a tag to the resource group for top-level instances or to the deployment for nested resource groups |
@@ -33,6 +34,9 @@ let deployment =
         // Assume myStorageAccount and myWebApp have been defined...
         add_resource myStorageAccount
         add_resource myWebApp
+
+        // Assuming the role assignments have been defined....
+        add_arm_resources [ roleAssignment1; roleAssignment2 ]
 
         add_resource (resourceGroup {
             name "nestedResourceGroup"

--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -119,7 +119,9 @@ type ResourceGroupBuilder() =
     member this.AddResources(state:ResourceGroupConfig, input:IBuilder list) =
         let resources = input |> List.collect(fun i -> i.BuildResources state.Location)
         ResourceGroupBuilder.AddResources(state, resources)
-    member this.AddResources(state:ResourceGroupConfig, input:IArmResource list) =
+
+    [<CustomOperation "add_arm_resources">]
+    member this.AddArmResources(state:ResourceGroupConfig, input:IArmResource list) =
         ResourceGroupBuilder.AddResources(state, input)
 
     [<CustomOperation "depends_on">]

--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -119,6 +119,8 @@ type ResourceGroupBuilder() =
     member this.AddResources(state:ResourceGroupConfig, input:IBuilder list) =
         let resources = input |> List.collect(fun i -> i.BuildResources state.Location)
         ResourceGroupBuilder.AddResources(state, resources)
+    member this.AddResources(state:ResourceGroupConfig, input:IArmResource list) =
+        ResourceGroupBuilder.AddResources(state, input)
 
     [<CustomOperation "depends_on">]
     member this.AddDepenencies(state:ResourceGroupConfig, dependencies: ResourceId list) =


### PR DESCRIPTION
The changes in this PR are as follows:

* Added an IArmResource list accepting function to the Resource Group builder

The motivation for the change is that I wanted to add a list of role assignments to a resource group.