### PR TITLE
Support zone redundancy on app service plans

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 ## vNext
 * WebApps/Functions: Don't turn on Logging Extension for Linux App Service.
 * WebApps/Functions: Fix .NET 5/6 on Linux deployments.
+* ServicePlan/WebApp: Support for enabling ZoneDedundant
 
 ## 1.6.25
 * CosmosDb: Add support for serverless capacity mode.

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -63,6 +63,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Service Plan | sku | Sets the sku of the service plan. |
 | Service Plan | worker_size | Sets the size of the service plan worker. |
 | Service Plan | number_of_workers | Sets the number of instances on the service plan. |
+| Service Plan | enable_zone_redundant | Enables ZoneRedundant on the service plan. |
 
 > **Farmer also comes with a dedicated Service Plan builder** that contains all of the above keywords that apply to a Service Plan.
 >

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -64,7 +64,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Service Plan | sku | Sets the sku of the service plan. |
 | Service Plan | worker_size | Sets the size of the service plan worker. |
 | Service Plan | number_of_workers | Sets the number of instances on the service plan. |
-| Service Plan | enable_zone_redundant | Enables ZoneRedundant on the service plan. |
+| Service Plan | zone_redundant | Enables ZoneRedundant on the service plan. |
 
 > **Farmer also comes with a dedicated Service Plan builder** that contains all of the above keywords that apply to a Service Plan.
 >

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -29,7 +29,7 @@ type ServerFarm =
       WorkerCount : int
       MaximumElasticWorkerCount : int option
       OperatingSystem : OS
-      ZoneRedundant : bool option
+      ZoneRedundant : FeatureFlag option
       Tags: Map<string,string> }
     member this.IsDynamic =
         match this.Sku, this.WorkerSize with
@@ -108,7 +108,7 @@ type ServerFarm =
                          perSiteScaling = if this.IsDynamic then Nullable() else Nullable false
                          reserved = this.Reserved
                          maximumElasticWorkerCount = this.MaximumElasticWorkerCount |> Option.toNullable
-                         zoneRedundant = this.ZoneRedundant |> Option.toNullable |}
+                         zoneRedundant = this.ZoneRedundant |> Option.map(fun f -> f.AsBoolean) |> Option.toNullable |}
                  kind = this.Kind |> Option.toObj
             |}
 

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -29,6 +29,7 @@ type ServerFarm =
       WorkerCount : int
       MaximumElasticWorkerCount : int option
       OperatingSystem : OS
+      ZoneRedundant : bool option
       Tags: Map<string,string> }
     member this.IsDynamic =
         match this.Sku, this.WorkerSize with
@@ -106,7 +107,8 @@ type ServerFarm =
                          computeMode = if this.IsDynamic then "Dynamic" else null
                          perSiteScaling = if this.IsDynamic then Nullable() else Nullable false
                          reserved = this.Reserved
-                         maximumElasticWorkerCount = this.MaximumElasticWorkerCount |> Option.toNullable |}
+                         maximumElasticWorkerCount = this.MaximumElasticWorkerCount |> Option.toNullable
+                         zoneRedundant = this.ZoneRedundant |> Option.toNullable |}
                  kind = this.Kind |> Option.toObj
             |}
 

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -284,6 +284,7 @@ type FunctionsConfig =
                   WorkerCount = 0
                   MaximumElasticWorkerCount = None
                   OperatingSystem = this.CommonWebConfig.OperatingSystem
+                  ZoneRedundant = None
                   Tags = this.Tags }
             | _ ->
                 ()

--- a/src/Farmer/Builders/Builders.ServicePlan.fs
+++ b/src/Farmer/Builders/Builders.ServicePlan.fs
@@ -12,6 +12,7 @@ type ServicePlanConfig =
       WorkerCount : int
       MaximumElasticWorkerCount : int option
       OperatingSystem : OS
+      ZoneRedundant : bool option
       Tags : Map<string,string> }
     interface IBuilder with
         member this.ResourceId = serverFarms.resourceId this.Name
@@ -23,6 +24,7 @@ type ServicePlanConfig =
             OperatingSystem = this.OperatingSystem
             WorkerCount = this.WorkerCount
             MaximumElasticWorkerCount = this.MaximumElasticWorkerCount
