### PR TITLE
Replicated database itself added to geo-replica dependency

### DIFF
--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -130,7 +130,7 @@ type SqlAzureConfig =
 
                     {| apiVersion = "2021-02-01-preview"
                        location = replica.Location.ArmValue
-                       dependsOn = [ Farmer.ResourceId.create(Farmer.Arm.Sql.servers, replicaServerName.ResourceName).Eval(); ]
+                       dependsOn = [ Farmer.ResourceId.create(Farmer.Arm.Sql.servers, replicaServerName.ResourceName).Eval(); primaryDatabaseFullId ]
                        name = $"{replicaServerName.ResourceName.Value}/{database.Name.Value + replica.NameSuffix}"
                        ``type`` = Farmer.Arm.Sql.databases.Type
                        sku =


### PR DESCRIPTION
Sorry to not notice this earlier but I was replicating existing databases, not new ones.
The changes in this PR are as follows:

* Geo-replicated database dependency added to the geo-replica deployment.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.

Yes, tested: Without this it failed on a new database, and with it, the deployment went through. This is a minor fix, shouldn't need anything else.