### PR TITLE
Allow deploying app slots without deploying the production slot

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 1.6.14
+* WebApp: allow disabling deployments to the production slot of multi-slot apps
+* Functions: allow disabling deployments to the production slot of multi-slot apps
+
 ## 1.6.13
 * Container Groups: Fix to generate parameters for secure environment variables on `initContainers`.
 * Alerts: Initial support for Alerts

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -55,6 +55,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | add_slot | Adds a deployment slot to the app |
 | Web App | add_slots | Adds multiple deployment slots to the app |
 | Web App | health_check_path | Sets the path to your functions health check endpoint, which Azure load balancers will ping to determine which instances are healthy.|
+| Web App | deploy_production_slot | Enables or disables deploying the production slot of a multi-slot webapp. Disabling this is required to enable zero-downtime deployments using Azure app slots. |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/samples/scripts/webapp-storage.fsx
+++ b/samples/scripts/webapp-storage.fsx
@@ -1,29 +1,26 @@
-#r "nuget:Farmer"
+#r @"..\..\src\Farmer\bin\Debug\net5.0\Farmer.dll"
+//#r "nuget:Farmer"
 
 open Farmer
 open Farmer.Builders
 
-let myStorage = storageAccount {
-    name "mystorage"
-    sku Storage.Sku.Standard_LRS
-    add_lifecycle_rule "cleanup" [ Storage.DeleteAfter 7<Days> ] Storage.NoRuleFilters
-    add_lifecycle_rule "test" [ Storage.DeleteAfter 1<Days>; Storage.DeleteAfter 2<Days>; Storage.ArchiveAfter 1<Days>; ] [ "foo/bar" ]
+let deploySlot = appSlot{
+    setting "originally" "deploy"
 }
 
 let myWebApp = webApp {
-    name "mysuperwebapp"
+    name "rsp-test-app"
     sku WebApp.Sku.S1
     app_insights_off
-    setting "storage_key" myStorage.Key
+    add_slot deploySlot
+    deploy_production_slot Disabled
 }
 
 let deployment = arm {
+    name "rsp-test2"
     location Location.NorthEurope
-    add_resource myStorage
     add_resource myWebApp
-    output "storage_key" myStorage.Key
-    output "web_password" myWebApp.PublishingPassword
 }
 
 deployment
-|> Deploy.execute "my-resource-group-name" Deploy.NoParameters
+|> Deploy.execute "rsp-test2" Deploy.NoParameters

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -276,12 +276,11 @@ type FunctionsConfig =
             | None ->
                 ()
 
-            if Map.isEmpty this.CommonWebConfig.Slots then
+            if Map.isEmpty this.CommonWebConfig.Slots || this.CommonWebConfig.DeployProductionSlot then
                 site
-            else
-                { site with AppSettings = Map.empty }
-                for (_, slot) in this.CommonWebConfig.Slots |> Map.toSeq do
-                    slot.ToSite site
+
+            for (_, slot) in this.CommonWebConfig.Slots |> Map.toSeq do
+                slot.ToSite (this.CommonWebConfig.DeployProductionSlot) site
         ]
 
 type FunctionsBuilder() =
@@ -301,7 +300,8 @@ type FunctionsBuilder() =
               Slots = Map.empty
               WorkerProcess = None
               ZipDeployPath = None
-              HealthCheckPath = None }
+              HealthCheckPath = None
+              DeployProductionSlot = true}
           StorageAccount = derived (fun config ->
             let storage = config.Name.ResourceName.Map (sprintf "%sstorage") |> sanitiseStorage |> ResourceName
             storageAccounts.resourceId storage)

--- a/src/Tests/Helpers.fs
+++ b/src/Tests/Helpers.fs
@@ -4,6 +4,13 @@ module TestHelpers
 open Farmer
 open Microsoft.Rest.Serialization
 
+[<CLIMutable>]
+type GenericArmResource = 
+    { ``type``: string
+      name: string
+      dependsOn: string[]
+      location: string }
+
 let createSimpleDeployment parameters =
     { Location = Location.NorthEurope
       PostDeployTasks = []


### PR DESCRIPTION
This PR closes #750

The changes in this PR are as follows:

* The production app slot can now take settings
* Added `deploy_production_slot` operator to webApp & functions to enabled disabling production slot deployment

On of the main purposes of slots in webapps and functions is to enable zero-downtime deployments. This is achieved by making all your changes to the staging slot and then swapping that slot with the production slot in a way which does not cause any downtime in the production slot. However, this acting of swapping effectively changes the production infrastructure in a way which no long matches the ARM template it was generated from. This PR adds the option to exclude the production slot from the ARM template and, in so doing, prevents the production slot being affected directly. This in turn permits the zero-downtime deployment model which is desirable.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
