### PR TITLE
Simplify AKS builder usage with additional defaults.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.6.13
 * Container Groups: Fix to generate parameters for secure environment variables on `initContainers`.
+* Container Service (AKS): Simplify `aks` builder with defaults for node pool and DNS prefix.
 
 ## 1.6.12
 * Custom FarmerException raised for all exceptions.

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -64,8 +64,8 @@ The CNI builder (`azureCniNetworkProfile`) creates Azure CNI network profiles on
 
 #### Basic Example
 
-The simplest cluster uses managed identity and default settings for 
-the node pool (size of 3).
+The simplest cluster uses a system assigned managed identity and 
+default settings for the node pool (size of 3).
 
 ```fsharp
 open Farmer
@@ -74,8 +74,6 @@ open Farmer.ContainerService
 
 let myAks = aks {
     name "aks-cluster"
-    system_identity
-    linux_profile "azureuser" "public-key-here"
     service_principal_use_msi
 }
 ```

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -62,12 +62,26 @@ The CNI builder (`azureCniNetworkProfile`) creates Azure CNI network profiles on
 | service_cidr | Sets the service cidr to a network other than the default 10.224.0.0/16. |
 | load_balancer_sku | SKU for the Load Balancer - defaults to 'Standard' |
 
-#### Example
+#### Basic Example
+
+The simplest cluster uses managed identity and default settings for 
+the node pool (size of 3).
+
 ```fsharp
 open Farmer
 open Farmer.Builders
 open Farmer.ContainerService
 
+let myAks = aks {
+    name "aks-cluster"
+    system_identity
+    linux_profile "azureuser" "public-key-here"
+    service_principal_use_msi
+}
+```
+
+#### Customizing agent pool and network profile
+```fsharp
 let myAks = aks {
     name "k8s-cluster"
     dns_prefix "testaks"
@@ -78,12 +92,11 @@ let myAks = aks {
         }
     ]
     linux_profile "aksuser" "public-key-here"
-    service_principal_client_id "some-spn-client-id"
+    service_principal_use_msi
     network_profile (
         azureCniNetworkProfile {
             service_cidr "10.250.0.0/16"
         }
     )
 }
-
 ```