+            ZoneRedundant = this.ZoneRedundant
             Tags = this.Tags }
         ]
 
@@ -34,6 +36,7 @@ type ServicePlanBuilder() =
           WorkerCount = 1
           MaximumElasticWorkerCount = None
           OperatingSystem = Windows
+          ZoneRedundant = None
           Tags = Map.empty }
     [<CustomOperation "name">]
     /// Sets the name of the Server Farm.
@@ -56,6 +59,8 @@ type ServicePlanBuilder() =
     [<CustomOperation "serverless">]
     /// Configures this server farm to host serverless functions, not web apps.
     member _.Serverless(state:ServicePlanConfig) = { state with Sku = Dynamic; WorkerSize = Serverless }
+    [<CustomOperation "enable_zone_redundant">]
+    member _.ZoneRedundant(state:ServicePlanConfig) = {state with ZoneRedundant = Some true}
     interface ITaggable<ServicePlanConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let servicePlan = ServicePlanBuilder()

--- a/src/Farmer/Builders/Builders.ServicePlan.fs
+++ b/src/Farmer/Builders/Builders.ServicePlan.fs
@@ -12,7 +12,7 @@ type ServicePlanConfig =
       WorkerCount : int
       MaximumElasticWorkerCount : int option
       OperatingSystem : OS
-      ZoneRedundant : bool option
+      ZoneRedundant : FeatureFlag option
       Tags : Map<string,string> }
     interface IBuilder with
         member this.ResourceId = serverFarms.resourceId this.Name
@@ -59,8 +59,8 @@ type ServicePlanBuilder() =
     [<CustomOperation "serverless">]
     /// Configures this server farm to host serverless functions, not web apps.
     member _.Serverless(state:ServicePlanConfig) = { state with Sku = Dynamic; WorkerSize = Serverless }
-    [<CustomOperation "enable_zone_redundant">]
-    member _.ZoneRedundant(state:ServicePlanConfig) = {state with ZoneRedundant = Some true}
+    [<CustomOperation "zone_redundant">]
+    member _.ZoneRedundant(state:ServicePlanConfig, flag:FeatureFlag) = {state with ZoneRedundant = Some flag}
     interface ITaggable<ServicePlanConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let servicePlan = ServicePlanBuilder()

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -202,7 +202,8 @@ type WebAppConfig =
       AutomaticLoggingExtension : bool
       SiteExtensions : ExtensionName Set
       PrivateEndpoints: (LinkedResource * string option) Set
-      CustomDomain : DomainConfig }
+      CustomDomain : DomainConfig 
+      ZoneRedundant : bool option }
     member this.Name = this.CommonWebConfig.Name
     /// Gets this web app's Server Plan's full resource ID.
     member this.ServicePlanId = this.CommonWebConfig.ServicePlan.resourceId this.Name.ResourceName
@@ -467,6 +468,7 @@ type WebAppConfig =
                   WorkerCount = this.WorkerCount
                   MaximumElasticWorkerCount = this.MaximumElasticWorkerCount
                   OperatingSystem = this.CommonWebConfig.OperatingSystem
+                  ZoneRedundant = this.ZoneRedundant
                   Tags = this.Tags}
             | _ ->
                 ()
@@ -583,7 +585,8 @@ type WebAppBuilder() =
           AutomaticLoggingExtension = true
           SiteExtensions = Set.empty
           PrivateEndpoints = Set.empty
