### PR TITLE
Add .NET 5 and 6 support for Linux App Service

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.6.26
+* WebApp/Functions: Fix .NET on Linux deployments
 
 ## 1.6.25
 * CosmosDb: Add support for serverless capacity mode.

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -201,7 +201,7 @@ type WebAppConfig =
       DockerAcrCredentials : {| RegistryName : string; Password : SecureParameter |} option
       AutomaticLoggingExtension : bool
       SiteExtensions : ExtensionName Set
-      PrivateEndpoints: (LinkedResource * string option) Set 
+      PrivateEndpoints: (LinkedResource * string option) Set
       CustomDomain : DomainConfig }
     member this.Name = this.CommonWebConfig.Name
     /// Gets this web app's Server Plan's full resource ID.
@@ -372,6 +372,7 @@ type WebAppConfig =
                         | None ->
                             match this.Runtime with
                             | DotNetCore version -> Some $"DOTNETCORE|{version}"
+                            | DotNet version -> Some $"DOTNETCORE|{version}"
                             | Node version -> Some $"NODE|{version}"
                             | Php version -> Some $"PHP|{version}"
                             | Ruby version -> Some $"RUBY|{version}"
@@ -518,22 +519,22 @@ type WebAppConfig =
                 // Need to rename `location` binding to prevent conflict with `location` operator in resource group
                 let resourceLocation = location
                 // nested deployment to update hostname binding with specified SSL options
-                yield! (resourceGroup { 
+                yield! (resourceGroup {
                     name "[resourceGroup().name]"
                     location resourceLocation
                     add_resource { hostNameBinding with
                                     SiteId =
-                                        match hostNameBinding.SiteId with 
+                                        match hostNameBinding.SiteId with
                                         | Managed id -> Unmanaged id
-                                        | x -> x 
-                                    SslState = 
+                                        | x -> x
+                                    SslState =
                                         match certOptions with
                                         | AppManagedCertificate -> SniBased (cert.GetThumbprintReference aspRgName)
                                         | CustomCertificate thumbprint -> SniBased thumbprint
                                   }
                     depends_on certRg
                 } :> IBuilder).BuildResources location
-            | InsecureDomain customDomain -> 
+            | InsecureDomain customDomain ->
                 { Location = location
                   SiteId =  Managed (Arm.Web.sites.resourceId this.Name.ResourceName)
                   DomainName = customDomain

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -312,6 +312,12 @@ let tests = testList "Web App Tests" [
         Expect.equal site.SiteConfig.NetFrameworkVersion "v6.0" "Wrong dotnet version"
     }
 
+    test "Supports .NET 5 on Linux" {
+        let app = webApp { name "net5"; operating_system Linux; runtime_stack Runtime.DotNet50 }
+        let site:Site = app |> getResourceAtIndex 2
+        Expect.equal site.SiteConfig.LinuxFxVersion "DOTNETCORE|5.0" "Wrong dotnet version"
+    }
+
     test "WebApp supports adding slots" {
         let slot = appSlot { name "warm-up" }
         let site:WebAppConfig = webApp { name "slots"; add_slot slot }
@@ -558,7 +564,7 @@ let tests = testList "Web App Tests" [
         Expect.containsAll (theSlot.Identity.UserAssigned) [identity18.UserAssignedIdentity; identity21.UserAssignedIdentity] "Slot should have both user assigned identities"
         Expect.equal theSlot.KeyVaultReferenceIdentity (Some identity21.UserAssignedIdentity) "Slot should have correct keyvault identity"
     }
-    
+
     test "WebApp with slot can use AutoSwapSlotName" {
         let warmupSlot = appSlot { name "warm-up"; autoSlotSwapName "production" }
         let site:WebAppConfig = webApp { name "slots"; add_slot warmupSlot }
@@ -567,7 +573,7 @@ let tests = testList "Web App Tests" [
         let slot: Site =
             site
             |> getResourceAtIndex 4
-        
+
         Expect.equal slot.Name "slots/warm-up" "Should be expected slot"
         Expect.equal slot.SiteConfig.AutoSwapSlotName "production" "Should use provided auto swap slot name"
     }


### PR DESCRIPTION
This PR closes #860 

The changes in this PR are as follows:

* Introduce DOTNETCORE for NET 5 / 6 on Linux.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let app = webApp { name "net5"; operating_system Linux; runtime_stack Runtime.DotNet50 }
```
