### PR TITLE
Add docker port setting for app service

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 ## vNext
 * WebApps/Functions: Don't turn on Logging Extension for Linux App Service.
 * WebApps/Functions: Fix .NET 5/6 on Linux deployments.
+* WebApp: Support custom port for docker container with `docker_port`
 
 ## 1.6.25
 * CosmosDb: Add support for serverless capacity mode.

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -57,6 +57,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | add_slots | Adds multiple deployment slots to the app |
 | Web App | health_check_path | Sets the path to your functions health check endpoint, which Azure load balancers will ping to determine which instances are healthy.|
 | Web App | custom_domain | Adds custom domain to the app, containing an app service managed certificate |
+| Web App | docker_port | Adds `WEBSITE_PORT` setting to map custom docker port to app service port 80 |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -62,6 +62,7 @@ type Runtime =
 module AppSettings =
     let WebsiteNodeDefaultVersion version = "WEBSITE_NODE_DEFAULT_VERSION", version
     let RunFromPackage = "WEBSITE_RUN_FROM_PACKAGE", "1"
+    let WebSitePort (port:int) =  "WEBSITE_PORT", port.ToString()
 
 let publishingPassword (name:ResourceName) =
     let resourceId = config.resourceId (name, ResourceName "publishingCredentials")
@@ -202,7 +203,8 @@ type WebAppConfig =
       AutomaticLoggingExtension : bool
       SiteExtensions : ExtensionName Set
       PrivateEndpoints: (LinkedResource * string option) Set
-      CustomDomain : DomainConfig }
+      CustomDomain : DomainConfig 
+      DockerPort: int option }
     member this.Name = this.CommonWebConfig.Name
     /// Gets this web app's Server Plan's full resource ID.
     member this.ServicePlanId = this.CommonWebConfig.ServicePlan.resourceId this.Name.ResourceName
@@ -283,6 +285,10 @@ type WebAppConfig =
                     | Linux, Some _
                     | _ , None ->
                         ()
+
+                    match this.DockerPort with
+                    | Some port -> AppSettings.WebSitePort port
+                    | None -> ()
 
                     if this.DockerCi then "DOCKER_ENABLE_CI", "true"
                 ]
@@ -583,7 +589,8 @@ type WebAppBuilder() =
           AutomaticLoggingExtension = true
           SiteExtensions = Set.empty
           PrivateEndpoints = Set.empty
-          CustomDomain = NoDomain}
+          CustomDomain = NoDomain 
+          DockerPort = None }
     member _.Run(state:WebAppConfig) =
         if state.Name.ResourceName = ResourceName.Empty then raiseFarmer "No Web App name has been set."
         { state with
@@ -690,7 +697,10 @@ type WebAppBuilder() =
     member _.CustomDomain(state:WebAppConfig, domainConfig) = { state with CustomDomain = domainConfig }
     member _.CustomDomain(state:WebAppConfig, customDomain) = { state with CustomDomain = SecureDomain (customDomain,AppManagedCertificate) }
     member _.CustomDomain(state:WebAppConfig, (customDomain,thumbprint)) = { state with CustomDomain = SecureDomain (customDomain,CustomCertificate thumbprint) }
-
+    /// Map specified port traffic from your docker container to port 80 for App Service
+    [<CustomOperation "docker_port">]
+    member _.DockerPort(state: WebAppConfig, dockerPort:int) = { state with DockerPort = Some(dockerPort)}
+    
     interface IPrivateEndpoints<WebAppConfig> with member _.Add state endpoints = { state with PrivateEndpoints = state.PrivateEndpoints |> Set.union endpoints}
     interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     interface IDependable<WebAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -716,4 +716,22 @@ let tests = testList "Web App Tests" [
         let extensions = wa |> getResources |> getResource<SiteExtension>
         Expect.isEmpty extensions "Should not be any extensions"
     }
+
+    test "Supports docker ports with WEBSITE_PORT"{
+        let wa = webApp { name "testApp"; docker_port 8080; }
+        let port = Expect.wantSome wa.DockerPort "Docker port should be set"
+        Expect.equal port 8080 "Docker port should 8080"
+        
+        let site = wa |> getResources|> getResource<Web.Site> |> List.head
+
+        let settings = Expect.wantSome site.AppSettings "AppSettings should be set"
+        let (hasValue, value) = settings.TryGetValue("WEBSITE_PORT");
+      
+        Expect.isTrue hasValue "WEBSITE_PORT should be set"
+        Expect.equal value.Value "8080" "WEBSITE_PORT should be 8080"
+
+        let defaultWa = webApp { name "testApp"; }
+        Expect.isNone defaultWa.DockerPort "Docker port should not be set"
+    }
+
 ]


### PR DESCRIPTION
This PR closes #869

The changes in this PR are as follows:

*  Adds support for specifying a custom docker port for an app service

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let wa = webApp {
    name "myApp"
    docker_port 8080
}
```