### PR TITLE
Support for adding access policies on an existing key vault

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.6.13
 * Container Groups: Fix to generate parameters for secure environment variables on `initContainers`.
+* Key Vaults: Support for adding access policies on an existing key vault with `keyVaultAddPolicies`.
 
 ## 1.6.12
 * Custom FarmerException raised for all exceptions.

--- a/docs/content/api-overview/resources/keyvault.md
+++ b/docs/content/api-overview/resources/keyvault.md
@@ -6,11 +6,11 @@ weight: 11
 ---
 
 ### Overview
-The KeyVault package contains *three* builders, for the different components used by KeyVault: One for **access policies**, one for **secrets**, and one for the overall **keyvault** container.
+The KeyVault package contains *four* builders, for the different components used by KeyVault: One for **access policies**, one for **secrets**, one for the overall **keyvault** container, and one for **adding access policies** to an existing key vault.
 
 * KeyVault (`Microsoft.KeyVault/vaults`)
 * Secrets (`Microsoft.KeyVault/vaults/secrets`)
-
+* AccessPolicies (`Microsoft.KeyVault/vaults/accessPolicies`)
 
 #### Secret Builder
 The secret builder allows you to store secrets into key vault. Values for a secret are passed by Secure String parameters.
@@ -73,6 +73,15 @@ The Key Vault builder contains access policies, secrets, and configuration infor
 | add_secrets | Adds multiple secrets to the vault. This can either be "full" secret configs created using the Secret Builder, string literal values which represents the parameter name. |
 | add_tag | Adds a tag to the key vault. |
 | add_tags | Adds multiple tags to the key vault. |
+
+#### Key Vault Add Access Policy Builder (`keyVaultAddPolicies`)
+As applications grow, more components often need access to a key vault. The `keyVaultAddPolicies` builder is used to add new access policies to an existing key vault without the need to redeploy the full key vault, potentially changing existing access.
+
+| Keyword | Purpose |
+|-|-|
+| key_vault | Sets the resource Id or a builder for the existing key vault where the policies should be added. |
+| add_access_policies | A list of policies to add to the key vault. |
+| tenant_id | Used if granting access to users or service principals from another tenant. |
 
 #### Configuration Members
 

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -376,11 +376,9 @@ let keyVault = KeyVaultBuilder()
 
 /// Configuration for adding access policies to an existing key vault.
 type KeyVaultAddPoliciesConfig =
-    {
-        KeyVault : LinkedResource option
-        TenantId : string option
-        AccessPolicies : AccessPolicyConfig list
-    }
+    { KeyVault : LinkedResource option
+      TenantId : string option
+      AccessPolicies : AccessPolicyConfig list }
     interface IBuilder with
         member this.BuildResources _ =
             match this.KeyVault with
@@ -410,11 +408,9 @@ type KeyVaultAddPoliciesConfig =
 /// Builder for adding policies to an existing key vault.
 type KeyVaultAddPoliciesBuilder() =
     member _.Yield _ =
-        {
-            KeyVault = None
-            TenantId = None
-            AccessPolicies = []
-        }
+        { KeyVault = None
+          TenantId = None
+          AccessPolicies = [] }
     /// The key vault where the policies should be added.
     [<CustomOperation "key_vault">]
     member _.KeyVault (state:KeyVaultAddPoliciesConfig, kv:Vault) =

--- a/src/Tests/KeyVault.fs
+++ b/src/Tests/KeyVault.fs
@@ -158,9 +158,7 @@ let tests = testList "KeyVault" [
             }
         let template =
             arm {
-                add_resources [
-                    additionalPolicies
-                ]
+                add_resource additionalPolicies
             }
         let jobj = JObject.Parse(template.Template |> Writer.toJson)
         let name = jobj.SelectToken("resources[0].name")
@@ -188,9 +186,7 @@ let tests = testList "KeyVault" [
                 }
             let template =
                 arm {
-                    add_resources [
-                        additionalPolicies
-                    ]
+                    add_resource additionalPolicies
                 }
             template |> Writer.quickWrite |> ignore
         ) "Should have failed to build the key vault policy addition resource"


### PR DESCRIPTION
The changes in this PR are as follows:

* Key Vaults: Support for adding access policies on an existing key vault with `keyVaultAddPolicies`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.