### PR TITLE
CDN rules - Do not enforce setting CacheDuration for BypassCache

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-## v-next
+## 1.6.20
 * CDN rules: Only make CacheDuration required for Override and SetIfMissing and not BypassCache when creating cache_expiration action
 
 ## 1.6.19

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## v-next
+* CDN rules: Only make CacheDuration required for Override and SetIfMissing and not BypassCache when creating cache_expiration action
+
 ## 1.6.19
 * ExpressRoute: create authorization keys on newly created circuits.
 * ServiceBus: Allow Service Bus Queues/Topics/Subscriptions to be linked to unmanaged namespaces

--- a/src/Farmer/Arm/Cdn.fs
+++ b/src/Farmer/Arm/Cdn.fs
@@ -243,7 +243,7 @@ module CdnRule =
           HttpHeaderValue: string }
 
     type Action =
-        | CacheExpiration of {| CacheBehaviour: CacheBehaviour ;|}
+        | CacheExpiration of {| CacheBehaviour: CacheBehaviour |}
         | CacheKeyQueryString of {| Behaviour: QueryStringCacheBehavior ; Parameters: string |}
         | ModifyRequestHeader of ModifyHeader
         | ModifyResponseHeader of ModifyHeader

--- a/src/Farmer/Arm/Cdn.fs
+++ b/src/Farmer/Arm/Cdn.fs
@@ -243,7 +243,7 @@ module CdnRule =
           HttpHeaderValue: string }
 
     type Action =
-        | CacheExpiration of {| CacheBehaviour: CacheBehaviour ; CacheDuration: TimeSpan option |}
+        | CacheExpiration of {| CacheBehaviour: CacheBehaviour ;|}
         | CacheKeyQueryString of {| Behaviour: QueryStringCacheBehavior ; Parameters: string |}
         | ModifyRequestHeader of ModifyHeader
         | ModifyResponseHeader of ModifyHeader
@@ -276,13 +276,14 @@ module CdnRule =
           
             match this with
             | CacheExpiration a ->
+                let armValue = a.CacheBehaviour.ArmValue
                 map
                     "CacheExpiration"
                     "#Microsoft.Azure.Cdn.Models.DeliveryRuleCacheExpirationActionParameters"
                     (Map.empty<_, obj>
-                        .Add("cacheBehavior", a.CacheBehaviour.ArmValue)
+                        .Add("cacheBehavior", armValue.Behaviour)
                         .Add("cacheType", "All")
-                        .Add("cacheDuration", a.CacheDuration |> Option.map (fun d -> d.ToString "d\.hh\:mm\:ss") |> Option.toObj ))
+                        .Add("cacheDuration", armValue.CacheDuration |> Option.map (fun d -> d.ToString "d\.hh\:mm\:ss") |> Option.toObj ))
             | CacheKeyQueryString a ->
                 map
                     "CacheKeyQueryString"

--- a/src/Farmer/Builders/Builders.Cdn.fs
+++ b/src/Farmer/Builders/Builders.Cdn.fs
@@ -261,9 +261,9 @@ type CdnRuleBuilder () =
                              CaseTransform = caseTransform |} ] }
 
     [<CustomOperation "cache_expiration">]
-    member _.CacheExpiration(state: CdnRuleConfig, cacheBehaviour, ?cacheDuration) =
+    member _.CacheExpiration(state: CdnRuleConfig, cacheBehaviour) =
         { state with
-              Actions = state.Actions @ [ CacheExpiration {| CacheBehaviour = cacheBehaviour ; CacheDuration = cacheDuration |} ] }
+              Actions = state.Actions @ [ CacheExpiration {| CacheBehaviour = cacheBehaviour |} ] }
     [<CustomOperation "cache_key_query_string">]
     member _.CacheKeyQueryString(state: CdnRuleConfig, behaviour, parameters) =
         { state with

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1585,14 +1585,20 @@ module DeliveryPolicy =
             | ToUppercase -> [ "Uppercase" ]
 
     type CacheBehaviour =
-        | Override
+        | Override of TimeSpan
         | BypassCache
-        | SetIfMissing
+        | SetIfMissing of TimeSpan
         member this.ArmValue =
             match this with
-            | Override -> "Override"
-            | BypassCache -> "BypassCache"
-            | SetIfMissing -> "SetIfMissing"
+            | Override t ->
+                             {| Behaviour = "Override"
+                                CacheDuration = Some(t) |}
+            | BypassCache ->
+                             {| Behaviour = "BypassCache"
+                                CacheDuration = None |}
+            | SetIfMissing t ->
+                             {| Behaviour = "SetIfMissing"
+                                CacheDuration = Some(t) |}
 
     type QueryStringCacheBehavior =
         | Include

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1592,13 +1592,13 @@ module DeliveryPolicy =
             match this with
             | Override t ->
                              {| Behaviour = "Override"
-                                CacheDuration = Some(t) |}
+                                CacheDuration = Some t |}
             | BypassCache ->
                              {| Behaviour = "BypassCache"
                                 CacheDuration = None |}
             | SetIfMissing t ->
                              {| Behaviour = "SetIfMissing"
-                                CacheDuration = Some(t) |}
+                                CacheDuration = Some t |}
 
     type QueryStringCacheBehavior =
         | Include

--- a/src/Tests/Cdn.fs
+++ b/src/Tests/Cdn.fs
@@ -93,7 +93,7 @@ let tests = testList "CDN tests" [
             cdn {
                 name "test"
                 add_endpoints [ endpoint {
-                    add_rules [ cdnRule{ name "test-rule"; order 2; when_request_body Contains ["content"] ToLowercase; when_device_type EqualityOperator.Equals Mobile;  modify_response_header  Append "headerName" "headerValue" }]
+                    add_rules [ cdnRule{ name "test-rule"; order 2; when_request_body Contains ["content"] ToLowercase; when_device_type EqualityOperator.Equals Mobile;  modify_response_header  Append "headerName" "headerValue"; cache_expiration BypassCache }]
                 } ]
             }
             |> getResourceAtIndex 1
@@ -101,6 +101,6 @@ let tests = testList "CDN tests" [
         Expect.equal rule.Name "test-rule" "Incorrect rule name"
         Expect.equal rule.Order 2 "Incorrect rule order"
         Expect.hasLength rule.Conditions 2 "Incorrect number of conditions"
-        Expect.hasLength rule.Actions 1 "Incorrect number of actions"
+        Expect.hasLength rule.Actions 2 "Incorrect number of actions"
     }
 ]


### PR DESCRIPTION
This PR closes #664

The changes in this PR are as follows:

* Only make CacheDuration required for Override and SetIfMissing and not BypassCache

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
