### PR TITLE
Dashboard add_monitor_chart minor fix

### DIFF
--- a/src/Farmer/Arm/Dashboard.fs
+++ b/src/Farmer/Arm/Dashboard.fs
@@ -98,7 +98,7 @@ let generateMonitorChartPart (chartProperties : MonitorChartParameters) = {
     inputs = [ box <| {| name = "sharedTimeRange"; isOptional = true |};
                box <| {| name = "options"
                          value = {| v2charts = true
-                                    charts = [ chartProperties.chartInputs ] |} |} ]
+                                    charts = chartProperties.chartInputs |} |} ]
     settings = {| content = {| options = {| chart = chartProperties.chartSettings |} |} |}
     filters = chartProperties.filters
     asset = Unchecked.defaultof<LensAsset>


### PR DESCRIPTION
Dashboard add_monitor_chart minor fix:
Instead of `obj list list` use just `obj list` when generating json.

The `add_monitor_chart` did work already when deployed, but it crashed the deployment if you do `Deploy.whatIf`.

Annoyingly the deployment crashed to weird error:
`Farmer.FarmerException: ERROR: object of type 'NoneType' has no len()`
...which is not well known by Google.
