### PR TITLE
Dashboard webtest results: ResourceGroup fix

### DIFF
--- a/src/Farmer/Arm/Dashboard.fs
+++ b/src/Farmer/Arm/Dashboard.fs
@@ -66,7 +66,7 @@ let generateVirtualMachinePart (vmId:ResourceId) = {
 /// Generates a webtest part
 let generateWebtestResultPart (applicationInsightsName:string) = {
     ``type`` = "Extension/AppInsightsExtension/PartType/AllWebTestsResponseTimeFullGalleryAdapterPart"
-    inputs = [ {| name = "ComponentId"; value = {| Name = applicationInsightsName; SubscriptionId = "[ subscription().subscriptionId ]"; ResourceGroup = "[ resourceGroup().id ]" |} |} ]
+    inputs = [ {| name = "ComponentId"; value = {| Name = applicationInsightsName; SubscriptionId = "[ subscription().subscriptionId ]"; ResourceGroup = "[ resourceGroup().name ]" |} |} ]
     settings = null
     filters = null
     asset = { idInputName = "ComponentId"; ``type`` = "ApplicationInsights" }


### PR DESCRIPTION
This fixes incorrect ARM expression in dashboard webtest results.

There are few other locations in Farmer source-code where `resourceGroup().id` is used and I expect most of them actually should be checked and probably should do `resourceGroup().name` as the resourcegroup id seems not to work in ARM-templates so well. 

But I don't know those cases so I don't want to touch the code there, but this one I do know and it should be name and not id.
