### PR TITLE
Use --only-show-errors - fixes #884

### DIFF
--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -45,7 +45,7 @@ module Az =
                 let azProcess =
                     ProcessStartInfo(
                         FileName = azCliPath.Value,
-                        Arguments = $"%s{arguments} --output json",
+                        Arguments = $"%s{arguments} --output json --only-show-errors",
                         UseShellExecute = false,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true)


### PR DESCRIPTION
This PR closes #884

The changes in this PR are as follows:

* adding --only-show-errors to all az command line calls