### PR TITLE
Add additional overloads for service bus topic builder to simplify co…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 ## 1.6.22
-* Service Bus: Added additional overloads to topic.name and topic.duplicate_detection
+* Service Bus: Added additional overloads for topic.duplicate_detection and queue.duplicate_detection
 
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.6.22
+* Service Bus: Added additional overloads to topic.name and topic.duplicate_detection
 
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -17,7 +17,7 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Queue | name | The name of the queue. |
 | Queue | lock_duration_minutes | The length of time that a lock can be held on a message. |
 | Queue | max_delivery_count | The maximum number of times a message can be delivered before dead lettering. |
-| Topic | duplicate_detection | Whether to enable duplicate detection, and if so, how long to check for. |
+| Queue | duplicate_detection | Whether to enable duplicate detection, and if so, how long to check for. |
 | Queue | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for in minutes. |
 | Queue | enable_session | Enables session support. |
 | Queue | enable_dead_letter_on_message_expiration | Enables dead lettering of messages that expire. |

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -40,7 +40,8 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Subscription | add_sql_filter | Adds a filter to a subscription using SQL syntax. |
 | Subscription | add_correlation_filter | Adds a filter to a subscription using header value correlation. |
 | Topic | name | The name of the topic. |
-| Topic | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for. |
+| Topic | duplicate_detection | Whether to enable duplicate detection, and if so, how long to check for. |
+| Topic | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for in minutes. |
 | Topic | enable_partition | Enables partition support on the topic. |
 | Topic | max_topic_size | Maximum size for the topic in Megabytes e.g. `1024<Mb>`. |
 | Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan or a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes, or as an integer days e.g. `4<Days>`. |

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -17,7 +17,8 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Queue | name | The name of the queue. |
 | Queue | lock_duration_minutes | The length of time that a lock can be held on a message. |
 | Queue | max_delivery_count | The maximum number of times a message can be delivered before dead lettering. |
-| Queue | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for. |
+| Topic | duplicate_detection | Whether to enable duplicate detection, and if so, how long to check for. |
+| Queue | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for in minutes. |
 | Queue | enable_session | Enables session support. |
 | Queue | enable_dead_letter_on_message_expiration | Enables dead lettering of messages that expire. |
 | Queue | enable_partition | Enables partition support on the queue. |

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -231,9 +231,15 @@ type ServiceBusTopicBuilder() =
           Subscriptions = Map.empty }
 
     /// The name of the queue.
-    [<CustomOperation "name">] member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = ResourceName name }
+    [<CustomOperation "name">] 
+    member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = name }
+    member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = ResourceName name }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
-    [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
+    [<CustomOperation "duplicate_detection">]
+    member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = maxTimeWindow }
+    member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some maxTimeWindow }
+    [<CustomOperation "duplicate_detection_minutes">]
+    member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
     /// The maximum size for the topic in megabytes.
     [<CustomOperation "max_topic_size">]
     member _.MaxTopicSize(state:ServiceBusTopicConfig, maxTopicSize:int<Mb>) = { state with MaxSizeInMegabytes = Some maxTopicSize }

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -69,8 +69,13 @@ type ServiceBusQueueBuilder() =
     [<CustomOperation "name">] member _.Name(state:ServiceBusQueueConfig, name) = { state with Name = ResourceName name }
     /// The length of time that a lock can be held on a message.
     [<CustomOperation "lock_duration_minutes">] member _.LockDurationMinutes(state:ServiceBusQueueConfig, duration) = { state with LockDuration = Some (TimeSpan.FromMinutes (float duration)) }
-    /// The maximum number of times a message can be delivered before dead lettering.
-    [<CustomOperation "duplicate_detection_minutes">] member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
+    /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
+    [<CustomOperation "duplicate_detection">]
+    member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = maxTimeWindow }
+    member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some maxTimeWindow }
+    /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
+    [<CustomOperation "duplicate_detection_minutes">]
+    member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
     /// The maximum size for the queue in megabytes.
     [<CustomOperation "max_queue_size">]
     member _.MaxTopicSize(state:ServiceBusQueueConfig, maxTopicSize:int<Mb>) = { state with MaxSizeInMegabytes = Some maxTopicSize }
