### PR TITLE
Vm spot instance

### DIFF
--- a/Farmer.sln
+++ b/Farmer.sln
@@ -45,6 +45,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{C399
 		samples\scripts\storage.fsx = samples\scripts\storage.fsx
 		samples\scripts\template.json = samples\scripts\template.json
 		samples\scripts\vm.fsx = samples\scripts\vm.fsx
+		samples\scripts\vm-spot-instance.fsx = samples\scripts\vm-spot-instance.fsx
 		samples\scripts\vnet-gateway.fsx = samples\scripts\vnet-gateway.fsx
 		samples\scripts\vnet-hub-and-spoke.fsx = samples\scripts\vnet-hub-and-spoke.fsx
 		samples\scripts\vnet.fsx = samples\scripts\vnet.fsx

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,9 @@ Release Notes
 =============
 
 ## 1.6.30
+* VMs: Allow setting Priority and Spot Instance Settings
+
+## 1.6.30
 * WebApps/Functions: Allow adding IP restriction string with CIDR
 
 ## 1.6.29

--- a/docs/content/api-overview/resources/virtual-machine.md
+++ b/docs/content/api-overview/resources/virtual-machine.md
@@ -24,6 +24,8 @@ In addition, every VM you create will add a SecureString parameter to the ARM te
 |diagnostics_support|Turns on diagnostics support using an automatically created created storage account.|
 |diagnostics_support_external|Turns on diagnostics support using an existing storage account.|
 |vm_size|Sets the size of the VM.|
+|priority|Sets the VM Priority. Overrides `spot_instance`.|
+|spot_instance|Makes the VM a spot instance. Overrides `priority`|
 |username|Sets the admin username of the VM (note: the password is supplied as a securestring parameter to the generated ARM template).|
 |password_parameter|Sets the name of the parameter which contains the admin password for this VM. defaults to "password-for-<VM-name>"|
 |operating_system|Sets the operating system of the VM. A set of samples is provided in the `CommonImages` module.|

--- a/samples/scripts/vm-spot-instance.fsx
+++ b/samples/scripts/vm-spot-instance.fsx
@@ -1,0 +1,26 @@
+#r "nuget:Farmer"
+
+open Farmer
+open Farmer.Builders
+open Farmer.Vm
+
+let myVm = vm {
+    name "isaacsVM"
+    username "isaac"
+    spot_instance Deallocate
+    vm_size Standard_A2
+    operating_system WindowsServer_2012Datacenter
+    os_disk 128 StandardSSD_LRS
+    add_ssd_disk 128
+    add_slow_disk 512
+    diagnostics_support
+    system_identity
+}
+
+let deployment = arm {
+    location Location.NorthEurope
+    add_resource myVm
+}
+
+deployment
+|> Deploy.execute "my-resource-group-name" Deploy.NoParameters

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -309,6 +309,20 @@ module Vm =
 
     /// Represents a disk in a VM.
     type DiskInfo = { Size : int; DiskType : DiskType }
+    type EvictionPolicy =
+        | Deallocate
+        | Delete
+        member this.ArmValue = match this with x -> x.ToString()
+    type BillingProfile =
+        { MaxPrice: decimal }
+    type Priority =
+        | Low
+        | Regular
+        | Spot of evictionPolicy:EvictionPolicy * maxPrice:decimal
+        member this.ArmValue =
+            match this with
+            | Spot _ -> "Spot"
+            | x -> x.ToString()
 
 module internal Validation =
     // ANDs two validation rules

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -629,7 +629,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts/mongodbDatabases"
             },
             {
-              "apiVersion": "2018-10-01",
+              "apiVersion": "2019-03-01",
               "dependsOn": [
                 "[resourceId('Microsoft.Network/networkInterfaces', 'farmervm-nic')]"
               ],
@@ -656,6 +656,7 @@
                   "adminUsername": "farmer-admin",
                   "computerName": "farmervm"
                 },
+                "priority": "Regular",
                 "storageProfile": {
                   "dataDisks": [
                     {

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -9,7 +9,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2018-10-01",
+      "apiVersion": "2019-03-01",
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkInterfaces', 'isaacsVM-nic')]",
         "[resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage')]"
@@ -38,6 +38,7 @@
           "adminUsername": "isaac",
           "computerName": "isaacsVM"
         },
+        "priority": "Regular",
         "storageProfile": {
           "dataDisks": [
             {


### PR DESCRIPTION
The changes in this PR are as follows:

* Adds Priority and Spot Instance settings for VMs

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ x ] **Tested my code** end-to-end against a live Azure subscription.
* [ x ] **Updated the documentation** in the docs folder for the affected changes.
* [ x ] **Written unit tests** against the modified code that I have made.
* [ x ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ x ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
#r "nuget:Farmer"

open Farmer
open Farmer.Builders
open Farmer.Vm

let myVm = vm {
    name "isaacsVM"
    username "isaac"
    spot_instance Deallocate
    vm_size Standard_A2
    operating_system WindowsServer_2012Datacenter
    os_disk 128 StandardSSD_LRS
    add_ssd_disk 128
    add_slow_disk 512
    diagnostics_support
    system_identity
}

let deployment = arm {
    location Location.NorthEurope
    add_resource myVm
}

deployment
|> Deploy.execute "my-resource-group-name" Deploy.NoParameters
```
