### PR TITLE
Add support for VNet integration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.6.28
+- WebApps/Functions: Add support for vnet integration
 
 ## 1.6.27
 * Functions: Make connection_string available for Azure Functions in addition to WebApps.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,10 @@
 Release Notes
 =============
-## 1.6.28
-- WebApps/Functions: Add support for vnet integration
-
-## vNext
-* WebApps/Functions: Specify connection string types
 
 ## 1.6.30
 * WebApps/Functions: Allow adding IP restriction string with CIDR
+* WebApps/Functions: Specify connection string types
+* WebApps/Functions: Add support for vnet integration
 
 ## 1.6.29
 * CLI: include `--only-show-error` option when executing Azure CLI commands.

--- a/docs/content/api-overview/resources/functions.md
+++ b/docs/content/api-overview/resources/functions.md
@@ -50,7 +50,8 @@ The Functions builder is used to create Azure Functions accounts. It abstracts t
 | health_check_path | Sets the path to your functions health check endpoint, which Azure load balancers will ping to determine which instances are healthy.|
 | add_allowed_ip_restriction | Adds an 'allow' rule for an ip |
 | add_denied_ip_restriction | Adds an 'deny' rule for an ip |
-| route_via_vnet | Enable the VNET integration feature in azure where all outbound traffic from the function with be sent via the specified subnet. |
+| link_to_vnet | Enable the VNET integration feature in azure where all outbound traffic from the function with be sent via the specified subnet. Use this operator when the given VNET is in the same deployment |
+| link_to_unmanaged_vnet | Enable the VNET integration feature in azure where all outbound traffic from the function with be sent via the specified subnet. Use this operator when the given VNET is *not* in the same deployment |
 #### Post-deployment Builder Keywords
 The Functions builder contains special commands that are executed *after* the ARM deployment is completed.
 

--- a/docs/content/api-overview/resources/functions.md
+++ b/docs/content/api-overview/resources/functions.md
@@ -50,7 +50,7 @@ The Functions builder is used to create Azure Functions accounts. It abstracts t
 | health_check_path | Sets the path to your functions health check endpoint, which Azure load balancers will ping to determine which instances are healthy.|
 | add_allowed_ip_restriction | Adds an 'allow' rule for an ip |
 | add_denied_ip_restriction | Adds an 'deny' rule for an ip |
-
+| route_via_vnet | Enable the VNET integration feature in azure where all outbound traffic from the function with be sent via the specified subnet. |
 #### Post-deployment Builder Keywords
 The Functions builder contains special commands that are executed *after* the ARM deployment is completed.
 

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -60,7 +60,8 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | add_allowed_ip_restriction | Adds an 'allow' rule for an ip |
 | Web App | add_denied_ip_restriction | Adds an 'deny' rule for an ip |
 | Web App | docker_port | Adds `WEBSITES_PORT` setting to map custom docker port to app service port 80 |
-| Web App | route_via_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. |
+| Web App | link_to_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. Use this operator when the given VNET is in the same deployment |
+| Web App | link_to_unmanaged_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. Use this operator when the given VNET is *not* in the same deployment |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -60,6 +60,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | add_allowed_ip_restriction | Adds an 'allow' rule for an ip |
 | Web App | add_denied_ip_restriction | Adds an 'deny' rule for an ip |
 | Web App | docker_port | Adds `WEBSITES_PORT` setting to map custom docker port to app service port 80 |
+| Web App | route_via_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/src/Farmer/Aliases.fs
+++ b/src/Farmer/Aliases.fs
@@ -1,4 +1,19 @@
 ﻿[<AutoOpen>]
 module Farmer.Aliases
 
