### PR TITLE
Checkout submodules and include test coverage reports in CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,8 @@ stages:
     pool:
       vmImage: $(imageName)
     steps:
+    - checkout: self
+      submodules: 'true'
     - task: DotNetCoreCLI@2
       displayName: 'Restore'
       inputs:
@@ -39,18 +41,17 @@ stages:
         azureSubscription: 'Microsoft Azure Sponsorship(6c9e2629-3964-4b24-bc32-97dafc8c90f3)'
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
-        inlineScript: 'dotnet test -v n -c release -l trx'
+        inlineScript: 'dotnet test -v n -c release -l trx --collect:"XPlat Code Coverage"'
     - task: DotNetCoreCLI@2
       displayName: 'Test Pull Request'
       condition:  and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       inputs:
         command: 'test'
-        arguments: '-v n -c release -l trx'
-    - task: PublishTestResults@2
-      displayName: 'Publish Test Results'
+        arguments: '-v n -c release -l trx --collect:"XPlat Code Coverage"'
+    - task: PublishCodeCoverageResults@1
       inputs:
-        testResultsFiles: '**/*.trx'
-        testResultsFormat: VSTest
+        codeCoverageTool: 'Cobertura'
+        summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
     - task: DotNetCoreCLI@2
       displayName: 'Package'
       condition: and(succeeded(), eq(variables.imageName, 'ubuntu-latest'))

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -83,7 +83,10 @@
     <PackageReference Include="Microsoft.Azure.Management.TrafficManager" Version="2.5.3" />
     <PackageReference Include="Microsoft.Azure.Management.WebSites" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.9.1" />
     <PackageReference Update="FSharp.Core" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
CI changes only:

* Checkout submodules in CI builds so SourceLink no longer warns it cannot find some of the source.
* Include test coverage reports.