### PR TITLE
Multiple custom domains

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.6.27
+* WebApp: Allow multiple custom domains
+
 ## 1.6.26
 * WebApp/Functions: Fix .NET on Linux deployments
 

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -56,7 +56,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | add_slot | Adds a deployment slot to the app |
 | Web App | add_slots | Adds multiple deployment slots to the app |
 | Web App | health_check_path | Sets the path to your functions health check endpoint, which Azure load balancers will ping to determine which instances are healthy.|
-| Web App | custom_domain | Adds custom domain to the app, containing an app service managed certificate |
+| Web App | custom_domain | Adds a custom domain to the app.  Optionally this can also generate an SSL certificate for the domain. This operator can be used multiple times to add multiple domains |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -56,7 +56,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | add_slot | Adds a deployment slot to the app |
 | Web App | add_slots | Adds multiple deployment slots to the app |
 | Web App | health_check_path | Sets the path to your functions health check endpoint, which Azure load balancers will ping to determine which instances are healthy.|
-| Web App | custom_domain | Adds a custom domain to the app.  Optionally this can also generate an SSL certificate for the domain. This operator can be used multiple times to add multiple domains |
+| Web App | custom_domain | Adds a custom domain to the app.  By default this will produce an AppService-managed SSL certificate for your domain as well. Through the overloads of this operator, you can provide a custom certificate thumbprint or choose not to use SSL. You can use this operator multiple times to add multiple custom domains.  |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -380,7 +380,7 @@ type Certificate =
       SiteId: LinkedResource
       ServicePlanId: LinkedResource
       DomainName: string }
-        member this.ResourceName = this.SiteId.Name.Map (sprintf "%s-cert")
+        member this.ResourceName = ResourceName this.DomainName
         member this.Thumbprint = this.GetThumbprintReference None
         member this.GetThumbprintReference certificateResourceGroup =
             ArmExpression.reference({certificates.resourceId this.ResourceName with ResourceGroup = certificateResourceGroup}).Map(sprintf "%s.Thumbprint")

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -350,7 +350,8 @@ type HostNameBinding =
     { Location: Location
       SiteId: LinkedResource
       DomainName: string
-      SslState: SslState }
+      SslState: SslState
+      DependsOn: ResourceId Set }
         member this.SiteResourceId =
             match this.SiteId with
             | Managed id -> id.Name
@@ -360,7 +361,9 @@ type HostNameBinding =
         member this.Dependencies =
             [ match this.SiteId with
               | Managed resid -> resid
-              | _ -> () ]
+              | _ -> ()
+
+              yield! this.DependsOn ]
         member this.ResourceId =
             hostNameBindings.resourceId (this.SiteResourceId, ResourceName this.DomainName)
         interface IArmResource with

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -244,7 +244,11 @@ type CertificateOptions =
 type DomainConfig =
     | SecureDomain of domain:string * cert:CertificateOptions
     | InsecureDomain of domain:string
-    | NoDomain
+    member this.DomainName = 
+        match this with 
+        | SecureDomain (domainName,_)
+        | InsecureDomain (domainName) -> domainName
+
 
 [<AutoOpen>]
 module ResourceRef =

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -719,6 +719,36 @@ let tests = testList "Web App Tests" [
         
         Expect.equal secureBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
         Expect.equal insecureBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+    }
 
+    test "Assigns dependencies to host names when deploying multiple custom domains" {
+        let webappName = "test"
+        let resources = 
+            webApp {
+                name webappName
+                custom_domains ["secure1.io" ; "secure2.io" ; "secure3.io"]
+            } |> getResources
+        let wa = resources |> getResource<Web.Site> |> List.head
+
+        let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
+
+        //Testing HostnameBinding
+        let hostnameBindings = resources |> getResource<Web.HostNameBinding> 
+        let secureBinding1 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure1.io") |> List.head
+        let secureBinding2 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure2.io") |> List.head
+        let secureBinding3 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure3.io") |> List.head
+        let nestedResourceGroupHostNameUpdates = 
+            resources 
+            |> getResource<ResourceGroupDeployment> 
+            |> Seq.map(fun x -> getResource<Web.HostNameBinding>(x.Resources))
+            |> Seq.filter(fun x -> x.Length > 0)
+
+        Expect.all nestedResourceGroupHostNameUpdates (fun x -> x.Head.DependsOn.IsEmpty) "No dependencies expected on nested template"
+        Expect.equal secureBinding1.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+        Expect.equal secureBinding2.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+        Expect.equal secureBinding3.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+        Expect.isEmpty secureBinding1.DependsOn "First host name binding should have no dependency"
+        Expect.contains (secureBinding2.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure1.io')]" "Second host name binding should depend on first"
+        Expect.contains (secureBinding3.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure2.io')]" "Third host name binding depends on second"
     }
 ]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add support for multiple custom domains for a single web app

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
webApp {
  name "my-web-app"
  custom_domain "a.custom-domain.com"
  custom_domain "b.custom-domain.com"
}
```
