### PR TITLE
Only turn on "auto" extension for Windows

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* WebApps/Functions: Don't turn on Logging Extension for Linux App Service.
 
 ## 1.6.25
 * CosmosDb: Add support for serverless capacity mode.

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -497,16 +497,16 @@ type WebAppConfig =
                 hostNameBinding
 
                 // Get the resource group which contains the app service plan
-                let aspRgName = 
+                let aspRgName =
                   match this.CommonWebConfig.ServicePlan with
                   | LinkedResource linked -> linked.ResourceId.ResourceGroup
                   | _ -> None
                 // Create a nested resource group deployment for the certificate - this isn't strictly necessary when the app & app service plan are in the same resource group
                 // however, when they are in different resource groups this is required to make the deployment succeed (there is an ARM bug which causes a Not Found / Conflict otherwise)
                 // To keep the code simple, I opted to always nest the certificate deployment. - TheRSP 2021-12-14
-                let certRg = resourceGroup { 
+                let certRg = resourceGroup {
                     name (aspRgName |> Option.defaultValue "[resourceGroup().name]")
-                    add_resource 
+                    add_resource
                       { cert with
                           SiteId = Unmanaged cert.SiteId.ResourceId
                           ServicePlanId = Unmanaged cert.ServicePlanId.ResourceId }
@@ -591,8 +591,12 @@ type WebAppBuilder() =
                 // its important to only add this extension if we're not using Web App for Containers - if we are
                 // then this will generate an error during deployment:
                 // No route registered for '/api/siteextensions/Microsoft.AspNetCore.AzureAppServices.SiteExtension'
-                | { Runtime = Runtime.DotNetCore _; AutomaticLoggingExtension = true ; DockerImage = None } ->
-                    state.SiteExtensions.Add WebApp.Extensions.Logging
+                | { Runtime = DotNetCore _
+                    AutomaticLoggingExtension = true
+                    DockerImage = None
+                    CommonWebConfig = { OperatingSystem = Windows } }
+                    ->
+                    state.SiteExtensions.Add Extensions.Logging
                 | _ ->
                     state.SiteExtensions
             DockerImage =

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -280,7 +280,7 @@ let tests = testList "Web App Tests" [
         let wa : Site = webApp { name "testsite" } |> getResourceAtIndex 3
         wa |> hasSetting "APPINSIGHTS_INSTRUMENTATIONKEY" "Missing Windows instrumentation key"
 
-        let wa : Site = webApp { name "testsite"; operating_system Linux } |> getResourceAtIndex 3
+        let wa : Site = webApp { name "testsite"; operating_system Linux } |> getResourceAtIndex 2
         wa |> hasSetting "APPINSIGHTS_INSTRUMENTATIONKEY" "Missing Linux instrumentation key"
 
         let wa : Site = webApp { name "testsite"; app_insights_off } |> getResourceAtIndex 2
@@ -558,7 +558,7 @@ let tests = testList "Web App Tests" [
         Expect.containsAll (theSlot.Identity.UserAssigned) [identity18.UserAssignedIdentity; identity21.UserAssignedIdentity] "Slot should have both user assigned identities"
         Expect.equal theSlot.KeyVaultReferenceIdentity (Some identity21.UserAssignedIdentity) "Slot should have correct keyvault identity"
     }
-    
+
     test "WebApp with slot can use AutoSwapSlotName" {
         let warmupSlot = appSlot { name "warm-up"; autoSlotSwapName "production" }
         let site:WebAppConfig = webApp { name "slots"; add_slot warmupSlot }
@@ -567,7 +567,7 @@ let tests = testList "Web App Tests" [
         let slot: Site =
             site
             |> getResourceAtIndex 4
-        
+
         Expect.equal slot.Name "slots/warm-up" "Should be expected slot"
         Expect.equal slot.SiteConfig.AutoSwapSlotName "production" "Should use provided auto swap slot name"
     }
@@ -703,5 +703,11 @@ let tests = testList "Web App Tests" [
         let hostnameBinding = resources |> getResource<Web.HostNameBinding>
 
         Expect.equal hostnameBinding.Length 0 $"There should not be a hostname binding as a result of choosing the 'NoDomain' option"
+    }
+
+    test "Linux automatically turns off logging extension" {
+        let wa = webApp { name "siteX"; operating_system Linux }
+        let extensions = wa |> getResources |> getResource<SiteExtension>
+        Expect.isEmpty extensions "Should not be any extensions"
     }
 ]


### PR DESCRIPTION
This PR closes #782

The changes in this PR are as follows:

* Stop automatically turning on the logging extension if OS is Linux.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.