### PR TITLE
Cosmosdb serverless

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,10 @@
 Release Notes
 =============
 
-## 1.7.0
-* CosmosDb: Add support for serverless capacity mode.
-
 ## 1.6.23
 * ContainerApps: Adds support for [containerApps](https://docs.microsoft.com/azure/container-apps/overview).
 * WebApps/Functions: Added support for .NET 6 runtimes with new Runtime.DotNet60.
+* CosmosDb: Add support for serverless capacity mode.
 
 ## 1.6.22
 * Log Analytics: Add CustomerId configuration member to Log Analytics

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,12 @@
 Release Notes
 =============
 
+## 1.6.24
+* CosmosDb: Add support for serverless capacity mode.
+
 ## 1.6.23
 * ContainerApps: Adds support for [containerApps](https://docs.microsoft.com/azure/container-apps/overview).
 * WebApps/Functions: Added support for .NET 6 runtimes with new Runtime.DotNet60.
-* CosmosDb: Add support for serverless capacity mode.
 
 ## 1.6.22
 * Log Analytics: Add CustomerId configuration member to Log Analytics

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ Release Notes
 * Log Analytics: Add CustomerId configuration member to Log Analytics
 * Service Bus: Added additional overloads for topic.duplicate_detection and queue.duplicate_detection
 * WebApp: Fixed deployment name for nested template in app-managed certificate deployments
+* CosmosDb: Add support for serverless capacity mode.
 
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,13 @@
 Release Notes
 =============
 
+## 1.7.0
+* CosmosDb: Add support for serverless capacity mode.
+
 ## 1.6.22
 * Log Analytics: Add CustomerId configuration member to Log Analytics
 * Service Bus: Added additional overloads for topic.duplicate_detection and queue.duplicate_detection
 * WebApp: Fixed deployment name for nested template in app-managed certificate deployments
-* CosmosDb: Add support for serverless capacity mode.
 
 ## 1.6.21
 * Alerts: Extend a list of possible criteria for time aggregations and operators

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -22,16 +22,15 @@ The CosmosDB builder abstracts the idea of account and database into one. If you
 |-|-|-|
 | Database | name | Sets the name of the database. |
 | Database | link_to_account | Instructs Farmer to link this database to an existing Cosmos DB account rather than creating a new one. |
-| Database | throughput | Sets the throughput of the account. |
 | Database | add_containers | Adds a list of containers to the database. |
 | Account | account_name | Sets the name of the CosmosDB account. |
+| Account | capacityMode | Sets the capacity mode with either `ProvisionedThroughput` or `Serverless`. |
 | Account | api (not yet implemented) | Sets the API and data model to use -- currently defaults to "Core (SQL)". |
 | Account | enable_public_network_access | Enables public network access for the account. |
 | Account | disable_public_network_access | Disables public network access for the account. |
 | Account | consistency_policy | Sets the consistency policy of the database. |
 | Account | failover_policy | Sets the failover policy of the database. |
 | Account | free_tier | Registers this server with the free pricing tier, if supported and allowed by Azure. |
-| Account | serverless | Enables the "serverless" capacity mode. |
 
 #### Cosmos Container Builder
 The container builder allows you to create and configure a specific container that is attached to a cosmos database.
@@ -51,7 +50,7 @@ open Farmer.Builders
 let myCosmosDb = cosmosDb {
     name "isaacsappdb"
     account_name "isaacscosmosdb"
-    throughput 400<CosmosDb.RU>
+    capacityMode (ProvisionedThroughput 400<RU>)
     failover_policy CosmosDb.NoFailover
     consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
     add_containers [

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -22,9 +22,9 @@ The CosmosDB builder abstracts the idea of account and database into one. If you
 |-|-|-|
 | Database | name | Sets the name of the database. |
 | Database | link_to_account | Instructs Farmer to link this database to an existing Cosmos DB account rather than creating a new one. |
+| Database | throughput | Sets the throughput with either "provisioned throughput" or "serverless". |
 | Database | add_containers | Adds a list of containers to the database. |
 | Account | account_name | Sets the name of the CosmosDB account. |
-| Account | capacityMode | Sets the capacity mode with either `ProvisionedThroughput` or `Serverless`. |
 | Account | api (not yet implemented) | Sets the API and data model to use -- currently defaults to "Core (SQL)". |
 | Account | enable_public_network_access | Enables public network access for the account. |
 | Account | disable_public_network_access | Disables public network access for the account. |
@@ -50,7 +50,7 @@ open Farmer.Builders
 let myCosmosDb = cosmosDb {
     name "isaacsappdb"
     account_name "isaacscosmosdb"
-    capacityMode 400<RU>
+    throughput 400<RU>
     failover_policy CosmosDb.NoFailover
     consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
     add_containers [

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -31,6 +31,7 @@ The CosmosDB builder abstracts the idea of account and database into one. If you
 | Account | consistency_policy | Sets the consistency policy of the database. |
 | Account | failover_policy | Sets the failover policy of the database. |
 | Account | free_tier | Registers this server with the free pricing tier, if supported and allowed by Azure. |
+| Account | serverless | Enables the "serverless" capacity mode. |
 
 #### Cosmos Container Builder
 The container builder allows you to create and configure a specific container that is attached to a cosmos database.

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -50,7 +50,7 @@ open Farmer.Builders
 let myCosmosDb = cosmosDb {
     name "isaacsappdb"
     account_name "isaacscosmosdb"
-    capacityMode (ProvisionedThroughput 400<RU>)
+    capacityMode 400<RU>
     failover_policy CosmosDb.NoFailover
     consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
     add_containers [

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -50,7 +50,7 @@ open Farmer.Builders
 let myCosmosDb = cosmosDb {
     name "isaacsappdb"
     account_name "isaacscosmosdb"
-    throughput 400<RU>
+    throughput 400<RU> // or throughput Serverless
     failover_policy CosmosDb.NoFailover
     consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
     add_containers [

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -147,10 +147,10 @@ type DatabaseAccount =
                           enableAutomaticFailover = this.EnableAutomaticFailover |> Option.toNullable
                           enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
                           locations =
-                            match this.FailoverLocations with
-                            | [] when this.DbThroughput = Serverless -> box [{| locationName = this.Location.ArmValue |}]
-                            | [] -> null
-                            | locations -> box locations
+                            match this.FailoverLocations, this.DbThroughput with
+                            | [], Serverless -> box [{| locationName = this.Location.ArmValue |}]
+                            | [], Provisioned _ -> null
+                            | locations, _ -> box locations
                           publicNetworkAccess = string this.PublicNetworkAccess
                           enableFreeTier = this.FreeTier
                           capabilities =

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -144,12 +144,13 @@ type DatabaseAccount =
                           enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
                           locations =
                             match this.FailoverLocations with
+                            | [] when this.Serverless -> box [{| locationName = this.Location.ArmValue |}]
                             | [] -> null
                             | locations -> box locations
                           publicNetworkAccess = string this.PublicNetworkAccess
                           enableFreeTier = this.FreeTier
-                          capabilities = [
-                            if this.Serverless then {| name = "EnableServerless" |}
-                          ]
+                          capabilities =
+                            if this.Serverless then box [{| name = "EnableServerless" |}]
+                            else null
                        |} |> box
             |} :> _

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -70,7 +70,7 @@ module DatabaseAccounts =
     type SqlDatabase =
         { Name : ResourceName
           Account : ResourceName
-          CapacityMode : CapacityMode
+          Throughput : Throughput
           Kind: DatabaseKind }
         interface IArmResource with
             member this.ResourceId = sqlDatabases.resourceId (this.Account/this.Name)
@@ -84,7 +84,7 @@ module DatabaseAccounts =
                            {| resource = {| id = this.Name.Value |}
                               options =
                                   {| throughput =
-                                      match this.CapacityMode with
+                                      match this.Throughput with
                                       | ProvisionedThroughput t ->  t |> string
                                       | Serverless -> null |} 
                            |}
@@ -97,7 +97,7 @@ type DatabaseAccount =
       FailoverPolicy : FailoverPolicy
       PublicNetworkAccess : FeatureFlag
       FreeTier : bool
-      CapacityMode : CapacityMode
+      DbThroughput : Throughput
       Kind : DatabaseKind
       Tags: Map<string,string>  }
     member this.MaxStatelessPrefix =
@@ -148,13 +148,13 @@ type DatabaseAccount =
                           enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
                           locations =
                             match this.FailoverLocations with
-                            | [] when this.CapacityMode = Serverless -> box [{| locationName = this.Location.ArmValue |}]
+                            | [] when this.DbThroughput = Serverless -> box [{| locationName = this.Location.ArmValue |}]
                             | [] -> null
                             | locations -> box locations
                           publicNetworkAccess = string this.PublicNetworkAccess
                           enableFreeTier = this.FreeTier
                           capabilities =
-                            if this.CapacityMode = Serverless then box [{| name = "EnableServerless" |}]
+                            if this.DbThroughput = Serverless then box [{| name = "EnableServerless" |}]
                             else null
                        |} |> box
             |} :> _

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -141,7 +141,7 @@ type DatabaseAccount =
                             |}
                           databaseAccountOfferType = "Standard"
                           enableAutomaticFailover = this.EnableAutomaticFailover |> Option.toNullable
-                          autoenableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
+                          enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
                           locations =
                             match this.FailoverLocations with
                             | [] -> null

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -148,7 +148,7 @@ type DatabaseAccount =
                           enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
                           locations =
                             match this.FailoverLocations, this.Serverless with
-                            | [], Enabled -> box [{| locationName = this.Location.ArmValue |}]
+                            | [], Enabled -> box [ {| locationName = this.Location.ArmValue |} ]
                             | [], Disabled -> null
                             | locations, _ -> box locations
                           publicNetworkAccess = string this.PublicNetworkAccess

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -4,10 +4,10 @@ module Farmer.Arm.DocumentDb
 open Farmer
 open Farmer.CosmosDb
 
-let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2021-01-15")
-let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2021-01-15")
-let mongoDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2021-01-15")
-let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2021-01-15")
+let containers = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2021-04-15")
+let sqlDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2021-04-15")
+let mongoDatabases = ResourceType ("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2021-04-15")
+let databaseAccounts = ResourceType ("Microsoft.DocumentDb/databaseAccounts", "2021-04-15")
 
 type DatabaseKind =
     | Document

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -97,7 +97,7 @@ type DatabaseAccount =
       FailoverPolicy : FailoverPolicy
       PublicNetworkAccess : FeatureFlag
       FreeTier : bool
-      DbThroughput : Throughput
+      Serverless : FeatureFlag
       Kind : DatabaseKind
       Tags: Map<string,string>  }
     member this.MaxStatelessPrefix =
@@ -147,14 +147,14 @@ type DatabaseAccount =
                           enableAutomaticFailover = this.EnableAutomaticFailover |> Option.toNullable
                           enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
                           locations =
-                            match this.FailoverLocations, this.DbThroughput with
-                            | [], Serverless -> box [{| locationName = this.Location.ArmValue |}]
-                            | [], Provisioned _ -> null
+                            match this.FailoverLocations, this.Serverless with
+                            | [], Enabled -> box [{| locationName = this.Location.ArmValue |}]
+                            | [], Disabled -> null
                             | locations, _ -> box locations
                           publicNetworkAccess = string this.PublicNetworkAccess
                           enableFreeTier = this.FreeTier
                           capabilities =
-                            if this.DbThroughput = Serverless then box [{| name = "EnableServerless" |}]
+                            if this.Serverless = Enabled then box [ {| name = "EnableServerless" |} ]
                             else null
                        |} |> box
             |}

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -34,7 +34,7 @@ type CosmosDbConfig =
       AccountConsistencyPolicy : ConsistencyPolicy
       AccountFailoverPolicy : FailoverPolicy
       DbName : ResourceName
-      CapacityMode : CapacityMode
+      DbThroughput : Throughput
       Containers : CosmosDbContainerConfig list
       PublicNetworkAccess : FeatureFlag
       FreeTier : bool
@@ -61,7 +61,7 @@ type CosmosDbConfig =
                   Location = location
                   Kind = this.Kind
                   ConsistencyPolicy = this.AccountConsistencyPolicy
-                  CapacityMode = this.CapacityMode
+                  DbThroughput = this.DbThroughput
                   PublicNetworkAccess = this.PublicNetworkAccess
                   FailoverPolicy = this.AccountFailoverPolicy
                   FreeTier = this.FreeTier
@@ -72,7 +72,7 @@ type CosmosDbConfig =
             // Database
             { Name = this.DbName
               Account = this.AccountResourceId.Name
-              CapacityMode = this.CapacityMode
+              Throughput = this.DbThroughput
               Kind = this.Kind }
 
             // Containers
@@ -154,7 +154,7 @@ type CosmosDbBuilder() =
             |> databaseAccounts.resourceId)
           AccountConsistencyPolicy = Eventual
           AccountFailoverPolicy = NoFailover
