### PR TITLE
Added possibility to set vnet rules for PostgreSQL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.6.29
 * CLI: include `--only-show-error` option when executing Azure CLI commands.
+* PostgreSQL: Added possibility to set vnet rules for PostgreSQL.
 
 ## 1.6.28
 * ServicePlan/WebApp: Support for enabling ZoneDedundant

--- a/docs/content/api-overview/resources/postgresql.md
+++ b/docs/content/api-overview/resources/postgresql.md
@@ -35,6 +35,8 @@ parameter for the admin account password.
 | Server | enable_azure_firewall | Enables firewall access to all Azure services |
 | Server | add_firewall_rule (name:string, start ip:string, end ip:string) | Adds a firewall rule to the server |
 | Server | add_firewall_rules (rules:(string*string*sting)list) | As add_firewall_rule but a list of rules |
+| Server | add_vnet_rule (name:string, virtualNetworkSubnetId:string) | Adds a vnet rule to the server |
+| Server | add_vnet_rules (rules:(string*sting)list) | As add_vnet_rule but a list of rules |
 
 #### PostgreSQLDb Builder keywords
 | Applies To | Keyword | Purpose |

--- a/docs/content/api-overview/resources/postgresql.md
+++ b/docs/content/api-overview/resources/postgresql.md
@@ -35,8 +35,8 @@ parameter for the admin account password.
 | Server | enable_azure_firewall | Enables firewall access to all Azure services |
 | Server | add_firewall_rule (name:string, start ip:string, end ip:string) | Adds a firewall rule to the server |
 | Server | add_firewall_rules (rules:(string*string*sting)list) | As add_firewall_rule but a list of rules |
-| Server | add_vnet_rule (name:string, virtualNetworkSubnetId:string) | Adds a vnet rule to the server |
-| Server | add_vnet_rules (rules:(string*sting)list) | As add_vnet_rule but a list of rules |
+| Server | add_vnet_rule (name:string, virtualNetworkSubnetId:ResourceId) | Adds a vnet rule to the server |
+| Server | add_vnet_rules (rules:(string*ResourceId)list) | As add_vnet_rule but a list of rules |
 
 #### PostgreSQLDb Builder keywords
 | Applies To | Keyword | Purpose |

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -7,6 +7,7 @@ open Farmer.PostgreSQL
 
 let databases = ResourceType ("Microsoft.DBforPostgreSQL/servers/databases", "2017-12-01")
 let firewallRules = ResourceType ("Microsoft.DBforPostgreSQL/servers/firewallrules",  "2017-12-01")
+let virtualNetworkRules = ResourceType ("Microsoft.DBforPostgreSQL/servers/virtualNetworkRules",  "2017-12-01")
 let servers = ResourceType ("Microsoft.DBforPostgreSQL/servers", "2017-12-01")
 
 [<RequireQualifiedAccess>]
@@ -44,6 +45,18 @@ module Servers =
             member this.JsonModel =
                 {| firewallRules.Create(this.Server/this.Name, this.Location, [ servers.resourceId this.Server ]) with
                     properties = {| startIpAddress = string this.Start; endIpAddress = string this.End; |}
+                |}
+
+    type VnetRule =
+        { Name : ResourceName
+          Server : ResourceName
+          VirtualNetworkSubnetId : string
+          Location : Location }
+        interface IArmResource with
+            member this.ResourceId = virtualNetworkRules.resourceId (this.Server/this.Name)
+            member this.JsonModel =
+                {| virtualNetworkRules.Create(this.Server/this.Name, this.Location, [ servers.resourceId this.Server ]) with
+                    properties = {| virtualNetworkSubnetId = this.VirtualNetworkSubnetId |}
                 |}
 
 type Server =

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -50,13 +50,13 @@ module Servers =
     type VnetRule =
         { Name : ResourceName
           Server : ResourceName
-          VirtualNetworkSubnetId : string
+          VirtualNetworkSubnetId : ResourceId
           Location : Location }
         interface IArmResource with
             member this.ResourceId = virtualNetworkRules.resourceId (this.Server/this.Name)
             member this.JsonModel =
                 {| virtualNetworkRules.Create(this.Server/this.Name, this.Location, [ servers.resourceId this.Server ]) with
-                    properties = {| virtualNetworkSubnetId = this.VirtualNetworkSubnetId |}
+                    properties = {| virtualNetworkSubnetId = this.VirtualNetworkSubnetId.Eval() |}
                 |}
 
 type Server =

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -28,7 +28,7 @@ type PostgreSQLConfig =
       Tier : Sku
       Databases : PostgreSQLDbConfig list
       FirewallRules : {| Name : ResourceName; Start : IPAddress; End : IPAddress |} list
