### PR TITLE
Support subscriptionId on nested deployments

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.6.17
 * Container Groups: Use an ARM expression to populate a secure environment variable.
+* Resource Groups: Specify the target subscription for nested deployments.
 
 ## 1.6.16
 * Traffic Manager: allow priority and weight to be optional for endpoints.

--- a/docs/content/api-overview/resources/resource-group.md
+++ b/docs/content/api-overview/resources/resource-group.md
@@ -20,6 +20,7 @@ The Resource Group builder is always the top-level element of your deployment. I
 | add_tag | Add a tag to the resource group for top-level instances or to the deployment for nested resource groups |
 | add_tags | Add multiple tags to the resource group for top-level instances or to the deployment for nested resource groups |
 | name | the name of the resource group (only used for nested resource group deployments) |
+| subscription_id | On nested resource group deployments, specify the target subscription. |
 
 #### Utilities
 * The `createResourceGroup` function is used to define a resource group deployment resource by name and location, useful when deploying to a subscription.

--- a/src/Farmer/Aliases.fs
+++ b/src/Farmer/Aliases.fs
@@ -1,4 +1,4 @@
 ﻿[<AutoOpen>]
 module Farmer.Aliases
 
-let arm = Farmer.Builders.ResourceGroup.resourceGroup
+let arm = Farmer.Builders.ResourceGroup.DeploymentBuilder ()

--- a/src/Farmer/Arm/ResourceGroup.fs
+++ b/src/Farmer/Arm/ResourceGroup.fs
@@ -16,6 +16,7 @@ type ResourceGroupDeployment =
       Outputs : Map<string, string>
       Location : Location
       Resources : IArmResource list
+      SubscriptionId : System.Guid option
       Mode: DeploymentMode
       Tags: Map<string,string> }
     member this.ResourceId = resourceGroupDeployment.resourceId this.Name
@@ -45,6 +46,7 @@ type ResourceGroupDeployment =
             {| resourceGroupDeployment.Create(this.Name, this.Location, dependsOn = this.Dependencies, tags = this.Tags ) with
                 location = null // location is not supported for nested resource groups
                 resourceGroup = this.Name.Value
+                subscriptionId = this.SubscriptionId |> Option.map string<System.Guid> |> Option.toObj
                 properties = 
                     {|  template = TemplateGeneration.processTemplate this.Template
                         parameters = 

--- a/src/Tests/Template.fs
+++ b/src/Tests/Template.fs
@@ -273,4 +273,18 @@ let tests = testList "Template" [
 
         Expect.equal nestedParams.["password-for-vm"] "[parameters('password-for-vm')]" "Parameters not correctly proxied to nested template"
     }
+    test "Can specify subscriptionId on nested deployment" {
+        let inner1 = resourceGroup { 
+            name "inner1"
+            add_resource (vm { name "vm"; username "foo" })
+            subscription_id "0c3054fb-f576-4458-acff-f2c29c4123e4"
+        }
+        let deployment = arm {
+            add_resource inner1
+        }
+        let json = deployment.Template |> Writer.toJson
+        let jobj = JObject.Parse json
+        let actual = jobj.SelectToken("$.resources[?(@.name=='inner1')].subscriptionId") |> string
+        Expect.equal actual "0c3054fb-f576-4458-acff-f2c29c4123e4" "Nested deployment didn't have correct subscriptionId"
+    }
 ]


### PR DESCRIPTION
The changes in this PR are as follows:

* Resource Groups: support for specifying the target subscription for nested deployments.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.