### PR TITLE
Fix missing AutoSwapSlotName in json output.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.25
+* WebApp/Functions: Fix autoSwapSlotName for app slots.
+
 ## 1.6.24
 * ContainerApps: Eagerly validate whether all containers in an app have a valid CPU/RAM combination.
 * ContainerApps: Correctly round CPU to 2DP.
@@ -14,7 +17,6 @@ Release Notes
 * Log Analytics: Add CustomerId configuration member to Log Analytics
 * Service Bus: Added additional overloads for topic.duplicate_detection and queue.duplicate_detection
 * WebApp: Fixed deployment name for nested template in app-managed certificate deployments
-* WebApp/Functions: Fix autoSwapSlotName for app slots.
 
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.6.22
 * WebApp: Fixed deployment name for nested template in app-managed certificate deployments
+* WebApp/Functions: Fix autoSwapSlotName for app slots.
 
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -287,10 +287,7 @@ type Site =
                                            supportCredentials = credentials |> Option.toNullable |})
                             |> Option.toObj
                            healthCheckPath = this.HealthCheckPath |> Option.toObj
-                           autoSwapSlotName =
-                               match this.AutoSwapSlotName with
-                               | None -> null
-                               | Some name -> name
+                           autoSwapSlotName = this.AutoSwapSlotName |> Option.toObj
                         |}
                     |}
             |} :> _
@@ -343,7 +340,7 @@ type StaticSite =
         member this.SecureParameters = [
             this.RepositoryToken
         ]
-type SslState = 
+type SslState =
     | SslDisabled
     | SniBased of thumbprint: ArmExpression
 
@@ -352,25 +349,25 @@ type HostNameBinding =
       SiteId: LinkedResource
       DomainName: string
       SslState: SslState }
-        member this.SiteResourceId = 
-            match this.SiteId with 
+        member this.SiteResourceId =
+            match this.SiteId with
             | Managed id -> id.Name
             | Unmanaged id -> id.Name
         member this.ResourceName =
             this.SiteResourceId / this.DomainName
-        member this.Dependencies = 
+        member this.Dependencies =
             [ match this.SiteId with
               | Managed resid -> resid
               | _ -> () ]
-        member this.ResourceId = 
+        member this.ResourceId =
             hostNameBindings.resourceId (this.SiteResourceId, ResourceName this.DomainName)
         interface IArmResource with
             member this.ResourceId = hostNameBindings.resourceId this.ResourceName
             member this.JsonModel =
                 {| hostNameBindings.Create(this.ResourceName, this.Location, this.Dependencies) with
                     properties =
-                        match this.SslState with 
-                        | SniBased thumbprint -> 
+                        match this.SslState with
+                        | SniBased thumbprint ->
                             {| sslState = "SniEnabled"
                                thumbprint = thumbprint.Eval() |} :> obj
                         | SslDisabled -> {| |} :> obj
@@ -389,7 +386,7 @@ type Certificate =
             member this.JsonModel =
                 {| certificates.Create(
                         this.ResourceName,
-                        this.Location, 
+                        this.Location,
                         [this.SiteId; hostNameBindings.resourceId(this.SiteId.Name,ResourceName this.DomainName)]) with
                     properties =
                         {| serverFarmId = this.ServicePlanId.Eval()

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -287,6 +287,10 @@ type Site =
                                            supportCredentials = credentials |> Option.toNullable |})
                             |> Option.toObj
                            healthCheckPath = this.HealthCheckPath |> Option.toObj
+                           autoSwapSlotName =
+                               match this.AutoSwapSlotName with
+                               | None -> null
+                               | Some name -> name
                         |}
                     |}
             |} :> _

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -543,6 +543,19 @@ let tests = testList "Web App Tests" [
         Expect.containsAll (theSlot.Identity.UserAssigned) [identity18.UserAssignedIdentity; identity21.UserAssignedIdentity] "Slot should have both user assigned identities"
         Expect.equal theSlot.KeyVaultReferenceIdentity (Some identity21.UserAssignedIdentity) "Slot should have correct keyvault identity"
     }
+    
+    test "WebApp with slot can use AutoSwapSlotName" {
+        let warmupSlot = appSlot { name "warm-up"; autoSlotSwapName "production" }
+        let site:WebAppConfig = webApp { name "slots"; add_slot warmupSlot }
+        Expect.isTrue (site.CommonWebConfig.Slots.ContainsKey "warm-up") "Config should contain slot"
+
+        let slot: Site =
+            site
+            |> getResourceAtIndex 4
+        
+        Expect.equal slot.Name "slots/warm-up" "Should be expected slot"
+        Expect.equal slot.SiteConfig.AutoSwapSlotName "production" "Should use provided auto swap slot name"
+    }
 
     test "Supports private endpoints" {
         let subnet = ResourceId.create(Network.subnets,ResourceName "subnet")


### PR DESCRIPTION
This PR closes #836

The changes in this PR are as follows:

* Add autoSwapSlotName to JsonModel for WebApp.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
* The SlotBuilder does not seem to be documented.