-      VirtualNetworkRules : {| Name : ResourceName; VirtualNetworkSubnetId : string |} list
+      VirtualNetworkRules : {| Name : ResourceName; VirtualNetworkSubnetId : ResourceId |} list
       Tags: Map<string,string>  }
 
     interface IBuilder with
@@ -304,7 +304,7 @@ type PostgreSQLBuilder() =
 
     /// Adds a custom vnet rule given a name and a virtualNetworkSubnetId.
     [<CustomOperation "add_vnet_rule">]
-    member _.AddVnetRule(state:PostgreSQLConfig, name, virtualNetworkSubnetId:string) =
+    member _.AddVnetRule(state:PostgreSQLConfig, name, virtualNetworkSubnetId:ResourceId) =
         { state with
             VirtualNetworkRules =
                 {| Name = ResourceName name
@@ -313,7 +313,7 @@ type PostgreSQLBuilder() =
 
     /// Adds a custom firewall rules given a name and a virtualNetworkSubnetId.
     [<CustomOperation "add_vnet_rules">]
-    member _.AddVnetRules(state:PostgreSQLConfig, listOfRules:(string*string) list) =
+    member _.AddVnetRules(state:PostgreSQLConfig, listOfRules:(string*ResourceId) list) =
         let newRules =
             listOfRules |> List.map(fun (name, virtualNetworkSubnetId) ->
                 {| Name = ResourceName name

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -28,6 +28,7 @@ type PostgreSQLConfig =
       Tier : Sku
       Databases : PostgreSQLDbConfig list
       FirewallRules : {| Name : ResourceName; Start : IPAddress; End : IPAddress |} list
+      VirtualNetworkRules : {| Name : ResourceName; VirtualNetworkSubnetId : string |} list
       Tags: Map<string,string>  }
 
     interface IBuilder with
@@ -57,6 +58,12 @@ type PostgreSQLConfig =
                 { Name = rule.Name
                   Start = rule.Start
                   End = rule.End
+                  Server = this.Name
+                  Location = location }
+
+            for rule in this.VirtualNetworkRules do
+                { Name = rule.Name
+                  VirtualNetworkSubnetId = rule.VirtualNetworkSubnetId
                   Server = this.Name
                   Location = location }
         ]
@@ -175,6 +182,7 @@ type PostgreSQLBuilder() =
           Tier = Basic
           Databases = []
           FirewallRules = []
+          VirtualNetworkRules = []
           Tags = Map.empty  }
 
     member _.Run state : PostgreSQLConfig =
@@ -293,5 +301,23 @@ type PostgreSQLBuilder() =
     member this.EnableAzureFirewall(state:PostgreSQLConfig) =
         this.AddFirewallWall(state, "allow-azure-services", "0.0.0.0", "0.0.0.0")
     interface ITaggable<PostgreSQLConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+
+    /// Adds a custom vnet rule given a name and a virtualNetworkSubnetId.
+    [<CustomOperation "add_vnet_rule">]
+    member _.AddVnetRule(state:PostgreSQLConfig, name, virtualNetworkSubnetId:string) =
+        { state with
+            VirtualNetworkRules =
+                {| Name = ResourceName name
+                   VirtualNetworkSubnetId = virtualNetworkSubnetId |}
+                :: state.VirtualNetworkRules }
+
+    /// Adds a custom firewall rules given a name and a virtualNetworkSubnetId.
+    [<CustomOperation "add_vnet_rules">]
+    member _.AddVnetRules(state:PostgreSQLConfig, listOfRules:(string*string) list) =
+        let newRules =
+            listOfRules |> List.map(fun (name, virtualNetworkSubnetId) ->
+                {| Name = ResourceName name
+                   VirtualNetworkSubnetId = virtualNetworkSubnetId |})
+        { state with VirtualNetworkRules = newRules @ state.VirtualNetworkRules }
 
 let postgreSQL = PostgreSQLBuilder()

--- a/src/Tests/PostgreSQL.fs
+++ b/src/Tests/PostgreSQL.fs
@@ -166,7 +166,14 @@ let tests = testList "PostgreSQL Database Service" [
         let subscriptionId = "sid-subid"
         let resourceGroup = "rg-abc"
         let vnetName = "vnetid"
-        let networkResourceId = $"/subscriptions/%s{subscriptionId}/resourceGroups/%s{resourceGroup}/providers/Microsoft.Network/virtualNetworks/%s{vnetName}/subnets/default"
+        let subnetName = "default"
+        let networkResourceId =
+            { Type = subnets
+              ResourceGroup = Some resourceGroup
+              Subscription = Some subscriptionId
+              Name = ResourceName vnetName
+              Segments = [ResourceName subnetName] }
+        let networkResourceIdString = networkResourceId.Eval()
         let vnetRuleName = "vnet-rule-name"
         let actual = postgreSQL {
             name "testdb"
@@ -186,7 +193,7 @@ let tests = testList "PostgreSQL Database Service" [
               apiVersion = "2017-12-01"
               dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
               location = "northeurope"
-              properties = {| virtualNetworkSubnetId = networkResourceId |} }
+              properties = {| virtualNetworkSubnetId = networkResourceIdString |} }
         Expect.equal actual expectedVnetRuleResult "Vnet is incorrect"
     }
 
@@ -195,11 +202,25 @@ let tests = testList "PostgreSQL Database Service" [
         let resourceGroup = "rg-abc"
 
         let vnetName1 = "vnetid1"
-        let networkResourceId1 = $"/subscriptions/%s{subscriptionId}/resourceGroups/%s{resourceGroup}/providers/Microsoft.Network/virtualNetworks/%s{vnetName1}/subnets/default"
+        let subnetName1 = "default1"
+        let networkResourceId1 =
+            { Type = subnets
+              ResourceGroup = Some resourceGroup
+              Subscription = Some subscriptionId
+              Name = ResourceName vnetName1
+              Segments = [ResourceName subnetName1] }
+        let networkResourceId1String = networkResourceId1.Eval()
         let vnetRuleName1 = "vnet-rule-name1"
 
         let vnetName2 = "vnetid2"
-        let networkResourceId2 = $"/subscriptions/%s{subscriptionId}/resourceGroups/%s{resourceGroup}/providers/Microsoft.Network/virtualNetworks/%s{vnetName2}/subnets/default"
+        let subnetName2 = "default2"
+        let networkResourceId2 =
+            { Type = subnets
+              ResourceGroup = Some resourceGroup
+              Subscription = Some subscriptionId
+              Name = ResourceName vnetName2
+              Segments = [ResourceName subnetName2] }
+        let networkResourceId2String = networkResourceId2.Eval()
         let vnetRuleName2 = "vnet-rule-name2"
 
         let actual = postgreSQL {
@@ -225,14 +246,14 @@ let tests = testList "PostgreSQL Database Service" [
               apiVersion = "2017-12-01"
               dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
               location = "northeurope"
-              properties = {| virtualNetworkSubnetId = networkResourceId1 |} }
+              properties = {| virtualNetworkSubnetId = networkResourceId1String |} }
         let expectedVnetRuleResult2 : VnetResource =
             { name = $"testdb/%s{vnetRuleName2}"
               ``type`` = "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules"
               apiVersion = "2017-12-01"
               dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
               location = "northeurope"
-              properties = {| virtualNetworkSubnetId = networkResourceId2 |} }
+              properties = {| virtualNetworkSubnetId = networkResourceId2String |} }
         Expect.equal actual1 expectedVnetRuleResult1 "Vnet is incorrect"
         Expect.equal actual2 expectedVnetRuleResult2 "Vnet is incorrect"
     }