-          CapacityMode = ProvisionedThroughput 400<RU>
+          DbThroughput = ProvisionedThroughput 400<RU>
           Containers = []
           PublicNetworkAccess = Enabled
           FreeTier = false
@@ -179,9 +179,10 @@ type CosmosDbBuilder() =
     /// Sets the failover policy of the database.
     [<CustomOperation "failover_policy">]
     member _.FailoverPolicy(state:CosmosDbConfig, failoverPolicy:FailoverPolicy) = { state with AccountFailoverPolicy = failoverPolicy }
-    [<CustomOperation "capacityMode">]
-    member _.CapacityMode(state:CosmosDbConfig, capacityMode) = { state with CapacityMode = capacityMode }
-    member _.CapacityMode(state:CosmosDbConfig, throughput) = { state with CapacityMode = ProvisionedThroughput throughput }
+    /// Sets the throughput of the server.
+    [<CustomOperation "throughput">]
+    member _.Throughput(state:CosmosDbConfig, throughput) = { state with DbThroughput = throughput }
+    member _.Throughput(state:CosmosDbConfig, throughput) = { state with DbThroughput = ProvisionedThroughput throughput }
     /// Sets the storage kind
     [<CustomOperation "kind">]
     member _.StorageKind(state:CosmosDbConfig, kind) = { state with Kind = kind }

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -181,6 +181,7 @@ type CosmosDbBuilder() =
     member _.FailoverPolicy(state:CosmosDbConfig, failoverPolicy:FailoverPolicy) = { state with AccountFailoverPolicy = failoverPolicy }
     [<CustomOperation "capacityMode">]
     member _.CapacityMode(state:CosmosDbConfig, capacityMode) = { state with CapacityMode = capacityMode }