+[<AutoOpen>]
+module BuilderExtensions = 
+    open Farmer.Builders
+    open Farmer.Arm.Network
+    type IPrivateEndpoints<'TConfig> with
+    member this.AddPrivateEndpoint(state:'TConfig, subnetId:LinkedResource) = this.AddPrivateEndpoint (state, SubnetReference.create subnetId)
+    member this.AddPrivateEndpoint(state:'TConfig, subnet:SubnetConfig) = this.AddPrivateEndpoint (state, SubnetReference.create subnet)
+    member this.AddPrivateEndpoint(state, (subnetRef:LinkedResource,epName)) = this.AddPrivateEndpoint (state, (SubnetReference.create subnetRef, epName))
+    member this.AddPrivateEndpoint(state:'TConfig, (vnetRef, subnetName):LinkedResource * ResourceName) = this.AddPrivateEndpoint (state, SubnetReference.create (vnetRef,subnetName))
+    member this.AddPrivateEndpoint(state, (vnetRef,subnetName,epName):LinkedResource * ResourceName * string) = this.AddPrivateEndpoint (state, ((SubnetReference.create (vnetRef, subnetName)), epName))
+    member this.AddPrivateEndpoint(state:'TConfig, (vnet, subnetName):VirtualNetworkConfig * ResourceName) = this.AddPrivateEndpoint (state, SubnetReference.create (vnet,subnetName))
+    
+    member this.AddPrivateEndpoints(state:'TConfig, subnetIds:LinkedResource list) = this.AddPrivateEndpoints (state, subnetIds |> List.map SubnetReference.create |> Set)
+    member this.AddPrivateEndpoints(state:'TConfig, subnets:SubnetConfig list) = this.AddPrivateEndpoints (state, subnets |> List.map SubnetReference.create |> Set)
+
 let arm = Farmer.Builders.ResourceGroup.DeploymentBuilder ()

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -32,8 +32,8 @@ type SubnetReference =
         | Direct subnet -> subnet.ResourceId
     member this.Dependency = 
         match this with
-        | ViaManagedVNet (vnetId,_)
-        | Direct (Managed vnetId) -> Some vnetId
+        | ViaManagedVNet (id,_)
+        | Direct (Managed id) -> Some id
         | _ -> None
     static member create(vnetRef:LinkedResource, subnetName:ResourceName) = 
         if vnetRef.ResourceId.Type.Type <> virtualNetworks.Type then 
@@ -47,8 +47,6 @@ type SubnetReference =
         if subnetRef.ResourceId.Type.Type <> subnets.Type then 
             raiseFarmer $"given resource was not of type '{subnets.Type}'."
         Direct subnetRef
-
-    static member create(subnetId:ResourceId) = ()
 
 type PublicIpAddress =
     { Name : ResourceName

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -35,24 +35,17 @@ type SubnetReference =
         | ViaManagedVNet (vnetId,_)
         | Direct (Managed vnetId) -> Some vnetId
         | _ -> None
-    static member private validateVNetId vnetId = 
-        if vnetId.Type.Type <> virtualNetworks.Type then 
-            raiseFarmer $"given resource was not of type '{virtualNetworks.Type}'."
-    static member private validateSubnetId subnetId = 
-        if subnetId.Type.Type <> subnets.Type then 
-            raiseFarmer $"given resource was not of type '{subnets.Type}'."
-    static member private deriveSubnetId (vnetId:ResourceId) subnetName =
-        SubnetReference.validateVNetId vnetId
-        { vnetId with Type = subnets; Segments = [subnetName] }
     static member create(vnetRef:LinkedResource, subnetName:ResourceName) = 
-        SubnetReference.validateVNetId vnetRef.ResourceId
+        if vnetRef.ResourceId.Type.Type <> virtualNetworks.Type then 
+            raiseFarmer $"given resource was not of type '{virtualNetworks.Type}'."
         match vnetRef with
         | Managed vnetId -> 
             ViaManagedVNet (vnetId, subnetName)
         | Unmanaged vnetId ->
-            Direct (Unmanaged (SubnetReference.deriveSubnetId vnetId subnetName) )
+            Direct (Unmanaged { vnetId with Type = subnets; Segments = [subnetName] } )
     static member create(subnetRef:LinkedResource) = 
-        SubnetReference.validateSubnetId subnetRef.ResourceId
+        if subnetRef.ResourceId.Type.Type <> subnets.Type then 
+            raiseFarmer $"given resource was not of type '{subnets.Type}'."
         Direct subnetRef
 
     static member create(subnetId:ResourceId) = ()

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -20,6 +20,43 @@ let localNetworkGateways = ResourceType ("Microsoft.Network/localNetworkGateways
 let privateEndpoints = ResourceType ("Microsoft.Network/privateEndpoints", "2020-07-01")
 let virtualNetworkPeering = ResourceType ("Microsoft.Network/virtualNetworks/virtualNetworkPeerings","2020-05-01")
 
+type SubnetReference = 
+    | ViaManagedVNet of (ResourceId * ResourceName)
+    | Direct of LinkedResource
+    member this.ResourceId :ResourceId = 
+        match this with
+        | ViaManagedVNet (vnetId,subnet) ->
+            { vnetId with 
+                Type = subnets
+                Segments = [subnet] }
+        | Direct subnet -> subnet.ResourceId
+    member this.Dependency = 
+        match this with
+        | ViaManagedVNet (vnetId,_)
+        | Direct (Managed vnetId) -> Some vnetId
+        | _ -> None
+    static member private validateVNetId vnetId = 
+        if vnetId.Type.Type <> virtualNetworks.Type then 
+            raiseFarmer $"given resource was not of type '{virtualNetworks.Type}'."
+    static member private validateSubnetId subnetId = 
+        if subnetId.Type.Type <> subnets.Type then 
+            raiseFarmer $"given resource was not of type '{subnets.Type}'."
+    static member private deriveSubnetId (vnetId:ResourceId) subnetName =
+        SubnetReference.validateVNetId vnetId
+        { vnetId with Type = subnets; Segments = [subnetName] }
+    static member create(vnetRef:LinkedResource, subnetName:ResourceName) = 
+        SubnetReference.validateVNetId vnetRef.ResourceId
+        match vnetRef with
+        | Managed vnetId -> 
+            ViaManagedVNet (vnetId, subnetName)
+        | Unmanaged vnetId ->
+            Direct (Unmanaged (SubnetReference.deriveSubnetId vnetId subnetName) )
+    static member create(subnetRef:LinkedResource) = 
+        SubnetReference.validateSubnetId subnetRef.ResourceId
+        Direct subnetRef
+
+    static member create(subnetId:ResourceId) = ()
+
 type PublicIpAddress =
     { Name : ResourceName
       Location : Location
@@ -419,13 +456,13 @@ type ExpressRouteCircuitAuthorization =
 type PrivateEndpoint =
   { Name: ResourceName
     Location: Location
-    Subnet: LinkedResource
+    Subnet: SubnetReference
     Resource: LinkedResource
     GroupIds: string list}
   static member create location (resourceId:ResourceId) groupIds =
     Set.toSeq >> Seq.map
-      (fun (subnet: LinkedResource, epName:string option) ->
-        { Name = epName |> Option.defaultValue $"{resourceId.Name.Value}-ep-{subnet.Name.Value}" |> ResourceName
+      (fun (subnet: SubnetReference, epName:string option) ->
+        { Name = epName |> Option.defaultValue $"{resourceId.Name.Value}-ep-{subnet.ResourceId.Name.Value}" |> ResourceName
           Location = location
           Subnet = subnet
           Resource = Managed resourceId
@@ -434,7 +471,7 @@ type PrivateEndpoint =
     member this.ResourceId = privateEndpoints.resourceId this.Name
     member this.JsonModel =
       let dependencies =
-        [ match this.Subnet with | Managed x -> x | _ -> ()
+        [ yield! this.Subnet.Dependency |> Option.toList
           match this.Resource with | Managed x -> x | _ -> () ]
       {| privateEndpoints.Create(this.Name, this.Location, dependencies) with
           properties =

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -8,7 +8,7 @@ open Farmer.WebApp
 open System
 
 let serverFarms = ResourceType ("Microsoft.Web/serverfarms", "2018-02-01")
-let sites = ResourceType ("Microsoft.Web/sites", "2020-06-01")
+let sites = ResourceType ("Microsoft.Web/sites", "2021-03-01")
 let config = ResourceType ("Microsoft.Web/sites/config", "2016-08-01")
 let sourceControls = ResourceType ("Microsoft.Web/sites/sourcecontrols", "2019-08-01")
 let staticSites = ResourceType ("Microsoft.Web/staticSites", "2019-12-01-preview")
@@ -18,6 +18,8 @@ let certificates = ResourceType ("Microsoft.Web/certificates", "2019-08-01")
 let hostNameBindings = ResourceType ("Microsoft.Web/sites/hostNameBindings", "2020-12-01")
 let containerApps = ResourceType ("Microsoft.Web/containerApps", "2021-03-01")
 let kubeEnvironments = ResourceType ("Microsoft.Web/kubeEnvironments", "2021-02-01")
+let virtualNetworkConnections = ResourceType ("Microsoft.Web/sites/virtualNetworkConnections", "2021-03-01")
+let slotsVirtualNetworkConnections = ResourceType ("Microsoft.Web/sites/slots/virtualNetworkConnections", "2021-03-01")
 
 let private mapOrNull f = Option.map (Map.toList >> List.map f) >> Option.defaultValue Unchecked.defaultof<_>
 
@@ -160,8 +162,7 @@ type SiteType =
         match this with
         | Slot _ -> slots
         | Site _ -> sites
-
-
+        
 [<RequireQualifiedAccess>]
 type FTPState =
     | AllAllowed
@@ -199,7 +200,8 @@ type Site =
       AutoSwapSlotName: string option
       ZipDeployPath : (string * ZipDeploy.ZipDeployTarget * ZipDeploy.ZipDeploySlot) option
       HealthCheckPath : string option
-      IpSecurityRestrictions : IpSecurityRestriction list }
+      IpSecurityRestrictions : IpSecurityRestriction list 
+      LinkToSubnet : SubnetReference option }
     /// Shorthand for SiteType.ResourceType
     member this.ResourceType = this.SiteType.ResourceType
     /// Shorthand for SiteType.ResourceName
@@ -234,7 +236,7 @@ type Site =
     interface IArmResource with
         member this.ResourceId = sites.resourceId this.Name
         member this.JsonModel =
-            let dependencies = this.Dependencies + (Set this.Identity.Dependencies)
+            let dependencies = this.Dependencies + (Set this.Identity.Dependencies) + (this.LinkToSubnet |> Option.bind (fun x -> x.Dependency) |> Option.toList |> Set.ofList)
             let keyvaultId =
                 match (this.KeyVaultReferenceIdentity, this.Identity) with
                 | Some x, _
@@ -251,6 +253,10 @@ type Site =
                        httpsOnly = this.HTTPSOnly
                        clientAffinityEnabled = match this.ClientAffinityEnabled with Some v -> box v | None -> null
                        keyVaultReferenceIdentity = keyvaultId
+                       virtualNetworkSubnetId = 
+                            match this.LinkToSubnet with
+                            | None -> null
+                            | Some id -> id.ResourceId.ArmExpression.Eval()
                        siteConfig =
                         {| alwaysOn = this.AlwaysOn
                            appSettings =
@@ -301,6 +307,8 @@ type Site =
                             |> Option.toObj
                            healthCheckPath = this.HealthCheckPath |> Option.toObj
                            autoSwapSlotName = this.AutoSwapSlotName |> Option.toObj
+                           vnetName = this.LinkToSubnet |> Option.map (fun x -> x.ResourceId.Segments[0].Value) |> Option.toObj
+                           vnetRouteAllEnabled = this.LinkToSubnet |> function | Some _ -> Nullable true | None -> Nullable()
                         |}
                     |}
             |}
@@ -322,6 +330,26 @@ module Sites =
                            branch = this.Branch
                            isManualIntegration = this.ContinuousIntegration.AsBoolean |> not |}
                 |}
+
+type VirtualNetworkConnection =
+    { Site: Site
+      Subnet: ResourceId
+      Dependencies: ResourceId list}
+    member this.Name = this.Site.Name / this.Subnet.Name
+    member this.SiteId = this.Site.ResourceType.resourceId this.Site.Name
+    interface IArmResource with
+        member this.ResourceId = virtualNetworkConnections.resourceId this.Name
+        member this.JsonModel = 
+            let resourceType = 
+                match this.Site.SiteType with
+                | Site _ -> virtualNetworkConnections
+                | Slot _ -> slotsVirtualNetworkConnections
+            {| resourceType.Create (this.Name, dependsOn=[this.SiteId; yield! this.Dependencies]) with
+                properties = 
+                {| vnetResourceId = this.Subnet.ArmExpression.Eval()
+                   isSwift = true
+                |}
+            |} :> _
 
 type StaticSite =
     { Name : ResourceName

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -276,7 +276,7 @@ type FunctionsConfig =
                   WorkerProcess = this.CommonWebConfig.WorkerProcess
                   HealthCheckPath = this.CommonWebConfig.HealthCheckPath
                   IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions 
-                  LinkToSubnet = this.CommonWebConfig.RouteViaSubnet }
+                  LinkToSubnet = this.CommonWebConfig.IntegratedSubnet }
 
             match this.CommonWebConfig.ServicePlan with
             | DeployableResource this.Name.ResourceName resourceId ->
@@ -321,7 +321,7 @@ type FunctionsConfig =
             | None ->
                 ()
                 
-            match this.CommonWebConfig.RouteViaSubnet with
+            match this.CommonWebConfig.IntegratedSubnet with
             | None -> ()
             | Some subnetRef ->
                 { Site = site
@@ -358,7 +358,7 @@ type FunctionsBuilder() =
               ZipDeployPath = None
               HealthCheckPath = None 
               IpSecurityRestrictions = []
-              RouteViaSubnet = None
+              IntegratedSubnet = None
               PrivateEndpoints = Set.empty}
           StorageAccount = derived (fun config ->
             let storage = config.Name.ResourceName.Map (sprintf "%sstorage") |> sanitiseStorage |> ResourceName

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -11,6 +11,7 @@ open Farmer.Arm.Storage
 open Farmer.Arm.KeyVault
 open Farmer.Arm.KeyVault.Vaults
 open System
+open Farmer.Arm
 
 type FunctionsRuntime = DotNet | DotNetIsolated | Node | Java | Python
 type VersionedFunctionsRuntime =  FunctionsRuntime * string option
@@ -326,6 +327,7 @@ type FunctionsConfig =
                 { Site = site
                   Subnet = subnetRef.ResourceId
                   Dependencies = subnetRef.Dependency |> Option.toList }
+            yield! (PrivateEndpoint.create location this.ResourceId ["sites"] this.CommonWebConfig.PrivateEndpoints)
 
             if Map.isEmpty this.CommonWebConfig.Slots then
                 site

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -282,7 +282,7 @@ type FunctionsConfig =
             | DeployableResource this.Name.ResourceName resourceId ->
                 { Name = resourceId.Name
                   Location = location
-                  Sku = Sku.Y1
+                  Sku = this.CommonWebConfig.Sku
                   WorkerSize = Serverless
                   WorkerCount = 0
                   MaximumElasticWorkerCount = None
@@ -355,6 +355,7 @@ type FunctionsBuilder() =
               SecretStore = AppService
               ServicePlan = derived (fun name -> serverFarms.resourceId (name-"farm"))
               Settings = Map.empty
+              Sku = Sku.Y1
               Slots = Map.empty
               WorkerProcess = None
               ZipDeployPath = None
@@ -372,6 +373,7 @@ type FunctionsBuilder() =
           Tags = Map.empty }
     member _.Run (state:FunctionsConfig) =
         if state.Name.ResourceName = ResourceName.Empty then raiseFarmer "No Functions instance name has been set."
+        state.CommonWebConfig.Validate()
         state
     /// Do not create an automatic storage account; instead, link to a storage account that is created outside of this Functions instance.
     [<CustomOperation "link_to_storage_account">]

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -274,7 +274,8 @@ type FunctionsConfig =
                     | _ -> None
                   WorkerProcess = this.CommonWebConfig.WorkerProcess
                   HealthCheckPath = this.CommonWebConfig.HealthCheckPath
-                  IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions }
+                  IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions 
+                  LinkToSubnet = this.CommonWebConfig.RouteViaSubnet }
 
             match this.CommonWebConfig.ServicePlan with
             | DeployableResource this.Name.ResourceName resourceId ->
@@ -317,6 +318,13 @@ type FunctionsConfig =
             | Some _
             | None ->
                 ()
+                
+            match this.CommonWebConfig.RouteViaSubnet with
+            | None -> ()
+            | Some subnetRef ->
+                { Site = site
+                  Subnet = subnetRef.ResourceId
+                  Dependencies = subnetRef.Dependency |> Option.toList }
 
             if Map.isEmpty this.CommonWebConfig.Slots then
                 site
@@ -346,7 +354,9 @@ type FunctionsBuilder() =
               WorkerProcess = None
               ZipDeployPath = None
               HealthCheckPath = None 
-              IpSecurityRestrictions = [] }
+              IpSecurityRestrictions = []
+              RouteViaSubnet = None
+              PrivateEndpoints = Set.empty}
           StorageAccount = derived (fun config ->
             let storage = config.Name.ResourceName.Map (sprintf "%sstorage") |> sanitiseStorage |> ResourceName
             storageAccounts.resourceId storage)

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -2,6 +2,7 @@
 module Farmer.Builders.Storage
 
 open Farmer
+open Farmer.Builders
 open Farmer.Storage
 open Farmer.Arm.RoleAssignment
 open Farmer.Arm.Storage

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -2,6 +2,7 @@
 module Farmer.Builders.VirtualNetwork
 
 open Farmer
+open Farmer.Builders
 open Farmer.Network
 open Farmer.Arm.Network
 
@@ -387,3 +388,7 @@ type VNetPeeringSpecBuilder() =
     interface IDependable<VNetPeeringSpec> with member _.Add state resources = {state with DependsOn = state.DependsOn |> Set.union resources}
 
 let vnetPeering = VNetPeeringSpecBuilder ()
+
+type SubnetReference with
+    static member create (vnetConfig:VirtualNetworkConfig, subnetName) = ViaManagedVNet (vnetConfig.ResourceId,subnetName)
+    static member create (vnetConfig:SubnetConfig) = Direct (Managed (vnetConfig:>IBuilder).ResourceId)

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -952,16 +952,16 @@ module Extensions =
         member this.DenyIp(state:'T, name, ip) = 
             this.Map state (fun x -> { x with IpSecurityRestrictions = IpSecurityRestriction.Create name ip Deny :: x.IpSecurityRestrictions })
         /// Integrate this app with a virtual network subnet
-        [<CustomOperation "route_via_subnet">]
-        member this.RouteViaSubnet(state:'T, subnet:SubnetReference option) = 
+        [<CustomOperation "route_via_vnet">]
+        member this.RouteViaVNet(state:'T, subnet:SubnetReference option) = 
             match subnet with
             | Some subnetId ->
                 if subnetId.ResourceId.Type.Type <> Arm.Network.subnets.Type 
                     then raiseFarmer $"given resource was not of type '{Arm.Network.subnets.Type}'."
             | None -> ()
             this.Map state (fun x -> {x with RouteViaSubnet = subnet})
-        member this.RouteViaSubnet(state:'T, subnetRef) = this.RouteViaSubnet (state, Some subnetRef)
-        member this.RouteViaSubnet(state:'T, subnetId:LinkedResource) = this.RouteViaSubnet (state, SubnetReference.create subnetId)
-        member this.RouteViaSubnet(state:'T, subnet:SubnetConfig) = this.RouteViaSubnet (state, SubnetReference.create subnet)
-        member this.RouteViaSubnet(state:'T, (vnet:VirtualNetworkConfig, subnetName)) = this.RouteViaSubnet (state, SubnetReference.create (vnet,subnetName))
-        member this.RouteViaSubnet(state:'T, (vnetId:LinkedResource, subnetName)) = this.RouteViaSubnet (state, SubnetReference.create (vnetId,subnetName))
+        member this.RouteViaVNet(state:'T, subnetRef) = this.RouteViaVNet (state, Some subnetRef)
+        member this.RouteViaVNet(state:'T, subnetId:LinkedResource) = this.RouteViaVNet (state, SubnetReference.create subnetId)
+        member this.RouteViaVNet(state:'T, subnet:SubnetConfig) = this.RouteViaVNet (state, SubnetReference.create subnet)
+        member this.RouteViaVNet(state:'T, (vnet:VirtualNetworkConfig, subnetName)) = this.RouteViaVNet (state, SubnetReference.create (vnet,subnetName))
+        member this.RouteViaVNet(state:'T, (vnetId:LinkedResource, subnetName)) = this.RouteViaVNet (state, SubnetReference.create (vnetId,subnetName))

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -1005,17 +1005,12 @@ module Extensions =
             | None -> ()
             this.Map state (fun x -> {x with IntegratedSubnet = subnet})
         member this.LinkToVNet(state:'T, subnetRef) = this.LinkToVNet (state, Some subnetRef)
+        member this.LinkToVNet(state:'T, subnetId:ResourceId) = this.LinkToVNet (state, SubnetReference.create (Managed subnetId))
+        member this.LinkToVNet(state:'T, (vnetId, subnetName):ResourceId*ResourceName) = this.LinkToVNet (state, SubnetReference.create (Managed vnetId,subnetName))
         member this.LinkToVNet(state:'T, subnet:SubnetConfig) = this.LinkToVNet (state, SubnetReference.create subnet)
-        member this.LinkToVNet(state:'T, (vnet:VirtualNetworkConfig, subnetName)) = this.LinkToVNet (state, SubnetReference.create (vnet,subnetName))
-        member this.LinkToVNet(state:'T, (vnetId:ResourceId, subnetName)) = this.LinkToVNet (state, SubnetReference.create (Managed vnetId,subnetName))
+        member this.LinkToVNet(state:'T, (vnet, subnetName):VirtualNetworkConfig*ResourceName) = this.LinkToVNet (state, SubnetReference.create (vnet,subnetName))
         [<CustomOperation "link_to_unmanaged_vnet">]
-        member this.LinkToUnmanagedVNet(state:'T, subnet:SubnetReference option) = 
-            match subnet with
-            | Some subnetId ->
-                if subnetId.ResourceId.Type.Type <> Arm.Network.subnets.Type 
-                    then raiseFarmer $"given resource was not of type '{Arm.Network.subnets.Type}'."
-            | None -> ()
-            this.Map state (fun x -> {x with IntegratedSubnet = subnet})
-        member this.LinkToUnmanagedVNet(state:'T, subnetRef) = this.LinkToVNet (state, Some subnetRef)
-        member this.LinkToUnmanagedVNet(state:'T, subnetId:ResourceId) = this.LinkToUnmanagedVNet (state, SubnetReference.create (Unmanaged subnetId))
-        member this.LinkToUnmanagedVNet(state:'T, (vnetId:ResourceId, subnetName)) = this.LinkToUnmanagedVNet (state, SubnetReference.create (Unmanaged vnetId,subnetName))
+        member this.LinkToUnmanagedVNet(state:'T, subnetId:ResourceId) = this.LinkToVNet (state, SubnetReference.create (Unmanaged subnetId))
+        member this.LinkToUnmanagedVNet(state:'T, (vnetId, subnetName):ResourceId*ResourceName) = this.LinkToVNet (state, SubnetReference.create (Unmanaged vnetId,subnetName))
+        member this.LinkToUnmanagedVNet(state:'T, subnet:SubnetConfig) = this.LinkToUnmanagedVNet (state, (subnet:>IBuilder).ResourceId)
+        member this.LinkToUnmanagedVNet(state:'T, (vnet, subnetName):VirtualNetworkConfig*ResourceName) = this.LinkToUnmanagedVNet (state, vnet.SubnetIds[subnetName.Value])

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -3,6 +3,7 @@ module rec Farmer.Builders.WebApp
 
 open Farmer
 open Farmer.Arm
+open Farmer.Builders
 open Farmer.WebApp
 open Farmer.Arm.KeyVault.Vaults
 open Sites
@@ -205,7 +206,9 @@ type CommonWebConfig =
       WorkerProcess : Bitness option
       ZipDeployPath : (string*ZipDeploy.ZipDeploySlot) option
       HealthCheckPath: string option
-      IpSecurityRestrictions: IpSecurityRestriction list }
+      IpSecurityRestrictions: IpSecurityRestriction list 
+      RouteViaSubnet : SubnetReference option
+      PrivateEndpoints: (SubnetReference * string option) Set }
 
 type WebAppConfig =
     { CommonWebConfig: CommonWebConfig
@@ -227,7 +230,6 @@ type WebAppConfig =
       DockerAcrCredentials : {| RegistryName : string; Password : SecureParameter |} option
       AutomaticLoggingExtension : bool
       SiteExtensions : ExtensionName Set
-      PrivateEndpoints: (LinkedResource * string option) Set
       CustomDomain : DomainConfig 
       DockerPort: int option }
     member this.Name = this.CommonWebConfig.Name
@@ -454,7 +456,7 @@ type WebAppConfig =
                   ZipDeployPath = this.CommonWebConfig.ZipDeployPath |> Option.map (fun (path,slot) -> path, ZipDeploy.ZipDeployTarget.WebApp, slot )
                   HealthCheckPath = this.CommonWebConfig.HealthCheckPath
                   IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions
-                }
+                  LinkToSubnet = this.CommonWebConfig.RouteViaSubnet }
 
             match keyVault with
             | Some keyVault ->
@@ -571,7 +573,13 @@ type WebAppConfig =
                   SslState = SslDisabled }
             | NoDomain -> ()
 
-            yield! (PrivateEndpoint.create location this.ResourceId ["sites"] this.PrivateEndpoints)
+            match this.CommonWebConfig.RouteViaSubnet with
+            | None -> ()
+            | Some subnetRef ->
+                { Site = site
+                  Subnet = subnetRef.ResourceId
+                  Dependencies = subnetRef.Dependency |> Option.toList }
+            yield! (PrivateEndpoint.create location this.ResourceId ["sites"] this.CommonWebConfig.PrivateEndpoints)
         ]
 
 type WebAppBuilder() =
@@ -594,7 +602,9 @@ type WebAppBuilder() =
               WorkerProcess = None
               ZipDeployPath = None
               HealthCheckPath = None
-              IpSecurityRestrictions = [] }
+              IpSecurityRestrictions = []
+              RouteViaSubnet = None 
+              PrivateEndpoints = Set.empty }
           Sku = Sku.F1
           WorkerSize = Small
           WorkerCount = 1
@@ -613,7 +623,6 @@ type WebAppBuilder() =
           DockerAcrCredentials = None
           AutomaticLoggingExtension = true
           SiteExtensions = Set.empty
-          PrivateEndpoints = Set.empty
           CustomDomain = NoDomain 
           DockerPort = None }
     member _.Run(state:WebAppConfig) =
@@ -715,7 +724,7 @@ type WebAppBuilder() =
     [<CustomOperation "docker_port">]
     member _.DockerPort(state: WebAppConfig, dockerPort:int) = { state with DockerPort = Some dockerPort }
     
-    interface IPrivateEndpoints<WebAppConfig> with member _.Add state endpoints = { state with PrivateEndpoints = state.PrivateEndpoints |> Set.union endpoints}
+    interface IPrivateEndpoints<WebAppConfig> with member _.Add state endpoints = {state with CommonWebConfig = { state.CommonWebConfig with PrivateEndpoints =  state.CommonWebConfig.PrivateEndpoints |> Set.union endpoints}}
     interface ITaggable<WebAppConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     interface IDependable<WebAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
     interface IServicePlanApp<WebAppConfig> with
@@ -732,7 +741,7 @@ type EndpointBuilder with
 
 /// An interface for shared capabilities between builders that work with Service Plan-style apps.
 /// In other words, Web Apps or Functions.
-type IServicePlanApp<'T> =
+type IServicePlanApp<'T> = 
     abstract member Get : 'T -> CommonWebConfig
     abstract member Wrap : 'T -> CommonWebConfig -> 'T
 
@@ -942,3 +951,17 @@ module Extensions =
         [<CustomOperation "add_denied_ip_restriction">] 
         member this.DenyIp(state:'T, name, ip) = 
             this.Map state (fun x -> { x with IpSecurityRestrictions = IpSecurityRestriction.Create name ip Deny :: x.IpSecurityRestrictions })
+        /// Integrate this app with a virtual network subnet
+        [<CustomOperation "route_via_subnet">]
+        member this.RouteViaSubnet(state:'T, subnet:SubnetReference option) = 
+            match subnet with
+            | Some subnetId ->
+                if subnetId.ResourceId.Type.Type <> Arm.Network.subnets.Type 
+                    then raiseFarmer $"given resource was not of type '{Arm.Network.subnets.Type}'."
+            | None -> ()
+            this.Map state (fun x -> {x with RouteViaSubnet = subnet})
+        member this.RouteViaSubnet(state:'T, subnetRef) = this.RouteViaSubnet (state, Some subnetRef)
+        member this.RouteViaSubnet(state:'T, subnetId:LinkedResource) = this.RouteViaSubnet (state, SubnetReference.create subnetId)
+        member this.RouteViaSubnet(state:'T, subnet:SubnetConfig) = this.RouteViaSubnet (state, SubnetReference.create subnet)
+        member this.RouteViaSubnet(state:'T, (vnet:VirtualNetworkConfig, subnetName)) = this.RouteViaSubnet (state, SubnetReference.create (vnet,subnetName))
+        member this.RouteViaSubnet(state:'T, (vnetId:LinkedResource, subnetName)) = this.RouteViaSubnet (state, SubnetReference.create (vnetId,subnetName))

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -975,7 +975,7 @@ module Extensions =
         member this.DenyIp(state:'T, name, ip) = 
             this.Map state (fun x -> { x with IpSecurityRestrictions = IpSecurityRestriction.Create name ip Deny :: x.IpSecurityRestrictions })
         /// Integrate this app with a virtual network subnet
-        [<CustomOperation "route_via_vnet">]
+        [<CustomOperation "vnet">]
         member this.RouteViaVNet(state:'T, subnet:SubnetReference option) = 
             match subnet with
             | Some subnetId ->

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -994,16 +994,26 @@ module Extensions =
             let ip = IPAddressCidr.parse ip
             this.Map state (fun x -> { x with IpSecurityRestrictions = IpSecurityRestriction.Create name ip Deny :: x.IpSecurityRestrictions })
         /// Integrate this app with a virtual network subnet
-        [<CustomOperation "vnet">]
-        member this.RouteViaVNet(state:'T, subnet:SubnetReference option) = 
+        [<CustomOperation "link_to_vnet">]
+        member this.LinkToVNet(state:'T, subnet:SubnetReference option) = 
             match subnet with
             | Some subnetId ->
                 if subnetId.ResourceId.Type.Type <> Arm.Network.subnets.Type 
                     then raiseFarmer $"given resource was not of type '{Arm.Network.subnets.Type}'."
             | None -> ()
             this.Map state (fun x -> {x with IntegratedSubnet = subnet})
-        member this.RouteViaVNet(state:'T, subnetRef) = this.RouteViaVNet (state, Some subnetRef)
-        member this.RouteViaVNet(state:'T, subnetId:LinkedResource) = this.RouteViaVNet (state, SubnetReference.create subnetId)
-        member this.RouteViaVNet(state:'T, subnet:SubnetConfig) = this.RouteViaVNet (state, SubnetReference.create subnet)
-        member this.RouteViaVNet(state:'T, (vnet:VirtualNetworkConfig, subnetName)) = this.RouteViaVNet (state, SubnetReference.create (vnet,subnetName))
-        member this.RouteViaVNet(state:'T, (vnetId:LinkedResource, subnetName)) = this.RouteViaVNet (state, SubnetReference.create (vnetId,subnetName))
+        member this.LinkToVNet(state:'T, subnetRef) = this.LinkToVNet (state, Some subnetRef)
+        member this.LinkToVNet(state:'T, subnet:SubnetConfig) = this.LinkToVNet (state, SubnetReference.create subnet)
+        member this.LinkToVNet(state:'T, (vnet:VirtualNetworkConfig, subnetName)) = this.LinkToVNet (state, SubnetReference.create (vnet,subnetName))
+        member this.LinkToVNet(state:'T, (vnetId:ResourceId, subnetName)) = this.LinkToVNet (state, SubnetReference.create (Managed vnetId,subnetName))
+        [<CustomOperation "link_to_unmanaged_vnet">]
+        member this.LinkToUnmanagedVNet(state:'T, subnet:SubnetReference option) = 
+            match subnet with
+            | Some subnetId ->
+                if subnetId.ResourceId.Type.Type <> Arm.Network.subnets.Type 
+                    then raiseFarmer $"given resource was not of type '{Arm.Network.subnets.Type}'."
+            | None -> ()
+            this.Map state (fun x -> {x with IntegratedSubnet = subnet})
+        member this.LinkToUnmanagedVNet(state:'T, subnetRef) = this.LinkToVNet (state, Some subnetRef)
+        member this.LinkToUnmanagedVNet(state:'T, subnetId:ResourceId) = this.LinkToUnmanagedVNet (state, SubnetReference.create (Unmanaged subnetId))
+        member this.LinkToUnmanagedVNet(state:'T, (vnetId:ResourceId, subnetName)) = this.LinkToUnmanagedVNet (state, SubnetReference.create (Unmanaged vnetId,subnetName))

--- a/src/Farmer/Builders/Extensions.fs
+++ b/src/Farmer/Builders/Extensions.fs
@@ -2,13 +2,14 @@ namespace Farmer.Builders
 
 open Farmer
 open System
+open Farmer.Arm
 
 type ITaggable<'TConfig> =
     abstract member Add : 'TConfig -> list<string * string> -> 'TConfig
 type IDependable<'TConfig> =
     abstract member Add : 'TConfig -> ResourceId Set -> 'TConfig
 type IPrivateEndpoints<'TConfig> =
-    abstract member Add : 'TConfig -> (LinkedResource * String option) Set -> 'TConfig
+    abstract member Add : 'TConfig -> (SubnetReference * String option) Set -> 'TConfig
 
 [<AutoOpen>]
 module Extensions =

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -104,7 +104,6 @@
     <Compile Include="Arm/VirtualHub.fs" />
     <Compile Include="Arm\Dashboard.fs" />
     <Compile Include="IdentityExtensions.fs" />
-
     <Compile Include="Builders/Extensions.fs" />
     <Compile Include="Builders/Builders.UserAssignedIdentity.fs" />
     <Compile Include="Builders/Builders.ResourceGroup.fs" />

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -416,7 +416,7 @@ let tests = testList "Functions tests" [
     }
     test "Can integrate unmanaged vnet" {
         let subnetId = Arm.Network.subnets.resourceId (ResourceName "my-vnet", ResourceName "my-subnet") 
-        let wa = functions { name "testApp"; vnet (Unmanaged subnetId) }
+        let wa = functions { name "testApp"; link_to_unmanaged_vnet subnetId }
         
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head
@@ -425,11 +425,10 @@ let tests = testList "Functions tests" [
 
         let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection> 
         Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
-    }
-    
+    }    
     test "Can integrate managed vnet" {
         let vnetConfig = vnet { name "my-vnet" } 
-        let wa = functions { name "testApp"; vnet (vnetConfig, ResourceName "my-subnet") }
+        let wa = functions { name "testApp"; link_to_vnet (vnetConfig, ResourceName "my-subnet") }
             
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head
@@ -439,5 +438,4 @@ let tests = testList "Functions tests" [
         let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection> 
         Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
     }
-
 ]

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -414,4 +414,30 @@ let tests = testList "Functions tests" [
         Expect.equal slot.IpSecurityRestrictions [ expectedSlotRestriction ] "Slot should have correct allowed ip security restriction"
         Expect.equal site.IpSecurityRestrictions [ expectedSiteRestriction ] "Site should have correct allowed ip security restriction"
     }
+    test "Can integrate unmanaged vnet" {
+        let subnetId = Arm.Network.subnets.resourceId (ResourceName "my-vnet", ResourceName "my-subnet") 
+        let wa = functions { name "testApp"; route_via_vnet (Unmanaged subnetId) }
+        
+        let resources = wa |> getResources
+        let site = resources |> getResource<Web.Site> |> List.head
+        let vnet = Expect.wantSome site.LinkToSubnet "LinkToSubnet was not set"
+        Expect.equal vnet (Direct (Unmanaged subnetId)) "LinkToSubnet was incorrect"
+
+        let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection> 
+        Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
+    }
+    
+    test "Can integrate managed vnet" {
+        let vnetConfig = vnet { name "my-vnet" } 
+        let wa = functions { name "testApp"; route_via_vnet (vnetConfig, ResourceName "my-subnet") }
+            
+        let resources = wa |> getResources
+        let site = resources |> getResource<Web.Site> |> List.head
+        let vnet = Expect.wantSome site.LinkToSubnet "LinkToSubnet was not set"
+        Expect.equal vnet (ViaManagedVNet ( (Arm.Network.virtualNetworks.resourceId "my-vnet"), ResourceName "my-subnet" )) "LinkToSubnet was incorrect"
+        
+        let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection> 
+        Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
+    }
+
 ]

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -416,7 +416,7 @@ let tests = testList "Functions tests" [
     }
     test "Can integrate unmanaged vnet" {
         let subnetId = Arm.Network.subnets.resourceId (ResourceName "my-vnet", ResourceName "my-subnet") 
-        let wa = functions { name "testApp"; route_via_vnet (Unmanaged subnetId) }
+        let wa = functions { name "testApp"; vnet (Unmanaged subnetId) }
         
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head
@@ -429,7 +429,7 @@ let tests = testList "Functions tests" [
     
     test "Can integrate managed vnet" {
         let vnetConfig = vnet { name "my-vnet" } 
-        let wa = functions { name "testApp"; route_via_vnet (vnetConfig, ResourceName "my-subnet") }
+        let wa = functions { name "testApp"; vnet (vnetConfig, ResourceName "my-subnet") }
             
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -416,7 +416,8 @@ let tests = testList "Functions tests" [
     }
     test "Can integrate unmanaged vnet" {
         let subnetId = Arm.Network.subnets.resourceId (ResourceName "my-vnet", ResourceName "my-subnet") 
-        let wa = functions { name "testApp"; link_to_unmanaged_vnet subnetId }
+        let asp = serverFarms.resourceId "my-asp"
+        let wa = functions { name "testApp"; link_to_unmanaged_service_plan asp; link_to_unmanaged_vnet subnetId }
         
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head
@@ -428,7 +429,8 @@ let tests = testList "Functions tests" [
     }    
     test "Can integrate managed vnet" {
         let vnetConfig = vnet { name "my-vnet" } 
-        let wa = functions { name "testApp"; link_to_vnet (vnetConfig, ResourceName "my-subnet") }
+        let asp = serverFarms.resourceId "my-asp"
+        let wa = functions { name "testApp"; link_to_unmanaged_service_plan asp;  link_to_vnet (vnetConfig, ResourceName "my-subnet") }
             
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -814,9 +814,9 @@ let tests = testList "Web App Tests" [
 
         Expect.equal sf.ZoneRedundant (Some Enabled) "ZoneRedundant should be enabled"
     }
-    test "Can integrate unmanaged vnet" {
+    test "Can integrate with unmanaged vnet" {
         let subnetId = Arm.Network.subnets.resourceId (ResourceName "my-vnet", ResourceName "my-subnet") 
-        let wa = webApp { name "testApp"; route_via_vnet (Unmanaged subnetId) }
+        let wa = webApp { name "testApp"; vnet (Unmanaged subnetId) }
         
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head
@@ -827,9 +827,9 @@ let tests = testList "Web App Tests" [
         Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
     }
     
-    test "Can integrate managed vnet" {
+    test "Can integrate with managed vnet" {
         let vnetConfig = vnet { name "my-vnet" } 
-        let wa = webApp { name "testApp"; route_via_vnet (vnetConfig, ResourceName "my-subnet") }
+        let wa = webApp { name "testApp"; vnet (vnetConfig, ResourceName "my-subnet") }
             
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -817,7 +817,7 @@ let tests = testList "Web App Tests" [
     }
     test "Can integrate with unmanaged vnet" {
         let subnetId = Arm.Network.subnets.resourceId (ResourceName "my-vnet", ResourceName "my-subnet") 
-        let wa = webApp { name "testApp"; sku WebApp.Sku.S1; vnet (Unmanaged subnetId) }
+        let wa = webApp { name "testApp"; sku WebApp.Sku.S1; link_to_unmanaged_vnet subnetId }
         
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head
@@ -830,7 +830,7 @@ let tests = testList "Web App Tests" [
     
     test "Can integrate with managed vnet" {
         let vnetConfig = vnet { name "my-vnet" } 
-        let wa = webApp { name "testApp"; sku WebApp.Sku.S1; vnet (vnetConfig, ResourceName "my-subnet") }
+        let wa = webApp { name "testApp"; sku WebApp.Sku.S1; link_to_vnet (vnetConfig, ResourceName "my-subnet") }
             
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -816,7 +816,7 @@ let tests = testList "Web App Tests" [
     }
     test "Can integrate with unmanaged vnet" {
         let subnetId = Arm.Network.subnets.resourceId (ResourceName "my-vnet", ResourceName "my-subnet") 
-        let wa = webApp { name "testApp"; vnet (Unmanaged subnetId) }
+        let wa = webApp { name "testApp"; sku WebApp.Sku.S1; vnet (Unmanaged subnetId) }
         
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head
@@ -829,7 +829,7 @@ let tests = testList "Web App Tests" [
     
     test "Can integrate with managed vnet" {
         let vnetConfig = vnet { name "my-vnet" } 
-        let wa = webApp { name "testApp"; vnet (vnetConfig, ResourceName "my-subnet") }
+        let wa = webApp { name "testApp"; sku WebApp.Sku.S1; vnet (vnetConfig, ResourceName "my-subnet") }
             
         let resources = wa |> getResources
         let site = resources |> getResource<Web.Site> |> List.head

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -45,7 +45,7 @@
       "type": "Microsoft.Web/sites/siteextensions"
     },
     {
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2021-03-01",
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', 'isaacdiagsuperweb-farm')]"
       ],

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -140,7 +140,7 @@
       "type": "Microsoft.Web/sites/siteextensions"
     },
     {
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2021-03-01",
       "dependsOn": [
         "[resourceId('Microsoft.Insights/components', 'farmerwebapp1979-ai')]",
         "[resourceId('Microsoft.Web/serverfarms', 'farmerwebapp1979-farm')]"
@@ -252,7 +252,7 @@
       "type": "Microsoft.Insights/components"
     },
     {
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2021-03-01",
       "dependsOn": [
         "[resourceId('Microsoft.Insights/components', 'farmerfuncs1979-ai')]",
         "[resourceId('Microsoft.Storage/storageAccounts', 'farmerfuncs1979storage')]",
@@ -790,7 +790,7 @@
       "type": "Microsoft.Storage/storageAccounts"
     },
     {
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2021-03-01",
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', 'dockerfuncstorage')]",
         "[resourceId('Microsoft.Web/serverfarms', 'docker-func-farm')]"


### PR DESCRIPTION
This PR closes #656 #797

The changes in this PR are as follows:

* Added route_via_vnet to WebApp and functions

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders

let vnet = 
    vnet {
        name $"my-vnet"

        build_address_spaces [
            addressSpace {
                space $"10.1.0.0/16"
                subnets [ 
                    subnetSpec {
                        name "workload"
                        size 18
                        add_delegations [ Network.SubnetDelegationService "Microsoft.Web/serverfarms" ]
                    }
                ]
            } 
        ]
    }

let app = webApp {
    name "my-vnet-app"
    sku Farmer.WebApp.Sku.S1
    app_insights_off
    vnet (vnet, ResourceName "workload")
}

arm {
    add_resource vnet
    add_resource app
}
```
