### PR TITLE
Specify the connection string kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,6 @@ Release Notes
 ## 1.6.26
 * WebApps/Functions: Fix .NET 5/6 on Linux deployments.
 
-
 ## 1.6.25
 * CosmosDb: Add support for serverless capacity mode.
 * WebApps/Functions: Fix autoSwapSlotName for app slots.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## vNext
+* WebApps/Functions: Specify connection string types
+
 ## 1.6.27
 * Functions: Make `connection_string` available for Azure Functions in addition to WebApps.
 * WebApps/Functions: Add support for ip-restriction rules
@@ -10,6 +13,7 @@ Release Notes
 
 ## 1.6.26
 * WebApps/Functions: Fix .NET 5/6 on Linux deployments.
+
 
 ## 1.6.25
 * CosmosDb: Add support for serverless capacity mode.

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -28,7 +28,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | setting | Sets an app setting of the web app in the form "key" "value". |
 | Web App | secret_setting | Sets a "secret" app setting of the web app. You must supply the "key", whilst the value will be supplied as a secure parameter. |
 | Web App | settings | Sets a list of app setting of the web app as tuples in the form of ("key", "value"). |
-| Web App | connection_string | Creates a connection string whose value is supplied as secret parameter, or as an ARM expression in the tupled form of ("key", expr). |
+| Web App | connection_string | Creates a connection string whose value is supplied as secret parameter, or as an ARM expression in the tupled form of ("key", expr), or with the connection string type ("key", expr, SQLAzure). |
 | Web App | connection_strings | Creates a set of connection strings of the web app whose values will be supplied as secret parameters. |
 | Web App | ftp_state | Allows to enable or disable FTP and FTPS. |
 | Web App | https_only | Disables http for this webapp so that only HTTPS is used. |

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -823,9 +823,12 @@ module Extensions =
             { current with ConnectionStrings = current.ConnectionStrings.Add(key, (ParameterSetting (SecureParameter key), Custom)) }
             |> this.Wrap state
         member this.AddConnectionString(state:'T, (key, value:ArmExpression)) =
+            this.AddConnectionString(state, (key, value, Custom))
+        member this.AddConnectionString(state:'T, (key, value:ArmExpression, kind)) =
             let current = this.Get state
-            { current with ConnectionStrings = current.ConnectionStrings.Add(key, (ExpressionSetting value, Custom)) }
+            { current with ConnectionStrings = current.ConnectionStrings.Add(key, (ExpressionSetting value, kind)) }
             |> this.Wrap state
+            
         /// Creates a set of connection strings of the web app whose values will be supplied as secret parameters.
         [<CustomOperation "connection_strings">]
         member this.AddConnectionStrings(state:'T, connectionStrings) =

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -687,8 +687,6 @@ let tests = testList "Web App Tests" [
         let resources = webApp { name webappName; custom_domain (DomainConfig.InsecureDomain "customDomain.io") } |> getResources
         let wa = resources |> getResource<Web.Site> |> List.head
 
-        let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
-
         //Testing HostnameBinding
         let hostnameBinding = resources |> getResource<Web.HostNameBinding> |> List.head
         let expectedSslState = SslState.SslDisabled

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -64,12 +64,13 @@ let tests = testList "Web App Tests" [
     test "Web App correctly adds connection strings" {
         let sa = storageAccount { name "foo" }
         let wa =
-            let resources = webApp { name "test"; connection_string "a"; connection_string ("b", sa.Key) } |> getResources
+            let resources = webApp { name "test"; connection_string "a"; connection_string ("b", sa.Key); connection_string ("c", ArmExpression.create("c"), SQLAzure) } |> getResources
             resources |> getResource<Web.Site> |> List.head
 
         let expected = [
             "a", (ParameterSetting(SecureParameter "a"), Custom)
             "b", (ExpressionSetting sa.Key, Custom)
+            "c", (ExpressionSetting (ArmExpression.create("c")), SQLAzure)
         ]
         let parameters = wa :> IParameters
 
@@ -685,6 +686,8 @@ let tests = testList "Web App Tests" [
         let webappName = "test"
         let resources = webApp { name webappName; custom_domain (DomainConfig.InsecureDomain "customDomain.io") } |> getResources
         let wa = resources |> getResource<Web.Site> |> List.head
+
+        let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
 
         //Testing HostnameBinding
         let hostnameBinding = resources |> getResource<Web.HostNameBinding> |> List.head


### PR DESCRIPTION
Added ability to specify the connection string type when adding a connection string.

Added a test for the above.

This PR closes #871

The changes in this PR are as follows:

* Add a new overload that allows the builder to specify the connection string kind (e.g. a connection string is a for an AzureSQL database rather than "custom").

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here: 

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders
open Farmer.WebApp

let dbServer = "farmer_test"
let dbName = "farmer_test_db"
let userName = "admin"
let password = "****"

let webAppConfig =
    webApp {
        name $"farmer-con-string-test-568"
        sku Sku.F1
        connection_string ("DefaultConnection",
                           ArmExpression.create($"concat('Server=tcp:{dbServer}.database.windows.net,1433;Initial Catalog={dbName};Persist Security Info=False;User ID={userName};Password=', '{password}', ';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;')"), SQLAzure)
    }

let conStringTest =
    resourceGroup {
        name "con_string_test"
        location Location.CentralUS
        add_resources [ webAppConfig ]
    }

arm {
    add_resource conStringTest
 } |> Writer.quickWrite "con_string_test"
```
