### PR TITLE
Alerts: Support of custom metric alerts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 1.6.21
+* Alerts: Extend a list of possible criteria's time aggregations and operators
+* Alerts: Support of custom metric alerts
+
 ## 1.6.20
 * CDN rules: Only make CacheDuration required for Override and SetIfMissing and not BypassCache when creating cache_expiration action
 * Virtual Machine: Adds support for the `AADSSHLoginForLinux` extension for Azure AD login over SSH on Linux VM's.

--- a/src/Farmer/Builders/Builders.Alert.fs
+++ b/src/Farmer/Builders/Builders.Alert.fs
@@ -73,6 +73,10 @@ type AlertBuilder() =
     /// The rule criteria that defines the conditions of the alert rule.
     member __.SingleCriteria(state:AlertConfig, criteria) = { state with Criteria = SingleResourceMultipleMetricCriteria criteria }
 
+    [<CustomOperation "single_resource_multiple_custom_metric_criteria">]
+    /// The rule criteria that defines the conditions of the alert rule based on Application Insights custom metric.
+    member __.SingleCustomMetricCriteria(state:AlertConfig, criteria) = { state with Criteria = SingleResourceMultipleCustomMetricCriteria criteria }
+
     [<CustomOperation "multiple_resource_multiple_metric_criteria">]
     /// The rule criterias that defines the conditions of the alert rule.
     member __.MultiCriteria(state:AlertConfig, criteria) = { state with Criteria = MultipleResourceMultipleMetricCriteria criteria }


### PR DESCRIPTION
This PR closes #807

The changes in this PR are as follows:

* Alerts: Extend a list of possible criteria's time aggregations and operators
* Alerts: Support of custom metric alerts

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
