### PR TITLE
Allow traffic manager endpoints without weight or priority

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 Release Notes
 =============
+
+## 1.6.16
+* Traffic Manager: allow priority and weight to be optional for endpoints.
+
 ## 1.6.15
 * Key Vaults: Allow deploying standalone secrets without a KeyVault in the same deployment
 * WebApp/Functions: no longer overwrites production slot settings when using a multi-slot deploy

--- a/src/Farmer/Arm/TrafficManager.fs
+++ b/src/Farmer/Arm/TrafficManager.fs
@@ -12,8 +12,8 @@ type Endpoint =
     { Name : ResourceName
       Status: FeatureFlag
       Target : EndpointTarget
-      Weight: int
-      Priority: int
+      Weight: int option
+      Priority: int option
       Location: Location option }
     member this.JsonModel =
         {| name = this.Name.Value
@@ -23,8 +23,8 @@ type Endpoint =
                 | Website _ -> azureEndpoints.Type
            properties =
                 {| endpointStatus = this.Status.ArmValue
-                   weight = this.Weight
-                   priority = this.Priority
+                   weight = this.Weight |> Option.toNullable
+                   priority = this.Priority |> Option.toNullable
                    endpointLocation =
                         this.Location
                         |> Option.map (fun l -> l.ArmValue)

--- a/src/Farmer/Builders/Builders.TrafficManager.fs
+++ b/src/Farmer/Builders/Builders.TrafficManager.fs
@@ -12,8 +12,8 @@ type EndpointConfig =
     { Name : ResourceName
       Status : FeatureFlag
       Target : EndpointTarget
-      Weight : int
-      Priority : int
+      Weight : int option
+      Priority : int option
       Dependencies: Set<ResourceId> }
 
 type TrafficManagerConfig =
@@ -58,8 +58,8 @@ type EndpointBuilder() =
         { Name = ResourceName.Empty
           Status = Enabled
           Target = EndpointTarget.Website ResourceName.Empty
-          Weight = 1
-          Priority = 1
+          Weight = None
+          Priority = None
           Dependencies = Set.empty }
 
     member _.Run (state:EndpointConfig) =
@@ -72,7 +72,7 @@ type EndpointBuilder() =
 
     /// Sets the weight of the Endpoint
     [<CustomOperation "weight">]
-    member _.Weight(state:EndpointConfig, weight) = { state with Weight = weight }
+    member _.Weight(state:EndpointConfig, weight) = { state with Weight = Some weight }
 
     /// Disables the Endpoint
     [<CustomOperation "disable_endpoint">]
@@ -84,7 +84,7 @@ type EndpointBuilder() =
 
     /// Sets the priority of the Endpoint
     [<CustomOperation "priority">]
-    member _.Priority(state:EndpointConfig, priority) = { state with Priority = priority }
+    member _.Priority(state:EndpointConfig, priority) = { state with Priority = Some priority }
 
     /// Sets the target of the Endpoint to a web app
     [<CustomOperation "target_webapp">]


### PR DESCRIPTION
The changes in this PR are as follows:

* Traffic Manager: allow priority and weight to be optional for endpoints.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.