### PR TITLE
Add --overwrite true to storage blob upload command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.30
+* CLI: include `--overwrite true` option when executing `az storage blob upload-batch`.
+
 ## 1.6.29
 * CLI: include `--only-show-error` option when executing Azure CLI commands.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.29
+* CLI: include `--only-show-error` option when executing Azure CLI commands.
+
 ## 1.6.28
 * ServicePlan/WebApp: Support for enabling ZoneDedundant
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,9 @@
 Release Notes
 =============
-## 1.6.30
+## 1.6.32
 * CLI: Include `--overwrite true` option when executing `az storage blob upload-batch` with Azure CLI 2.34.0 and above.
+
+## 1.6.30
 * WebApps/Functions: Specify connection string types
 * WebApps/Functions: Allow adding IP restriction string with CIDR
 * Application Insights: Support for Workspace-enabled instances.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@ Release Notes
 =============
 
 ## 1.6.30
-* CLI: include `--overwrite true` option when executing `az storage blob upload-batch`.
+* CLI: include `--overwrite true` option when executing `az storage blob upload-batch` with Azure CLI 2.34.0 and above.
 
 ## 1.6.29
 * CLI: include `--only-show-error` option when executing Azure CLI commands.

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -79,7 +79,30 @@ module Az =
     let login() = az "login" |> Result.ignore
     /// Logs you into the Az CLI using the supplied service principal credentials.
     let loginWithCredentials appId secret tenantId = az $"login --service-principal --username %s{appId} --password %s{secret} --tenant %s{tenantId}"
+    /// Gets the version of Az CLI
     let version() = az "--version"