@@ -231,13 +236,12 @@ type ServiceBusTopicBuilder() =
           Subscriptions = Map.empty }
 
     /// The name of the queue.
-    [<CustomOperation "name">] 
-    member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = name }
-    member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = ResourceName name }
+    [<CustomOperation "name">] member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = ResourceName name }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection">]
     member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = maxTimeWindow }
     member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some maxTimeWindow }
+    /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection_minutes">]
     member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
     /// The maximum size for the topic in megabytes.

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -71,8 +71,8 @@ type ServiceBusQueueBuilder() =
     [<CustomOperation "lock_duration_minutes">] member _.LockDurationMinutes(state:ServiceBusQueueConfig, duration) = { state with LockDuration = Some (TimeSpan.FromMinutes (float duration)) }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection">]
-    member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = maxTimeWindow }
-    member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some maxTimeWindow }
+    member _.DuplicateDetectionTs(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = maxTimeWindow }
+    member _.DuplicateDetectionTs(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some maxTimeWindow }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection_minutes">]
     member _.DuplicateDetection(state:ServiceBusQueueConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }
@@ -239,8 +239,8 @@ type ServiceBusTopicBuilder() =
     [<CustomOperation "name">] member _.Name(state:ServiceBusTopicConfig, name) = { state with Name = ResourceName name }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection">]
-    member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = maxTimeWindow }
-    member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some maxTimeWindow }
+    member _.DuplicateDetectionTs(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = maxTimeWindow }
+    member _.DuplicateDetectionTs(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some maxTimeWindow }
     /// Whether to enable duplicate detection, and if so, how long to check for.ServiceBusQueueConfig
     [<CustomOperation "duplicate_detection_minutes">]
     member _.DuplicateDetection(state:ServiceBusTopicConfig, maxTimeWindow) = { state with DuplicateDetection = Some (TimeSpan.FromMinutes (float maxTimeWindow)) }

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -98,7 +98,7 @@ let tests = testList "Service Bus Tests" [
                     add_queues [
                         queue {
                             name "my-queue"
-                            duplicate_detection (TimeSpan.FromSeconds(900))
+                            duplicate_detection (TimeSpan.FromSeconds(900.))
                         }
                     ]
                 }
@@ -296,7 +296,7 @@ let tests = testList "Service Bus Tests" [
                     add_topics [
                         topic {
                             name "my-topic"
-                            duplicate_detection_minutes None
+                            duplicate_detection None
                         }
                     ]
                 } |> getResourceAtIndex 1
@@ -311,7 +311,7 @@ let tests = testList "Service Bus Tests" [
                     add_topics [
                         topic {
                             name "my-topic"
-                            duplicate_detection_minutes (TimeSpan.FromSeconds(900))
+                            duplicate_detection (TimeSpan.FromSeconds(900.))
                         }
                     ]
                 } |> getResourceAtIndex 1

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -90,6 +90,40 @@ let tests = testList "Service Bus Tests" [
             Expect.equal (queue.DefaultMessageTimeToLive.GetValueOrDefault TimeSpan.MinValue).TotalDays 10. "Default TTL incorrect"
             Expect.equal queue.MaxDeliveryCount (Nullable 3) "Max delivery count incorrect"
         }