--- a/src/Tests/PostgreSQL.fs
+++ b/src/Tests/PostgreSQL.fs
@@ -56,6 +56,14 @@ type FirewallResource =
         properties: {| endIpAddress: string; startIpAddress: string |}
         location: string }
 
+type VnetResource =
+    {   name: string
+        apiVersion: string
+        ``type`` : string
+        dependsOn : string array
+        properties: {| virtualNetworkSubnetId: string |}
+        location: string }
+
 let runBuilder<'T> = toTypedTemplate<'T> Location.NorthEurope
 
 module Expect =
@@ -144,7 +152,7 @@ let tests = testList "PostgreSQL Database Service" [
             |> Serialization.ofJson<TypedArmTemplate<FirewallResource>>
             |> fun r -> r.Resources
             |> Seq.find(fun r -> r.name = "testdb/allow-azure-services")
-        let expectedFwRuleRes =
+        let expectedFwRuleRes : FirewallResource =
             { name = "testdb/allow-azure-services"
               ``type`` = "Microsoft.DBforPostgreSQL/servers/firewallrules"
               apiVersion = "2017-12-01"
@@ -152,6 +160,81 @@ let tests = testList "PostgreSQL Database Service" [
               location = "northeurope"
               properties = {| startIpAddress = "0.0.0.0"; endIpAddress = "0.0.0.0" |} }
         Expect.equal actual expectedFwRuleRes "Firewall is incorrect"
+    }
+
+    test "Vnet rule are correctly set" {
+        let subscriptionId = "sid-subid"
+        let resourceGroup = "rg-abc"
+        let vnetName = "vnetid"
+        let networkResourceId = $"/subscriptions/%s{subscriptionId}/resourceGroups/%s{resourceGroup}/providers/Microsoft.Network/virtualNetworks/%s{vnetName}/subnets/default"
+        let vnetRuleName = "vnet-rule-name"
+        let actual = postgreSQL {
+            name "testdb"
+            admin_username "myadminuser"
+            add_vnet_rule vnetRuleName networkResourceId
+        }
+        let actual =
+            actual
+            |> toTemplate Location.NorthEurope
+            |> Writer.toJson
+            |> Serialization.ofJson<TypedArmTemplate<VnetResource>>
+            |> fun r -> r.Resources
+            |> Seq.find(fun r -> r.name = $"testdb/%s{vnetRuleName}")
+        let expectedVnetRuleResult : VnetResource =
+            { name = $"testdb/%s{vnetRuleName}"
+              ``type`` = "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules"
+              apiVersion = "2017-12-01"
+              dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
+              location = "northeurope"
+              properties = {| virtualNetworkSubnetId = networkResourceId |} }
+        Expect.equal actual expectedVnetRuleResult "Vnet is incorrect"
+    }
+
+    test "Vnet rules are correctly set" {
+        let subscriptionId = "sid-subid"
+        let resourceGroup = "rg-abc"
+
+        let vnetName1 = "vnetid1"
+        let networkResourceId1 = $"/subscriptions/%s{subscriptionId}/resourceGroups/%s{resourceGroup}/providers/Microsoft.Network/virtualNetworks/%s{vnetName1}/subnets/default"
+        let vnetRuleName1 = "vnet-rule-name1"
+
+        let vnetName2 = "vnetid2"
+        let networkResourceId2 = $"/subscriptions/%s{subscriptionId}/resourceGroups/%s{resourceGroup}/providers/Microsoft.Network/virtualNetworks/%s{vnetName2}/subnets/default"
+        let vnetRuleName2 = "vnet-rule-name2"
+
+        let actual = postgreSQL {
+            name "testdb"
+            admin_username "myadminuser"
+            add_vnet_rules [vnetRuleName1, networkResourceId1; vnetRuleName2, networkResourceId2]
+        }
+        let actual =
+            actual
+            |> toTemplate Location.NorthEurope
+            |> Writer.toJson
+            |> Serialization.ofJson<TypedArmTemplate<VnetResource>>
+            |> fun r -> r.Resources
+        let actual1 =
+            actual
+            |> Seq.find(fun r -> r.name = $"testdb/%s{vnetRuleName1}")
+        let actual2 =
+            actual
+            |> Seq.find(fun r -> r.name = $"testdb/%s{vnetRuleName2}")
+        let expectedVnetRuleResult1 : VnetResource =
+            { name = $"testdb/%s{vnetRuleName1}"
+              ``type`` = "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules"
+              apiVersion = "2017-12-01"
+              dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
+              location = "northeurope"
+              properties = {| virtualNetworkSubnetId = networkResourceId1 |} }
+        let expectedVnetRuleResult2 : VnetResource =
+            { name = $"testdb/%s{vnetRuleName2}"
+              ``type`` = "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules"
+              apiVersion = "2017-12-01"
+              dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
+              location = "northeurope"
+              properties = {| virtualNetworkSubnetId = networkResourceId2 |} }
+        Expect.equal actual1 expectedVnetRuleResult1 "Vnet is incorrect"
+        Expect.equal actual2 expectedVnetRuleResult2 "Vnet is incorrect"
     }
 
     test "Server name must be given" {


### PR DESCRIPTION
This PR closes -

The changes in this PR are as follows:

* Added possibility to set vnet rules for PostgreSQL

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
Could not figure out how to best test this as I mostly looked at the configuration for adding firewall rules. Can try to add them if this is something you want to merge.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let networkResourceId = $"/subscriptions/%s{subscriptionId}/resourceGroups/%s{resourceGroup}/providers/Microsoft.Network/virtualNetworks/%s{myVnet.ResourceId.Name.Value}/subnets/default"

postgreSQL {
  admin_username "Admin name"
  name "the-name"
  capacity 1<VCores>
  storage_size 1<Gb>
  ...  
  add_vnet_rule "TheNetworkName" networkResourceId
}
```
