### PR TITLE
Update sql.md server_name --> name

### DIFF
--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -13,7 +13,7 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 #### SQL Server Builder Keywords
 | Keyword | Purpose |
 |-|-|
-| server_name | Sets the name of the SQL server. |
+| name | Sets the name of the SQL server. |
 | add_firewall_rule | Adds a custom firewall rule given a name, start and end IP address range. |
 | add_firewall_rules | As add_firewall_rule but a list of rules |
 | enable_azure_firewall | Adds a firewall rule that enables access to other Azure services. |


### PR DESCRIPTION
builder for sql server has no "server_name" field. its called "name"

This PR closes #

The changes in this PR are as follows:

* ...
* ...
* ...

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