-          CustomDomain = NoDomain}
+          CustomDomain = NoDomain
+          ZoneRedundant = None}
     member _.Run(state:WebAppConfig) =
         if state.Name.ResourceName = ResourceName.Empty then raiseFarmer "No Web App name has been set."
         { state with
@@ -690,6 +693,9 @@ type WebAppBuilder() =
     member _.CustomDomain(state:WebAppConfig, domainConfig) = { state with CustomDomain = domainConfig }
     member _.CustomDomain(state:WebAppConfig, customDomain) = { state with CustomDomain = SecureDomain (customDomain,AppManagedCertificate) }
     member _.CustomDomain(state:WebAppConfig, (customDomain,thumbprint)) = { state with CustomDomain = SecureDomain (customDomain,CustomCertificate thumbprint) }
+    /// Enables the zone redundancy in service plan
+    [<CustomOperation "enable_zone_redundant">]
+    member this.ZoneRedundant(state:WebAppConfig) = {state with ZoneRedundant = Some true}
 
     interface IPrivateEndpoints<WebAppConfig> with member _.Add state endpoints = { state with PrivateEndpoints = state.PrivateEndpoints |> Set.union endpoints}
     interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -204,9 +204,8 @@ type WebAppConfig =
       SiteExtensions : ExtensionName Set
       PrivateEndpoints: (LinkedResource * string option) Set
       CustomDomain : DomainConfig 
-      ZoneRedundant : bool option 
-      DockerPort: int option }
-
+      DockerPort: int option
+      ZoneRedundant : FeatureFlag option }
     member this.Name = this.CommonWebConfig.Name
     /// Gets this web app's Server Plan's full resource ID.
     member this.ServicePlanId = this.CommonWebConfig.ServicePlan.resourceId this.Name.ResourceName
@@ -591,8 +590,8 @@ type WebAppBuilder() =
           SiteExtensions = Set.empty
           PrivateEndpoints = Set.empty
           CustomDomain = NoDomain
-          ZoneRedundant = None
-          DockerPort = None }
+          DockerPort = None
+          ZoneRedundant = None }
 
     member _.Run(state:WebAppConfig) =
         if state.Name.ResourceName = ResourceName.Empty then raiseFarmer "No Web App name has been set."
@@ -700,12 +699,12 @@ type WebAppBuilder() =
     member _.CustomDomain(state:WebAppConfig, domainConfig) = { state with CustomDomain = domainConfig }
     member _.CustomDomain(state:WebAppConfig, customDomain) = { state with CustomDomain = SecureDomain (customDomain,AppManagedCertificate) }
     member _.CustomDomain(state:WebAppConfig, (customDomain,thumbprint)) = { state with CustomDomain = SecureDomain (customDomain,CustomCertificate thumbprint) }
-    /// Enables the zone redundancy in service plan
-    [<CustomOperation "enable_zone_redundant">]
-    member this.ZoneRedundant(state:WebAppConfig) = {state with ZoneRedundant = Some true}
     /// Map specified port traffic from your docker container to port 80 for App Service
     [<CustomOperation "docker_port">]
     member _.DockerPort(state: WebAppConfig, dockerPort:int) = { state with DockerPort = Some dockerPort }
+    /// Enables the zone redundancy in service plan
+    [<CustomOperation "zone_redundant">]
+    member this.ZoneRedundant(state:WebAppConfig, flag:FeatureFlag) = {state with ZoneRedundant = Some flag}
 
     interface IPrivateEndpoints<WebAppConfig> with member _.Add state endpoints = { state with PrivateEndpoints = state.PrivateEndpoints |> Set.union endpoints}
     interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -60,6 +60,7 @@ let allTests =
                 WebApp.tests
                 Dashboards.tests
                 Alerts.tests
