### PR TITLE
Target netstandard2 only.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* Revert back to targetting NET Standard 2 only.
 
 ## 1.6.23
 * WebApps/Functions: Added support for .NET 6 runtimes with new Runtime.DotNet60.

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
@@ -9,7 +9,7 @@
     <Authors>Isaac Abraham and contributors</Authors>
 
     <!-- Build settings -->
-    <TargetFrameworks>netstandard2.0; net5.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Library</OutputType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -41,8 +41,6 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" Version="5.0.1" />
+    <PackageReference Include="System.Text.Json" Version="5" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../../Icon.jpg">


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Revert to targetting netstandard2 only. Improves build time by ~30%.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

No changes aside from the project file. Unit tests still all pass.