### PR TITLE
Add dotnet-isolated function support for linux

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* Functions: fix for .Net isolated functions hosted on linux
 
 ## 1.6.21
 * CDN: Adds new SKU types for Azure Front Door Standard/Premium

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -252,7 +252,7 @@ type FunctionsConfig =
                       match this.VersionedRuntime with
                       | DotNet, Some version -> 
                         match Double.TryParse(version) with
-                        | true, versionNo when versionNo < 5 -> Some $"DOTNETCORE|{version}"
+                        | true, versionNo when versionNo < 4.0 -> Some $"DOTNETCORE|{version}"
                         | _ -> Some $"DOTNET|{version}"
                       | DotNetIsolated, Some version -> Some $"DOTNET-ISOLATED|{version}"
                       | _, Some version -> Some $"{functionsRuntime.ToUpper()}|{version}"

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -108,11 +108,13 @@ let tests = testList "Functions tests" [
         Expect.equal secrets.[1].Value (ExpressionSecret sa.Key) "Incorrect secret value"
         Expect.sequenceEqual secrets.[1].Dependencies [ vaults.resourceId "testfuncvault"; storageAccounts.resourceId "teststorage" ] "Incorrect secret dependencies"
     }
-
+    
     test "Supports dotnet-isolated runtime" {
-        let f = functions { name "func"; use_runtime (FunctionsRuntime.DotNetIsolated) }
+        let f = functions { name "func"; use_runtime (FunctionsRuntime.DotNet50Isolated); operating_system Linux }
         let resources = (f :> IBuilder).BuildResources Location.WestEurope
         let site = resources.[3] :?> Web.Site
+        Expect.equal site.LinuxFxVersion (Some "DOTNET-ISOLATED|5.0") "Should set linux fx runtime"
+
         let settings = Expect.wantSome site.AppSettings "AppSettings should be set"
         Expect.equal settings.["FUNCTIONS_WORKER_RUNTIME"] (LiteralSetting "dotnet-isolated") "Should use dotnet-isolated functions runtime"
     }


### PR DESCRIPTION
This PR closes #825

The changes in this PR are as follows:

* Update FunctionRuntime DU to include DotnetCore and version details for all .NET variations [BREAKING]
* Set WebApp.LinuxFxVersion for function apps

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
This is a bug fix with no change to the public API surface so no documentation change seems necessary.


Note that I have only added support for .NET isolated functions on linux as this what I have the means to test. I have left the situation unchanged for non-.NET functions