+        test "Can set duplicate dection from a TimeSpan" {
+            let queue =
+                serviceBus {
+                    name "my-bus"
+                    sku ServiceBus.Standard
+                    add_queues [
+                        queue {
+                            name "my-queue"
+                            duplicate_detection (TimeSpan.FromSeconds(900))
+                        }
+                    ]
+                }
+            let queue : SBQueue = queue |> getResourceAtIndex 1
+
+            Expect.isTrue (queue.RequiresDuplicateDetection.GetValueOrDefault false) "Duplicate detection should be enabled"
+            Expect.equal queue.DuplicateDetectionHistoryTimeWindow (Nullable(TimeSpan(0, 15, 0))) "Duplicate detection window incorrect"
+        }
+        test "Can set duplicate detection to None" {
+            let queue =
+                serviceBus {
+                    name "my-bus"
+                    sku ServiceBus.Standard
+                    add_queues [
+                        queue {
+                            name "my-queue"
+                            duplicate_detection None
+                        }
+                    ]
+                }
+            let queue : SBQueue = queue |> getResourceAtIndex 1
+
+            Expect.equal queue.RequiresDuplicateDetection (Nullable()) "Duplicate detection should be null"
+            Expect.equal queue.DuplicateDetectionHistoryTimeWindow (Nullable()) "Duplicate detection window incorrect"
+        }
 
         test "Cannot set duplicate detection on basic tier" {
             Expect.throws (fun () ->
@@ -254,6 +288,36 @@ let tests = testList "Service Bus Tests" [
             Expect.equal topic.DuplicateDetectionHistoryTimeWindow (Nullable (TimeSpan.FromMinutes 3.)) "Duplicate detection time not set"
             Expect.equal topic.DefaultMessageTimeToLive (Nullable (TimeSpan.FromDays 2.)) "Time to live not set"
             Expect.equal topic.EnablePartitioning (Nullable true) "Paritition not set"
+        }
+        test "Can set duplicate detection to None" {
+            let topic:SBTopic =
+                serviceBus {
+                    name "my-bus"
+                    add_topics [
+                        topic {
+                            name "my-topic"
+                            duplicate_detection_minutes None
+                        }
+                    ]
+                } |> getResourceAtIndex 1
+            Expect.equal topic.Name "my-bus/my-topic" "Name not set"
+            Expect.equal topic.RequiresDuplicateDetection (Nullable()) "Duplicate detection set"
+            Expect.equal topic.DuplicateDetectionHistoryTimeWindow (Nullable()) "Duplicate detection time not null"
+        }
+        test "Can set duplicate using a timespan" {
+            let topic:SBTopic =
+                serviceBus {
+                    name "my-bus"
+                    add_topics [
+                        topic {
+                            name "my-topic"
+                            duplicate_detection_minutes (TimeSpan.FromSeconds(900))
+                        }
+                    ]
+                } |> getResourceAtIndex 1
+            Expect.equal topic.Name "my-bus/my-topic" "Name not set"
+            Expect.equal topic.RequiresDuplicateDetection (Nullable true) "Duplicate detection not set"
+            Expect.equal topic.DuplicateDetectionHistoryTimeWindow (Nullable (TimeSpan.FromMinutes 15)) "Duplicate detection time incorrect"
         }
         test "Can create a topic with a max size" {
             let topic:SBTopic =

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -317,7 +317,7 @@ let tests = testList "Service Bus Tests" [
                 } |> getResourceAtIndex 1
             Expect.equal topic.Name "my-bus/my-topic" "Name not set"
             Expect.equal topic.RequiresDuplicateDetection (Nullable true) "Duplicate detection not set"
-            Expect.equal topic.DuplicateDetectionHistoryTimeWindow (Nullable (TimeSpan.FromMinutes 15)) "Duplicate detection time incorrect"
+            Expect.equal topic.DuplicateDetectionHistoryTimeWindow (Nullable (TimeSpan.FromMinutes 15.)) "Duplicate detection time incorrect"
         }
         test "Can create a topic with a max size" {
             let topic:SBTopic =


### PR DESCRIPTION
Add additional overloads for service bus topic builder to simplify conditional/loop scenarios

~This PR closes #~

The changes in this PR are as follows:

* Added additional builder overloads to support scenarios where topic are being generated in loops and only some need duplicate detection

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
