### PR TITLE
Added .NET 6 runtime support for web/function apps.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,10 @@
 Release Notes
 =============
-## 1.6.23
-* WebApps/Functions: Added support for .NET 6 runtimes with new Runtime.DotNet60.
 
 ## 1.6.22
 * Service Bus: Added additional overloads for topic.duplicate_detection and queue.duplicate_detection
-
-## 1.6.22
 * WebApp: Fixed deployment name for nested template in app-managed certificate deployments
+* WebApps/Functions: Added support for .NET 6 runtimes with new Runtime.DotNet60.
 
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.6.23
+* WebApps/Functions: Added support for .NET 6 runtimes with new Runtime.DotNet60.
+
 ## 1.6.22
 * Service Bus: Added additional overloads for topic.duplicate_detection and queue.duplicate_detection
 

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -51,6 +51,7 @@ type Runtime =
     static member Java8WildFly14 = Java (Java8, WildFly14)
     static member Java8Tomcat90 = Java (Java8, JavaHost.Tomcat90)
     static member Java8Tomcat85 = Java (Java8, JavaHost.Tomcat85)
+    static member DotNet60 = DotNet "6.0"
     static member DotNet50 = DotNet "5.0"
     static member AspNet47 = AspNet "4.0"
     static member AspNet35 = AspNet "2.0"
@@ -381,7 +382,8 @@ type WebAppConfig =
                   NetFrameworkVersion =
                     match this.Runtime with
                     | AspNet version
-                    | DotNet ("5.0" as version) ->
+                    | DotNet ("5.0" as version)
+                    | DotNet ("6.0" as version) ->
                         Some $"v{version}"
                     | _ ->
                         None

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -306,12 +306,6 @@ let tests = testList "Web App Tests" [
         Expect.equal site.SiteConfig.Use32BitWorkerProcess (Nullable false) "Should not use 32 bit worker process"
     }
 
-    test "Supports .NET 5" {
-        let app = webApp { name "net5"; runtime_stack Runtime.DotNet50 }
-        let site:Site = app |> getResourceAtIndex 2
-        Expect.equal site.SiteConfig.NetFrameworkVersion "v5.0" "Wrong dotnet version"
-    }
-
     test "Supports .NET 6" {
         let app = webApp { name "net6"; runtime_stack Runtime.DotNet60 }
         let site:Site = app |> getResourceAtIndex 2

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -306,10 +306,10 @@ let tests = testList "Web App Tests" [
         Expect.equal site.SiteConfig.Use32BitWorkerProcess (Nullable false) "Should not use 32 bit worker process"
     }
 
-    test "Supports .NET 5 EAP" {
-        let app = webApp { name "net5"; runtime_stack Runtime.DotNet50 }
+    test "Supports .NET 6" {
+        let app = webApp { name "net6"; runtime_stack Runtime.DotNet60 }
         let site:Site = app |> getResourceAtIndex 2
-        Expect.equal site.SiteConfig.NetFrameworkVersion "v5.0" "Wrong dotnet version"
+        Expect.equal site.SiteConfig.NetFrameworkVersion "v6.0" "Wrong dotnet version"
     }
 
     test "WebApp supports adding slots" {

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -306,6 +306,12 @@ let tests = testList "Web App Tests" [
         Expect.equal site.SiteConfig.Use32BitWorkerProcess (Nullable false) "Should not use 32 bit worker process"
     }
 
+    test "Supports .NET 5" {
+        let app = webApp { name "net5"; runtime_stack Runtime.DotNet50 }
+        let site:Site = app |> getResourceAtIndex 2
+        Expect.equal site.SiteConfig.NetFrameworkVersion "v5.0" "Wrong dotnet version"
+    }
+
     test "Supports .NET 6" {
         let app = webApp { name "net6"; runtime_stack Runtime.DotNet60 }
         let site:Site = app |> getResourceAtIndex 2


### PR DESCRIPTION
This PR closes #841 

The changes in this PR are as follows:

* Added Runtime.DotNet60
* Modified old .NET 5 EAP test to use .NET 6
* Modified Arm code to also output NetFrameworkVersion of v6.0

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
I compared to output of exported template, but haven't run a real deployment with it yet.