+    member _.CapacityMode(state:CosmosDbConfig, throughput) = { state with CapacityMode = ProvisionedThroughput throughput }
     /// Sets the storage kind
     [<CustomOperation "kind">]
     member _.StorageKind(state:CosmosDbConfig, kind) = { state with Kind = kind }

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -61,7 +61,10 @@ type CosmosDbConfig =
                   Location = location
                   Kind = this.Kind
                   ConsistencyPolicy = this.AccountConsistencyPolicy
-                  DbThroughput = this.DbThroughput
+                  Serverless =
+                    match this.DbThroughput with
+                    | Serverless -> Enabled
+                    | Provisioned _ -> Disabled
                   PublicNetworkAccess = this.PublicNetworkAccess
                   FailoverPolicy = this.AccountFailoverPolicy
                   FreeTier = this.FreeTier

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1429,8 +1429,8 @@ module CosmosDb =
     /// A request unit.
     [<Measure>]
     type RU
-    /// The capacity mode for CosmosDB account
-    type CapacityMode =
+    /// The throughput for CosmosDB account
+    type Throughput =
         | ProvisionedThroughput of int<RU>
         | Serverless
 

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1429,6 +1429,10 @@ module CosmosDb =
     /// A request unit.
     [<Measure>]
     type RU
+    /// The capacity mode for CosmosDB account
+    type CapacityMode =
+        | ProvisionedThroughput of int<RU>
+        | Serverless
 
 module PostgreSQL =
     type Sku =

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -38,7 +38,7 @@ let tests = testList "Cosmos" [
         Expect.isNotEmpty locationName "location should be filled"
     }
     test "ProvisionedThroughput template should include 'throughput' and should not contain 'EnableServerless'" {
-        let t = arm { add_resource (cosmosDb { name "foo"; capacityMode (CosmosDb.ProvisionedThroughput 400<CosmosDb.RU>); }) }
+        let t = arm { add_resource (cosmosDb { name "foo"; capacityMode 400<CosmosDb.RU>; }) }
         let json = t.Template |> Writer.toJson
         Expect.isTrue (json.Contains("\"throughput\": \"400\"")) "Shared throughput template should contain 'throughput'."
         Expect.isFalse (json.Contains("EnableServerless")) "Shared throughput template should not contain 'EnableServerless'."

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -22,14 +22,14 @@ let tests = testList "Cosmos" [
         Expect.contains container.UniqueKeys ["/FirstName"] "UniqueKeys should contain /FirstName"
         Expect.contains container.UniqueKeys ["/LastName"] "UniqueKeys should contain /LastName"
     }
-    test "Serverless template should include 'EnableServerless' and exclude 'throughput'" {
-        let t = arm { add_resource (cosmosDb { name "foo"; serverless; }) }
+    test "Serverless template should include 'EnableServerless' and should not contains 'throughput'" {
+        let t = arm { add_resource (cosmosDb { name "foo"; capacityMode CosmosDb.Serverless; }) }
         let json = t.Template |> Writer.toJson
         Expect.isTrue (json.Contains("EnableServerless")) "Serverless template should contain 'EnableServerless'."
         Expect.isFalse (json.Contains("throughput")) "Serverless template should not contain 'throughput'."
     }
     test "Serverless template should include one locations.location with filled locationName" {
-        let t = arm { add_resource (cosmosDb { name "foo"; serverless; }) }
+        let t = arm { add_resource (cosmosDb { name "foo"; capacityMode CosmosDb.Serverless; }) }
         let jobj = t.Template |> Writer.toJson |> Newtonsoft.Json.Linq.JObject.Parse
         let locationJOjb = jobj.SelectToken("$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts')].properties.locations[0]") 
         Expect.isNotEmpty (locationJOjb |> string) "location should be filled"
@@ -37,8 +37,8 @@ let tests = testList "Cosmos" [
         let locationName = locationJOjb.SelectToken("locationName") |> string
         Expect.isNotEmpty locationName "location should be filled"
     }
-    test "Shared throughput should include 'throughput' and exclude 'EnableServerless'" {
-        let t = arm { add_resource (cosmosDb { name "foo"; throughput 400<CosmosDb.RU>; }) }
+    test "ProvisionedThroughput template should include 'throughput' and should not contain 'EnableServerless'" {
+        let t = arm { add_resource (cosmosDb { name "foo"; capacityMode (CosmosDb.ProvisionedThroughput 400<CosmosDb.RU>); }) }
         let json = t.Template |> Writer.toJson
         Expect.isTrue (json.Contains("\"throughput\": \"400\"")) "Shared throughput template should contain 'throughput'."
         Expect.isFalse (json.Contains("EnableServerless")) "Shared throughput template should not contain 'EnableServerless'."

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -23,13 +23,13 @@ let tests = testList "Cosmos" [
         Expect.contains container.UniqueKeys ["/LastName"] "UniqueKeys should contain /LastName"
     }
     test "Serverless template should include 'EnableServerless' and should not contains 'throughput'" {
-        let t = arm { add_resource (cosmosDb { name "foo"; capacityMode CosmosDb.Serverless; }) }
+        let t = arm { add_resource (cosmosDb { name "foo"; throughput CosmosDb.Serverless; }) }
         let json = t.Template |> Writer.toJson
         Expect.isTrue (json.Contains("EnableServerless")) "Serverless template should contain 'EnableServerless'."
         Expect.isFalse (json.Contains("throughput")) "Serverless template should not contain 'throughput'."
     }
     test "Serverless template should include one locations.location with filled locationName" {
-        let t = arm { add_resource (cosmosDb { name "foo"; capacityMode CosmosDb.Serverless; }) }
+        let t = arm { add_resource (cosmosDb { name "foo"; throughput CosmosDb.Serverless; }) }
         let jobj = t.Template |> Writer.toJson |> Newtonsoft.Json.Linq.JObject.Parse
         let locationJOjb = jobj.SelectToken("$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts')].properties.locations[0]") 
         Expect.isNotEmpty (locationJOjb |> string) "location should be filled"
@@ -38,7 +38,7 @@ let tests = testList "Cosmos" [
         Expect.isNotEmpty locationName "location should be filled"
     }
     test "ProvisionedThroughput template should include 'throughput' and should not contain 'EnableServerless'" {
-        let t = arm { add_resource (cosmosDb { name "foo"; capacityMode 400<CosmosDb.RU>; }) }
+        let t = arm { add_resource (cosmosDb { name "foo"; throughput 400<CosmosDb.RU>; }) }
         let json = t.Template |> Writer.toJson
         Expect.isTrue (json.Contains("\"throughput\": \"400\"")) "Shared throughput template should contain 'throughput'."
         Expect.isFalse (json.Contains("EnableServerless")) "Shared throughput template should not contain 'EnableServerless'."

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -51,7 +51,7 @@ let tests =
             let cosmos = cosmosDb {
                 name "testdb"
                 account_name "testaccount"
-                throughput 400<CosmosDb.RU>
+                capacityMode (CosmosDb.ProvisionedThroughput 400<CosmosDb.RU>)
                 failover_policy CosmosDb.NoFailover
                 consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
                 add_containers [
@@ -67,7 +67,7 @@ let tests =
                 name "testdbmongo"
                 account_name "testaccountmongo"
                 kind Mongo
-                throughput 400<CosmosDb.RU>
+                capacityMode (CosmosDb.ProvisionedThroughput 400<CosmosDb.RU>)
                 failover_policy CosmosDb.NoFailover
                 consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
             }

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -51,7 +51,7 @@ let tests =
             let cosmos = cosmosDb {
                 name "testdb"
                 account_name "testaccount"
-                capacityMode 400<CosmosDb.RU>
+                throughput 400<CosmosDb.RU>
                 failover_policy CosmosDb.NoFailover
                 consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
                 add_containers [
@@ -67,7 +67,7 @@ let tests =
                 name "testdbmongo"
                 account_name "testaccountmongo"
                 kind Mongo
-                capacityMode 400<CosmosDb.RU>
+                throughput 400<CosmosDb.RU>
                 failover_policy CosmosDb.NoFailover
                 consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
             }

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -51,7 +51,7 @@ let tests =
             let cosmos = cosmosDb {
                 name "testdb"
                 account_name "testaccount"
-                capacityMode (CosmosDb.ProvisionedThroughput 400<CosmosDb.RU>)
+                capacityMode 400<CosmosDb.RU>
                 failover_policy CosmosDb.NoFailover
                 consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
                 add_containers [
@@ -67,7 +67,7 @@ let tests =
                 name "testdbmongo"
                 account_name "testaccountmongo"
                 kind Mongo
-                capacityMode (CosmosDb.ProvisionedThroughput 400<CosmosDb.RU>)
+                capacityMode 400<CosmosDb.RU>
                 failover_policy CosmosDb.NoFailover
                 consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
             }

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -519,7 +519,7 @@
           },
           "resources": [
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "kind": "GlobalDocumentDB",
               "location": "uksouth",
               "name": "testaccount",
@@ -537,7 +537,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts"
             },
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccount')]"
               ],
@@ -553,7 +553,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases"
             },
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts/sqlDatabases', 'testaccount', 'testdb')]"
               ],
@@ -595,7 +595,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers"
             },
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "kind": "MongoDB",
               "location": "uksouth",
               "name": "testaccountmongo",
@@ -613,7 +613,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts"
             },
             {
-              "apiVersion": "2021-01-15",
+              "apiVersion": "2021-04-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccountmongo')]"
               ],


### PR DESCRIPTION
This PR closes #333

Thanks to discussion in #333 and for @dnperfors and @JordanMarr work on the subject, I added the last brick in order to make the serverless work on cosmos db.

The changes in this PR are as follows:

* Update databaseAccounts/* api versions to 2021-04-15
* Add 'serverless' operation to Cosmos builder
  * Using 'serverless' disables previous 'throughput' usages.
  * Likewise, using 'throughput' disables previous 'serverless' usages.cosmosDb 
 ```fsharp
// Per example, the 'throughput' will be ignored, only the 'serverless' will be applied.
cosmosDb {
    name "cosmos-foo"   
    throughput 400<CosmosDb.RU> 
    serverless
}
```
  * Applying 'serverless' in the arm template:
    * adds 'EnableServerless' inside capabitilities
    * adds a location with a location name (without adding it, the template will not work, more details on: #333)

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
cosmosDb {
    name "cosmos-foo"
    serverless
}
```