+    /// Checks that the version of the Azure CLI meets minimum version.
+    let checkVersion minimum = result {
+        let! versionOutput = version()
+        let! version =
+            versionOutput.Replace("\r\n","\n").Replace("\r","\n").Split([| "\n" |], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.tryHead
+            |> Option.bind(fun text ->
+                match text.Split([| ' ' |], StringSplitOptions.RemoveEmptyEntries) with
+                | [| _; version |]
+                | [| _; version; _ |] ->
+                    Some version
+                | _ ->
+                    None)
+            |> Option.bind(fun versionText ->
+                try Some(Version versionText)
+                with _ -> None)
+            |> Result.ofOption $"Unable to determine Azure CLI version. You need to have at least {minimum} installed. Output was: %s{versionOutput}"
+        return!
+            if version < minimum then Error $"You have {version} of the Azure CLI installed, but the minimum version is {minimum}. Please upgrade."
+            else Ok version
+    }
+    
     /// Lists all subscriptions
     let listSubscriptions() = az "account list --all"
     let setSubscription subscriptionId = az $"account set --subscription %s{subscriptionId}"
@@ -133,7 +156,8 @@ module Az =
         |> String.concat " "
         |> az
     let batchUploadStaticWebsite name path =
-        az $"storage blob upload-batch --account-name %s{name} --destination $web --source %s{path} --overwrite true"
+        let overwriteParameter = checkVersion (Version "2.34.0") |> function | Ok _ -> "--overwrite true" | Error _ -> ""
+        az $"storage blob upload-batch --account-name %s{name} --destination $web --source %s{path} {overwriteParameter}"
 
     type AzureErrorCode = { Code : string; Message : string }
     type AzureError = { Error : AzureErrorCode }
@@ -163,29 +187,6 @@ let listSubscriptions() = result {
     return response |> Serialization.ofJson<Subscription array>
 }
 
-
-/// Checks that the version of the Azure CLI meets minimum version.
-let checkVersion minimum = result {
-    let! versionOutput = Az.version()
-    let! version =
-        versionOutput.Replace("\r\n","\n").Replace("\r","\n").Split([| "\n" |], StringSplitOptions.RemoveEmptyEntries)
-        |> Array.tryHead
-        |> Option.bind(fun text ->
-            match text.Split([| ' ' |], StringSplitOptions.RemoveEmptyEntries) with
-            | [| _; version |]
-            | [| _; version; _ |] ->
-                Some version
-            | _ ->
-                None)
-        |> Option.bind(fun versionText ->
-            try Some(Version versionText)
-            with _ -> None)
-        |> Result.ofOption $"Unable to determine Azure CLI version. You need to have at least {minimum} installed. Output was: %s{versionOutput}"
-    return!
-        if version < minimum then Error $"You have {version} of the Azure CLI installed, but the minimum version is {minimum}. Please upgrade."
-        else Ok version
-}
-
 /// Sets the currently active (default) subscription.
 let setSubscription (subscriptionId:Guid) =
     Az.setSubscription (subscriptionId.ToString())
@@ -206,7 +207,7 @@ let NoParameters : (string * string) list = []
 let private prepareForDeployment parameters resourceGroupName (deployment:IDeploymentSource) = result {
     do! deployment |> validateParameters parameters
 
-    let! version = checkVersion Az.MinimumVersion
+    let! version = Az.checkVersion Az.MinimumVersion
     printfn "Compatible version of Azure CLI %O detected" version
 
     prepareDeploymentFolder()

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -155,9 +155,14 @@ module Az =
           yield! errorDoc |> Option.mapList (sprintf "--404-document %s") ]
         |> String.concat " "
         |> az
+    /// The overwrite parameter was introduced in Azure CLI v2.34.0 with a breaking change to the default behaviour
+    let private cliVersionWithOverwriteParameter = Version "2.34.0"
     let batchUploadStaticWebsite name path =
-        let overwriteParameter = checkVersion (Version "2.34.0") |> function | Ok _ -> "--overwrite true" | Error _ -> ""
-        az $"storage blob upload-batch --account-name %s{name} --destination $web --source %s{path} {overwriteParameter}"
+        let additionalParameters =
+            match checkVersion cliVersionWithOverwriteParameter with
+            | Ok _ -> "--overwrite true"
+            | _ -> ""
+        az $"storage blob upload-batch --account-name %s{name} --destination $web --source %s{path} {additionalParameters}"
 
     type AzureErrorCode = { Code : string; Message : string }
     type AzureError = { Error : AzureErrorCode }

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -133,7 +133,7 @@ module Az =
         |> String.concat " "
         |> az
     let batchUploadStaticWebsite name path =
-        az $"storage blob upload-batch --account-name %s{name} --destination $web --source %s{path}"
+        az $"storage blob upload-batch --account-name %s{name} --destination $web --source %s{path} --overwrite true"
 
     type AzureErrorCode = { Code : string; Message : string }
     type AzureError = { Error : AzureErrorCode }

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.6.29</Version>
+    <Version>1.6.30</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.6.30</Version>
+    <Version>1.6.32</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.6.28</Version>
+    <Version>1.6.29</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Tests/AzCli.fs
+++ b/src/Tests/AzCli.fs
@@ -29,7 +29,7 @@ let endToEndTests = testList "End to end tests" [
 
 let tests = testList "Azure CLI" [
     test "Can connect to Az CLI" {
-        match Deploy.checkVersion Deploy.Az.MinimumVersion with
+        match Deploy.Az.checkVersion Deploy.Az.MinimumVersion with
         | Ok _ -> ()
         | Error msg -> raiseFarmer $"Version check failed: {msg}"
     }


### PR DESCRIPTION
This PR closes #890

The changes in this PR are as follows:

* Adds the parameter `--overwrite true` to the `az storage blob upload-batch` command used for WebApp zip deployment, which is required due to breaking changes introduced in [Azure CLI v2.34.0](https://github.com/MicrosoftDocs/azure-docs-cli/blob/main/docs-ref-conceptual/release-notes-azure-cli.md#march-03-2022)

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
* No feature changes - only a small change to something not covered by existing tests in order to maintain compatibility with the latest Azure CLI version

