### PR TITLE
Bundle LICENSE and README in nuget

### DIFF
--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -21,7 +21,8 @@
     <PackageTags>azure;resource-manager;template;dsl;fsharp;infrastructure-as-code</PackageTags>
     <PackageReleaseNotes>https://raw.githubusercontent.com/CompositionalIT/farmer/master/RELEASE_NOTES.md</PackageReleaseNotes>
     <PackageProjectUrl>https://compositionalit.github.io/farmer</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/CompositionalIT/farmer</RepositoryUrl>
@@ -48,6 +49,11 @@
       <Pack>true</Pack>
       <PackagePath>$(PackageIconUrl)</PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../LICENSE" Pack="true" PackagePath="" />
+    <None Include="../../readme.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* [Bundles the LICENSE file](https://docs.microsoft.com/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file) in the nuget package, so if the license ever changes it is clear which license applies to a package version.
* [Bundles the readme](https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/) in the nuget package so it is displayed on the nuget page.
