### PR TITLE
Fix generated deployment name for dynamically-named resource groups

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.22
+* WebApp: Fixed deployment name for nested template in app-managed certificate deployments
+
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators
 * Alerts: Support of custom metric alerts

--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -42,7 +42,7 @@ type ResourceGroupConfig =
       | Some rg when rg.[0]='[' -> 
         // TargetResourceGroup can be an ARM expression when doing nested deployments such as when creating App-managed certificates in the WebApp builder.
         // Because the value is not known when we generate the template, we must use the ARM concat function to append a suffix to prevent deployment errors
-        $"[concat({rg},'deployment-{deploymentIndex()}]"
+        $"[concat({rg.Trim([|'[';']'|])},'deployment-{deploymentIndex()}')]"
       | Some rg -> 
         $"{rg}-deployment-{deploymentIndex()}"
       | None -> 

--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -38,14 +38,15 @@ type ResourceGroupConfig =
       Mode: DeploymentMode
       Tags: Map<string,string> }
     member private this.GenerateDeploymentName () =
-        [
-            match this.TargetResourceGroup with
-            | Some v -> v
-            | None -> ()
-            "deployment"
-            deploymentIndex() |> string
-        ]
-        |> String.concat "-"
+      match this.TargetResourceGroup with
+      | Some rg when rg.[0]='[' -> 
+        // TargetResourceGroup can be an ARM expression when doing nested deployments such as when creating App-managed certificates in the WebApp builder.
+        // Because the value is not known when we generate the template, we must use the ARM concat function to append a suffix to prevent deployment errors
+        $"[concat({rg},'deployment-{deploymentIndex()}]"
+      | Some rg -> 
+        $"{rg}-deployment-{deploymentIndex()}"
+      | None -> 
+        $"deployment-{deploymentIndex()}"
 
     member this.ResourceId = resourceGroupDeployment.resourceId (this.DeploymentName.GetValue this.GenerateDeploymentName)
     member private this.ContentDeployment =

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -611,6 +611,8 @@ let tests = testList "Web App Tests" [
         let resourceGroupDeployment = resources |> getResource<ResourceGroup.ResourceGroupDeployment> |> List.head
         let innerResource = resourceGroupDeployment.Resources |> getResource<Web.HostNameBinding> |> List.head
         let innerExpectedSslState = SslState.SniBased thumbprint
+        Expect.stringStarts resourceGroupDeployment.DeploymentName.Value "[concat" "resourceGroupDeployment name should start as a valid ARM expression"
+        Expect.stringEnds resourceGroupDeployment.DeploymentName.Value ")]" "resourceGroupDeployment stage should end as a valid ARM expression"
         Expect.equal resourceGroupDeployment.Resources.Length 1 "resourceGroupDeployment stage should only contain one resource"
         Expect.equal resourceGroupDeployment.Dependencies.Count 2 "resourceGroupDeployment stage should only contain two dependencies"
         Expect.equal innerResource.SslState innerExpectedSslState $"hostnameBinding should have a {innerExpectedSslState} Ssl state inside the resourceGroupDeployment template"


### PR DESCRIPTION
This PR closes #832

The changes in this PR are as follows:

* Fix deployment name generation when resource group name is an ARM expression

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
Bug fix for already documented features