### PR TITLE
ACI fix to generate parameter for initContainer environment variables

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.13
+* Container Groups: Fix to generate parameters for secure environment variables on `initContainers`.
+
 ## 1.6.12
 * Custom FarmerException raised for all exceptions.
 * Dashboards: Changed the API to use non-anonymous record.

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -119,6 +119,11 @@ type ContainerGroup =
                     match envVar.Value with
                     | SecureEnvValue p -> p
                     | EnvValue _ -> ()
+            for container in this.InitContainers do
+                for envVar in container.EnvironmentVariables do
+                    match envVar.Value with
+                    | SecureEnvValue p -> p
+                    | EnvValue _ -> ()
             for volume in this.Volumes do
                 match volume.Value with
                 | Volume.Secret secrets ->

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -300,6 +300,25 @@ let tests = testList "Container Group" [
         Expect.hasLength deployment.Template.Parameters 1 "Should have a secure parameter for environment variable"
         Expect.equal (deployment.Template.Parameters.Head.ArmExpression.Eval()) "[parameters('secret-foo')]" "Generated incorrect secure parameter."
     }
+    test "Secure environment variables are generated for init containers" {
+        let cg = containerGroup {
+            name "myapp"
+            add_init_containers [
+                initContainer {
+                    name "nginx"
+                    image "nginx:1.17.6-alpine"
+                    env_vars [
+                        EnvVar.createSecure "foo" "secret-init"
+                    ]
+                }
+            ]
+        }
+        let deployment = arm {
+            add_resource cg
+        }
+        Expect.hasLength deployment.Template.Parameters 1 "Should have a secure parameter for initContainer environment variable"
+        Expect.equal (deployment.Template.Parameters.Head.ArmExpression.Eval()) "[parameters('secret-init')]" "Generated incorrect secure parameter."
+    }
     test "Secure parameters for secret volume is generated correctly" {
         let cg = containerGroup {
             name "myapp"


### PR DESCRIPTION
The changes in this PR are as follows:

* Container Groups: Fix to generate parameters for secure environment variables on `initContainers`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.