--- a/src/Farmer/Arm/ContainerService.fs
+++ b/src/Farmer/Arm/ContainerService.fs
@@ -67,7 +67,7 @@ type ManagedCluster =
                        {| agentPoolProfiles =
                            this.AgentPoolProfiles
                            |> List.mapi (fun idx agent ->
-                               {| name = if agent.Name = ResourceName.Empty then $"{this.Name.Value}-agent-pool{idx}"
+                               {| name = if agent.Name = ResourceName.Empty then $"nodepool{idx + 1}"
                                          else agent.Name.Value.ToLowerInvariant ()
                                   count = agent.Count
                                   maxPods = agent.MaxPods |> Option.toNullable

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -67,7 +67,7 @@ type AksConfig =
               Location = location
               DnsPrefix =
                   if String.IsNullOrWhiteSpace this.DnsPrefix then
-                      String.Format("{0}-{1:x}", this.Name.Value, this.Name.Value.GetHashCode())
+                      $"{this.Name.Value}-%x{this.Name.Value.GetHashCode()}"
                   else this.DnsPrefix
               EnableRBAC = this.EnableRBAC
               Identity = this.Identity

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -1,10 +1,10 @@
 [<AutoOpen>]
 module Farmer.Builders.ContainerService
 
+open System
 open Farmer
-open Farmer.Arm.ContainerService
+open Farmer.Arm
 open Farmer.Identity
-open Farmer.LoadBalancer
 open Farmer.Vm
 
 type AgentPoolConfig =
@@ -17,7 +17,19 @@ type AgentPoolConfig =
       VmSize : VMSize
       VirtualNetworkName : ResourceName option
       SubnetName : ResourceName option }
-
+    static member Default = {
+            Name = ResourceName.Empty
+            Count = 1
+            // Default for CNI is 30, Kubenet default is 110
+            // https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#maximum-pods-per-node
+            MaxPods = None
+            Mode = System
+            OsDiskSize = 0<Gb>
+            OsType = OS.Linux
+            VirtualNetworkName = None
+            SubnetName = None
+            VmSize = Standard_DS2_v2
+        }
 type ApiServerAccessProfileConfig =
     { AuthorizedIPRanges : string list
       EnablePrivateCluster : bool option }
@@ -53,11 +65,16 @@ type AksConfig =
             // VM itself
             { Name = this.Name
               Location = location
-              DnsPrefix = this.DnsPrefix
+              DnsPrefix =
+                  if String.IsNullOrWhiteSpace this.DnsPrefix then
+                      String.Format("{0}-{1:x}", this.Name.Value, this.Name.Value.GetHashCode())
+                  else this.DnsPrefix
               EnableRBAC = this.EnableRBAC
               Identity = this.Identity
               AgentPoolProfiles =
-                this.AgentPools
+                match this.AgentPools with
+                | [] -> [ { AgentPoolConfig.Default with Count = 3 } ]
+                | agentPools -> agentPools
                 |> List.map (fun agentPool ->
                     {| Name = agentPool.Name
                        Count = agentPool.Count
@@ -102,19 +119,7 @@ type AksConfig =
         ]
 
 type AgentPoolBuilder() =
-    member _.Yield _ =
-        { Name = ResourceName.Empty
-          Count = 1
-          // Default for CNI is 30, Kubenet default is 110
-          // https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#maximum-pods-per-node
-          MaxPods = None
-          Mode = System
-          OsDiskSize = 0<Gb>
-          OsType = OS.Linux
-          VirtualNetworkName = None
-          SubnetName = None
-          VmSize = Standard_DS2_v2
-        }
+    member _.Yield _ = AgentPoolConfig.Default
     /// Sets the name of the agent pool.
     [<CustomOperation "name">]
     member _.Name(state:AgentPoolConfig, name) = { state with Name = ResourceName name }
@@ -242,9 +247,7 @@ type AksBuilder() =
     [<CustomOperation "enable_rbac">]
     member _.EnableRBAC(state:AksConfig) = { state with EnableRBAC = true }
     /// Sets the managed identity on this cluster.
-    [<CustomOperation "add_identity">]
-    member _.AddIdentity(state:AksConfig, identity:UserAssignedIdentity) = { state with Identity = state.Identity + identity }
-    member this.AddIdentity(state, identity:UserAssignedIdentityConfig) = this.AddIdentity(state, identity.UserAssignedIdentity)
+    interface IIdentity<AksConfig> with member _.Add state updater = { state with Identity = updater state.Identity }
     /// Adds agent pools to the AKS cluster.
     [<CustomOperation "add_agent_pools">]
     member _.AddAgentPools(state:AksConfig, pools) = { state with AgentPools = state.AgentPools @ pools }

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -17,19 +17,18 @@ type AgentPoolConfig =
       VmSize : VMSize
       VirtualNetworkName : ResourceName option
       SubnetName : ResourceName option }
-    static member Default = {
-            Name = ResourceName.Empty
-            Count = 1
-            // Default for CNI is 30, Kubenet default is 110
-            // https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#maximum-pods-per-node
-            MaxPods = None
-            Mode = System
-            OsDiskSize = 0<Gb>
-            OsType = OS.Linux
-            VirtualNetworkName = None
-            SubnetName = None
-            VmSize = Standard_DS2_v2
-        }
+    static member Default =
+        { Name = ResourceName.Empty
+          Count = 1
+          // Default for CNI is 30, Kubenet default is 110
+          // https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#maximum-pods-per-node
+          MaxPods = None
+          Mode = System
+          OsDiskSize = 0<Gb>
+          OsType = OS.Linux
+          VirtualNetworkName = None
+          SubnetName = None
+          VmSize = Standard_DS2_v2 }
 type ApiServerAccessProfileConfig =
     { AuthorizedIPRanges : string list
       EnablePrivateCluster : bool option }
@@ -73,8 +72,10 @@ type AksConfig =
               Identity = this.Identity
               AgentPoolProfiles =
                 match this.AgentPools with
-                | [] -> [ { AgentPoolConfig.Default with Count = 3 } ]
-                | agentPools -> agentPools
+                | [] ->
+                    [ { AgentPoolConfig.Default with Count = 3 } ]
+                | agentPools ->
+                    agentPools
                 |> List.map (fun agentPool ->
                     {| Name = agentPool.Name
                        Count = agentPool.Count

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -234,8 +234,8 @@ type AksBuilder() =
         | BasicLoadBalancer, PrivateClusterEnabled ->
             invalidArg "sku" "Private cluster requires a standard SKU load balancer."
         | _ -> ()
-        if System.String.IsNullOrWhiteSpace config.ServicePrincipalClientID then
-            raiseFarmer "Missing ServicePrincipalClientID on ManagedCluster."
+        if String.IsNullOrWhiteSpace config.ServicePrincipalClientID then
+            raiseFarmer "Missing ServicePrincipalClientID on ManagedCluster - specify 'service_principal_use_msi' or 'service_principal_client_id' to assign one."
         config
     /// Sets the name of the AKS cluster.
     [<CustomOperation "name">]


### PR DESCRIPTION
This PR closes #744 

The changes in this PR are as follows:

* Container Service (AKS): Simplify `aks` builder with defaults for node pool and DNS prefix.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.