### PR TITLE
Allow adding an IP restriction with CIDR as a string to web apps and functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,14 @@
 Release Notes
 =============
 
+## 1.6.30
+* WebApps/Functions: Allow adding IP restriction string with CIDR
+
 ## 1.6.29
 * CLI: include `--only-show-error` option when executing Azure CLI commands.
 
 ## 1.6.28
-* ServicePlan/WebApp: Support for enabling ZoneDedundant
+* ServicePlan/WebApp: Support for enabling ZoneRedundant
 
 ## 1.6.27
 * Functions: Make `connection_string` available for Azure Functions in addition to WebApps.

--- a/samples/scripts/webapp-storage.fsx
+++ b/samples/scripts/webapp-storage.fsx
@@ -15,6 +15,8 @@ let myWebApp = webApp {
     sku WebApp.Sku.S1
     app_insights_off
     setting "storage_key" myStorage.Key
+    add_allowed_ip_restriction "allow everything" "0.0.0.0/0"
+    add_denied_ip_restriction "deny" "1.2.3.4/31"
 }
 
 let deployment = arm {

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -597,27 +597,30 @@ module Storage =
 
 /// A network represented by an IP address and CIDR prefix.
 type public IPAddressCidr =
-    { Address : System.Net.IPAddress
+    { Address : Net.IPAddress
       Prefix : int }
 
 /// Functions for IP networks and CIDR notation.
 module IPAddressCidr =
     let parse (s:string) : IPAddressCidr =
-        match s.Split([|'/'|], System.StringSplitOptions.RemoveEmptyEntries) with
-        [| ip; prefix |] ->
-            { Address = System.Net.IPAddress.Parse (ip.Trim ())
+        match s.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries) with
+        | [| ip; prefix |] ->
+            { Address = Net.IPAddress.Parse (ip.Trim())
               Prefix = int prefix }
-        | _ -> raise (System.ArgumentOutOfRangeException "Malformed CIDR, expecting an IP and prefix separated by '/'")
-    let safeParse (s:string) : Result<IPAddressCidr, System.Exception> =
+        | [| ip |] ->
+            { Address = Net.IPAddress.Parse (ip.Trim())
+              Prefix = 32 }
+        | _ -> raise (ArgumentOutOfRangeException "Malformed CIDR, expecting an IP and prefix separated by '/'")
+    let safeParse (s:string) : Result<IPAddressCidr, Exception> =
         try parse s |> Ok
         with ex -> Error ex
     let format (cidr:IPAddressCidr) = $"{cidr.Address}/{cidr.Prefix}"
     /// Gets uint32 representation of an IP address.
-    let private num (ip:System.Net.IPAddress) =
+    let private num (ip:Net.IPAddress) =
         ip.GetAddressBytes() |> Array.rev |> fun bytes -> BitConverter.ToUInt32 (bytes, 0)
     /// Gets IP address from uint32 representations
     let private ofNum (num:uint32) =
-        num |> BitConverter.GetBytes |> Array.rev |> System.Net.IPAddress
+        num |> BitConverter.GetBytes |> Array.rev |> Net.IPAddress
     let private ipRangeNums (cidr:IPAddressCidr) =
         let ipNumber = cidr.Address |> num
         let mask = 0xffffffffu <<< (32 - cidr.Prefix)

--- a/src/Tests/Common.fs
+++ b/src/Tests/Common.fs
@@ -53,6 +53,11 @@ let tests = testList "Common" [
         Expect.isFalse (outerCidr |> IPAddressCidr.contains innerCidr) ""
     }
 
+    test "IPAddressCidr default prefix is 32" {
+        let cidr = IPAddressCidr.parse "192.168.1.0"
+        Expect.equal cidr.Prefix 32 ""
+    }
+
     test "Docker image tag generation" {
         let officialNginx = Containers.DockerImage.PublicImage ("nginx", None)
         Expect.equal officialNginx.ImageTag "nginx:latest" "Official image generated with incorrect tag"

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -752,11 +752,11 @@ let tests = testList "Web App Tests" [
         Expect.contains (secureBinding3.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure2.io')]" "Third host name binding depends on second"
     }
     test "Supports adding ip restriction for allowed ip" {
-        let ip = IPAddressCidr.parse "1.2.3.4/32"
+        let ip = "1.2.3.4/32"
         let resources = webApp { name "test"; add_allowed_ip_restriction "test-rule" ip } |> getResources
         let site = resources |> getResource<Web.Site> |> List.head
 
-        let expectedRestriction = IpSecurityRestriction.Create "test-rule" ip Allow
+        let expectedRestriction = IpSecurityRestriction.Create "test-rule" (IPAddressCidr.parse ip) Allow
         Expect.equal site.IpSecurityRestrictions [ expectedRestriction ] "Should add allowed ip security restriction"
     }
     test "Supports adding ip restriction for denied ip" {


### PR DESCRIPTION
#835 added support for adding IP restrictions to web apps and functions. If adding an IP address directly as a string, CIDR notation was not allowed.

This PR allows using CIDR notation, while keeping the prefix as 32 if no CIDR is specified. This is a non-breaking change. 

---

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let myWebApp = webApp {
    name "mysuperwebapp"
    add_allowed_ip_restriction "allow everything" "0.0.0.0/0"
    add_denied_ip_restriction "deny" "1.2.3.4/31"
}
```