+                ServicePlan.tests
             ]
             testList "Control" [
                 if (hasEnv "TF_BUILD" "True" && notEnv "BUILD_REASON" "PullRequest") || hasEnv "FARMER_E2E" "True" then

--- a/src/Tests/ServicePlan.fs
+++ b/src/Tests/ServicePlan.fs
@@ -1,0 +1,19 @@
+﻿module ServicePlan
+
+open Expecto
+open Farmer
+open Farmer.Builders
+open Farmer.Arm
+open System
+
+let getResource<'T when 'T :> IArmResource> (data:IArmResource list) = data |> List.choose(function :? 'T as x -> Some x | _ -> None)
+let getResources (v:IBuilder) = v.BuildResources Location.WestEurope
+
+let tests = testList "Service Plan Tests"[
+    test "Enable zoneRedundant in service plan" {
+       let resources = webApp { name "test"; enable_zone_redundant } |> getResources
+       let sf = resources |> getResource<Web.ServerFarm> |> List.head
+       
+       Expect.equal sf.ZoneRedundant (Some true) "ZoneRedundant should be enabled"
+   }
+]

--- a/src/Tests/ServicePlan.fs
+++ b/src/Tests/ServicePlan.fs
@@ -25,7 +25,7 @@ let tests = testList "Service Plan Tests" [
     }
 
     test "Enable zoneRedundant in service plan" {
-        let servicePlan = servicePlan { name "test"; enable_zone_redundant } 
+        let servicePlan = servicePlan { name "test"; zone_redundant Enabled } 
         let sf = servicePlan |> getResources |> getResource<Web.ServerFarm> |> List.head
 
         let template = arm{ add_resource servicePlan}
@@ -34,8 +34,23 @@ let tests = testList "Service Plan Tests" [
         let zoneRedundant = 
             jobj.SelectToken($"$..resources[?(@.type=='Microsoft.Web/serverfarms')].properties.zoneRedundant")
        
-        Expect.equal sf.ZoneRedundant (Some true) "ZoneRedundant should be enabled"
+        Expect.equal sf.ZoneRedundant (Some Enabled) "ZoneRedundant should be enabled"
         Expect.isNotNull zoneRedundant "Template should include zone redundancy information"
         Expect.equal (zoneRedundant.ToString().ToLower()) "true" "ZoneRedundant should be set to true"
+    }
+
+    test "Disable zoneRedundant in service plan" {
+        let servicePlan = servicePlan { name "test"; zone_redundant Disabled } 
+        let sf = servicePlan |> getResources |> getResource<Web.ServerFarm> |> List.head
+
+        let template = arm{ add_resource servicePlan}
+        let jobj = template.Template |> Writer.toJson |> Newtonsoft.Json.Linq.JObject.Parse
+
+        let zoneRedundant = 
+            jobj.SelectToken($"$..resources[?(@.type=='Microsoft.Web/serverfarms')].properties.zoneRedundant")
+       
+        Expect.equal sf.ZoneRedundant (Some Disabled) "ZoneRedundant should be disabled"
+        Expect.isNotNull zoneRedundant "Template should include zone redundancy information"
+        Expect.equal (zoneRedundant.ToString().ToLower()) "false" "ZoneRedundant should be set to false"
     }
 ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="ServicePlan.fs" />
     <Content Include="test-data\*.json" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="Helpers.fs" />
     <Compile Include="AppGateway.fs" />

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -716,4 +716,11 @@ let tests = testList "Web App Tests" [
         let extensions = wa |> getResources |> getResource<SiteExtension>
         Expect.isEmpty extensions "Should not be any extensions"
     }
+
+    test "Web App enables zoneRedundant in service plan" {
+        let resources = webApp { name "test"; enable_zone_redundant } |> getResources
+        let sf = resources |> getResource<Web.ServerFarm> |> List.head
+           
+        Expect.equal sf.ZoneRedundant (Some true) "ZoneRedundant should be enabled"
+    }
 ]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -717,14 +717,6 @@ let tests = testList "Web App Tests" [
         Expect.isEmpty extensions "Should not be any extensions"
     }
 
-
-    test "Web App enables zoneRedundant in service plan" {
-        let resources = webApp { name "test"; enable_zone_redundant } |> getResources
-        let sf = resources |> getResource<Web.ServerFarm> |> List.head
-           
-        Expect.equal sf.ZoneRedundant (Some true) "ZoneRedundant should be enabled"
-    }
-
     test "Supports docker ports with WEBSITES_PORT"{
         let wa = webApp { name "testApp"; docker_port 8080; }
         let port = Expect.wantSome wa.DockerPort "Docker port should be set"
@@ -742,4 +734,10 @@ let tests = testList "Web App Tests" [
         Expect.isNone defaultWa.DockerPort "Docker port should not be set"
     }
 
+    test "Web App enables zoneRedundant in service plan" {
+        let resources = webApp { name "test"; zone_redundant Enabled } |> getResources
+        let sf = resources |> getResource<Web.ServerFarm> |> List.head
+
+        Expect.equal sf.ZoneRedundant (Some Enabled) "ZoneRedundant should be enabled"
+    }
 ]


### PR DESCRIPTION
This PR closes #875

The changes in this PR are as follows:

* Introduced `enable_zone_redundant` for WebApp/ServicePlan

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let myasp = servicePlan {
    name "zone-redundant-sp"
    sku WebApp.Sku.P1V2
    enable_zone_redundant
}
```

OR

```fsharp
let myapp = webApp{
    name "zone-redundant-app"
    sku WebApp.Sku.P1V2
    enable_zone_redundant
}
```
