### PR TITLE
Fix vnet bug for KeyVault

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.6.21
 * CDN: Adds new SKU types for Azure Front Door Standard/Premium
+* KeyVault: Fixed bug where adding vnetRules to KeyVault did not work.
 
 ## 1.6.20
 * CDN rules: Only make CacheDuration required for Override and SetIfMissing and not BypassCache when creating cache_expiration action

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -157,7 +157,7 @@ type Vault =
                         {| defaultAction = this.DefaultAction  |> Option.map string |> Option.toObj
                            bypass = this.Bypass  |> Option.map string |> Option.toObj
                            ipRules = this.IpRules
-                           virtualNetworkRules = this.VnetRules |}
+                           virtualNetworkRules = this.VnetRules |> List.map (fun rule -> {| id = rule |}) |}
                     |}
             |} :> _
 


### PR DESCRIPTION
This PR closes -

The changes in this PR are as follows:

* Fixed bug where it was not possible to add vnet restrictions for KeyVault. Although not really sure if thats the place where the list of objects should be created.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
As it was just a bug fix I could not come up with any relevant documentation to write.