### PR TITLE
Update ArmExpression expression

### DIFF
--- a/docs/content/contributing/outputs-and-expressions.md
+++ b/docs/content/contributing/outputs-and-expressions.md
@@ -19,7 +19,7 @@ let buildKey accountName : ArmExpression =
         $"concat('DefaultEndpointsProtocol=https;AccountName={accountName};AccountKey=', listKeys('{accountName}', '2017-10-01').keys[0].value)"
 
     // Wrap the raw value in an ARM Expression and return it
-    ArmExpression rawValue
+    ArmExpression.create rawValue
 ```
 
 Notice that you do *not* wrap the expression in square brackets [ ]; Farmer will do this when writing out the ARM template.


### PR DESCRIPTION
It appears the shape of this API has been changed to use a helper function.

![msedge_mvTbBd2aWh](https://user-images.githubusercontent.com/23742214/136989509-ca7d13a4-132a-4c3e-ba5e-84b0f26cc801.png)

This PR closes #

The changes in this PR are as follows:

* Update ArmExpression expression

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Small update to documentation