### PR TITLE
Support for App Insights workspaces

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,8 @@
 Release Notes
 =============
-## vNext
-* Application Insights: Support for Workspace-enabled instances.
-
 ## 1.6.30
 * WebApps/Functions: Allow adding IP restriction string with CIDR
+* Application Insights: Support for Workspace-enabled instances.
 
 ## 1.6.29
 * CLI: include `--only-show-error` option when executing Azure CLI commands.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* Application Insights: Support for Workspace-enabled instances.
 
 ## 1.6.30
 * WebApps/Functions: Allow adding IP restriction string with CIDR

--- a/docs/content/api-overview/resources/app-insights.md
+++ b/docs/content/api-overview/resources/app-insights.md
@@ -10,6 +10,8 @@ The App Insights builder is used to create Application Insights accounts. Use th
 
 * Application Insights (`Microsoft.Insights/components`)
 
+> This builder supports both "Classic" (standalone) and "Workspace Enabled" (Log Analytics-backed) instances of App Insights. See the `log_analytics_workspace` keyword to see how to create the latter type of instance.
+
 #### Builder Keywords
 
 | Keyword | Purpose |
@@ -17,6 +19,7 @@ The App Insights builder is used to create Application Insights accounts. Use th
 | name | Sets the name of the App Insights instance. |
 | disable_ip_masking | Disable IP masking. |
 | sampling_percentage | Define sampling percentage (0-100) |
+| log_analytics_workspace | Use a Log Analytics workspace as the backing store for this AI instance. You can supply either a Farmer-generate Log Analytics`WorkspaceConfig` instance that exists in the same resource group, or a fully-qualified Resource ID path to that instance. This will also switch the AI instance over to creating a "workspace enabled" AI instance. |
 
 #### Configuration Members
 
@@ -32,5 +35,6 @@ open Farmer.Builders
 
 let ai = appInsights {
     name "myAI"
+    log_analytics_workspace myWorkspace // use to activate workspace-enabled AI instances.
 }
 ```

--- a/samples/scripts/appinsights-loganalytics.fsx
+++ b/samples/scripts/appinsights-loganalytics.fsx
@@ -1,0 +1,26 @@
+#r @"nuget:Farmer"
+
+open Farmer
+open Farmer.Builders
+
+let workspace = logAnalytics {
+    name "loganalytics-workspace"
+}
+
+let myAppInsights = appInsights {
+    name "appInsights"
+    log_analytics_workspace workspace
+}
+
+let myFunctions = functions {
+    name "functions-app"
+    link_to_app_insights myAppInsights.Name
+}
+
+let template = arm {
+    location Location.NorthEurope
+    add_resources [ workspace; myAppInsights; myFunctions ]
+}
+
+template
+|> Deploy.execute "deleteme" Deploy.NoParameters

--- a/src/Farmer/Arm/Insights.fs
+++ b/src/Farmer/Arm/Insights.fs
@@ -4,6 +4,16 @@ module Farmer.Arm.Insights
 open Farmer
 
 let components = ResourceType("Microsoft.Insights/components", "2014-04-01")
+let componentsWorkspace = ResourceType("Microsoft.Insights/components", "2020-02-02")
+
+/// The type of AI instance to create.
+type ComponentsType =
+    | Classic
+    | Workspace of ResourceId
+    member this.ComponentsType =
+        match this with
+        | Classic -> components
+        | Workspace _ -> componentsWorkspace
 
 type Components =
     { Name : ResourceName
@@ -11,7 +21,9 @@ type Components =
       LinkedWebsite : ResourceName option
       DisableIpMasking : bool
       SamplingPercentage : int
-      Tags: Map<string,string> }
+      Type : ComponentsType
+      Tags: Map<string,string>
+      Dependencies : ResourceId Set }
     interface IArmResource with
         member this.ResourceId = components.resourceId this.Name
         member this.JsonModel =
@@ -19,16 +31,24 @@ type Components =
                 match this.LinkedWebsite with
                 | Some linkedWebsite -> this.Tags.Add($"[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', '{linkedWebsite.Value}')]", "Resource")
                 | None -> this.Tags
-
-            {| components.Create(this.Name, this.Location, tags = tags) with
-                 kind = "web"
-                 properties =
-                  {| name = this.Name.Value
-                     Application_Type = "web"
-                     ApplicationId =
-                       match this.LinkedWebsite with
-                       | Some linkedWebsite -> linkedWebsite.Value
-                       | None -> null
-                     DisableIpMasking = this.DisableIpMasking
-                     SamplingPercentage = this.SamplingPercentage |}
+            {| this.Type.ComponentsType.Create(this.Name, this.Location, this.Dependencies, tags) with
+                kind = "web"
+                properties =
+                    {|
+                        name = this.Name.Value
+                        Application_Type = "web"
+                        ApplicationId =
+                            match this.LinkedWebsite with
+                            | Some linkedWebsite -> linkedWebsite.Value
+                            | None -> null
+                        DisableIpMasking = this.DisableIpMasking
+                        SamplingPercentage = this.SamplingPercentage
+                        IngestionMode =
+                            match this.Type with
+                            | Workspace _ -> "LogAnalytics"
+                            | Classic -> null
+                        WorkspaceResourceId =
+                            match this.Type with
+                            | Workspace resourceId -> resourceId.Eval()
+                            | Classic -> null |}
             |}

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -3,23 +3,27 @@ module Farmer.Builders.AppInsights
 
 open Farmer
 open Farmer.Arm.Insights
+open Farmer.Arm.LogAnalytics
 
 type AppInsights =
     static member getInstrumentationKey (resourceId:ResourceId) =
         ArmExpression
-            .reference(components, resourceId)
+            .reference(resourceId)
             .Map(fun r -> r + ".InstrumentationKey")
             .WithOwner(resourceId)
-    static member getInstrumentationKey (name:ResourceName, ?resourceGroup) =
-        AppInsights.getInstrumentationKey(ResourceId.create (components, name, ?group = resourceGroup))
+    static member getInstrumentationKey (name:ResourceName, ?resourceGroup, ?componentsType) =
+        let componentsType = componentsType |> Option.defaultValue components
+        AppInsights.getInstrumentationKey(ResourceId.create (componentsType, name, ?group = resourceGroup))
 
 type AppInsightsConfig =
     { Name : ResourceName
       DisableIpMasking : bool
       SamplingPercentage : int
+      Type : ComponentsType
+      Dependencies : ResourceId Set
       Tags : Map<string,string> }
     /// Gets the ARM expression path to the instrumentation key of this App Insights instance.
-    member this.InstrumentationKey = AppInsights.getInstrumentationKey this.Name
+    member this.InstrumentationKey = AppInsights.getInstrumentationKey(this.Name, componentsType = this.Type.ComponentsType)
     interface IBuilder with
         member this.ResourceId = components.resourceId this.Name
         member this.BuildResources location = [
@@ -28,6 +32,8 @@ type AppInsightsConfig =
               LinkedWebsite = None
               DisableIpMasking = this.DisableIpMasking
               SamplingPercentage = this.SamplingPercentage
+              Dependencies = this.Dependencies
+              Type = this.Type
               Tags = this.Tags }
         ]
 
@@ -36,7 +42,10 @@ type AppInsightsBuilder() =
         { Name = ResourceName.Empty
           DisableIpMasking = false
           SamplingPercentage = 100
-          Tags = Map.empty }
+          Tags = Map.empty
+          Dependencies = Set.empty
+          Type = Classic }
+
     [<CustomOperation "name">]
     /// Sets the name of the App Insights instance.
     member _.Name(state:AppInsightsConfig, name) = { state with Name = ResourceName name }
@@ -49,10 +58,22 @@ type AppInsightsBuilder() =
     /// Sets the name of the App Insights instance.
     member _.SamplingPercentage(state:AppInsightsConfig, samplingPercentage) = { state with SamplingPercentage = samplingPercentage }
 
+    /// Links this AI instance to a Log Analytics workspace, using the newer 2020-02-02-preview App Insights version.
+    [<CustomOperation "log_analytics_workspace">]
+    member _.Workspace(state:AppInsightsConfig, workspace:ResourceId) =
+        { state with
+            Type = Workspace workspace
+            Dependencies = state.Dependencies.Add workspace
+        }
+    member this.Workspace(state:AppInsightsConfig, workspace:WorkspaceConfig) =
+        this.Workspace(state, workspaces.resourceId workspace.Name)
+
     member _.Run (state:AppInsightsConfig) =
         if state.SamplingPercentage > 100  then raiseFarmer "Sampling Percentage cannot be higher than 100%"
         elif state.SamplingPercentage <= 0 then raiseFarmer "Sampling Percentage cannot be lower than or equal to 0%"
         state
+
     interface ITaggable<AppInsightsConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    interface IDependable<AppInsightsConfig> with member _.Add state resources = { state with Dependencies = state.Dependencies + resources }
 
 let appInsights = AppInsightsBuilder()

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -311,7 +311,7 @@ type FunctionsConfig =
                   DisableIpMasking = false
                   SamplingPercentage = 100
                   Dependencies = Set.empty
-                  Type = Classic
+                  InstanceKind = Classic
                   LinkedWebsite =
                     match this.CommonWebConfig.OperatingSystem with
                     | Windows -> Some this.Name.ResourceName

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -15,7 +15,7 @@ open System
 type FunctionsRuntime = DotNet | DotNetIsolated | Node | Java | Python
 type VersionedFunctionsRuntime =  FunctionsRuntime * string option
 type FunctionsRuntime with
-    // These values are defined on FunctionsRuntime to reduce the need for users to be aware of the distinction 
+    // These values are defined on FunctionsRuntime to reduce the need for users to be aware of the distinction
     // between FunctionsRuntime and VersionedFunctionsRuntime as well as to provide parity with WebApp runtime
     static member DotNetCore31 = DotNet, Some "3.1"
     static member DotNet50 = DotNet, Some "5.0"
@@ -246,12 +246,12 @@ type FunctionsConfig =
                   HTTP20Enabled = None
                   ClientAffinityEnabled = None
                   WebSocketsEnabled = None
-                  LinuxFxVersion = 
+                  LinuxFxVersion =
                     match this.CommonWebConfig.OperatingSystem with
                     | Windows -> None
                     | Linux ->
                       match this.VersionedRuntime with
-                      | DotNet, Some version -> 
+                      | DotNet, Some version ->
                         match Double.TryParse(version) with
                         | true, versionNo when versionNo < 4.0 -> Some $"DOTNETCORE|{version}"
                         | _ -> Some $"DOTNET|{version}"
@@ -310,6 +310,8 @@ type FunctionsConfig =
                   Location = location
                   DisableIpMasking = false
                   SamplingPercentage = 100
+                  Dependencies = Set.empty
+                  Type = Classic
                   LinkedWebsite =
                     match this.CommonWebConfig.OperatingSystem with
                     | Windows -> Some this.Name.ResourceName
@@ -346,7 +348,7 @@ type FunctionsBuilder() =
               Slots = Map.empty
               WorkerProcess = None
               ZipDeployPath = None
-              HealthCheckPath = None 
+              HealthCheckPath = None
               IpSecurityRestrictions = [] }
           StorageAccount = derived (fun config ->
             let storage = config.Name.ResourceName.Map (sprintf "%sstorage") |> sanitiseStorage |> ResourceName

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -480,7 +480,7 @@ type WebAppConfig =
                   Location = location
                   DisableIpMasking = false
                   SamplingPercentage = 100
-                  Type = Classic
+                  InstanceKind = Classic
                   Dependencies = Set.empty
                   LinkedWebsite =
                     match this.CommonWebConfig.OperatingSystem with

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -244,8 +244,8 @@ type CertificateOptions =
 type DomainConfig =
     | SecureDomain of domain:string * cert:CertificateOptions
     | InsecureDomain of domain:string
-    member this.DomainName = 
-        match this with 
+    member this.DomainName =
+        match this with
         | SecureDomain (domainName,_)
         | InsecureDomain (domainName) -> domainName
 

--- a/src/Tests/AppInsights.fs
+++ b/src/Tests/AppInsights.fs
@@ -31,14 +31,13 @@ let tests = testList "AppInsights" [
         let deployment = arm {
             add_resources [ workspace; ai ]
         }
-        let json = deployment.Template |> Writer.toJson |> JObject.Parse
-        let version = json.SelectToken("resources[?(@.name=='ai')].apiVersion").ToString()
-        let resourceId = json.SelectToken("resources[?(@.name=='ai')].properties.WorkspaceResourceId").ToString()
-        let dependencies = json.SelectToken("resources[?(@.name=='ai')].dependsOn").Children() |> Seq.map string |> Seq.toArray
 
-        Expect.equal resourceId "[resourceId('Microsoft.OperationalInsights/workspaces', 'la')]" "Incorrect workspace id"
-        Expect.equal version "2020-02-02" "Incorrect API version"
+        let json = deployment.Template |> Writer.toJson |> JObject.Parse
+        let select query = json.SelectToken(query).ToString()
+
+        Expect.equal (select "resources[?(@.name=='ai')].properties.WorkspaceResourceId") "[resourceId('Microsoft.OperationalInsights/workspaces', 'la')]" "Incorrect workspace id"
+        Expect.equal (select "resources[?(@.name=='ai')].apiVersion") "2020-02-02" "Incorrect API version"
         Expect.equal ai.InstrumentationKey.Value ("reference(resourceId('Microsoft.Insights/components', 'ai'), '2020-02-02').InstrumentationKey") "Incorrect Instrumentation Key reference"
-        Expect.sequenceEqual dependencies [ "[resourceId('Microsoft.OperationalInsights/workspaces', 'la')]" ] "Incorrect dependencies"
+        Expect.sequenceEqual (json.SelectToken("resources[?(@.name=='ai')].dependsOn").Children() |> Seq.map string |> Seq.toArray) [ "[resourceId('Microsoft.OperationalInsights/workspaces', 'la')]" ] "Incorrect dependencies"
    }
 ]

--- a/src/Tests/AppInsights.fs
+++ b/src/Tests/AppInsights.fs
@@ -37,8 +37,8 @@ let tests = testList "AppInsights" [
         let dependencies = json.SelectToken("resources[?(@.name=='ai')].dependsOn").Children() |> Seq.map string |> Seq.toArray
 
         Expect.equal resourceId "[resourceId('Microsoft.OperationalInsights/workspaces', 'la')]" "Incorrect workspace id"
-        Expect.equal version "2020-02-02-preview" "Incorrect API version"
-        Expect.equal ai.InstrumentationKey.Value ("reference(resourceId('Microsoft.Insights/components', 'ai'), '2020-02-02-preview').InstrumentationKey") "Incorrect Instrumentation Key reference"
+        Expect.equal version "2020-02-02" "Incorrect API version"
+        Expect.equal ai.InstrumentationKey.Value ("reference(resourceId('Microsoft.Insights/components', 'ai'), '2020-02-02').InstrumentationKey") "Incorrect Instrumentation Key reference"
         Expect.sequenceEqual dependencies [ "[resourceId('Microsoft.OperationalInsights/workspaces', 'la')]" ] "Incorrect dependencies"
    }
 ]

--- a/src/Tests/AppInsights.fs
+++ b/src/Tests/AppInsights.fs
@@ -3,6 +3,8 @@ module AppInsights
 open Expecto
 open Farmer
 open Farmer.Builders.AppInsights
+open Farmer.Builders.LogAnalytics
+open Newtonsoft.Json.Linq
 
 let tests = testList "AppInsights" [
     test "Creates keys on an AI instance correctly" {
@@ -11,8 +13,32 @@ let tests = testList "AppInsights" [
         Expect.equal ai.InstrumentationKey.Value ("reference(resourceId('Microsoft.Insights/components', 'foo'), '2014-04-01').InstrumentationKey") "Incorrect Value"
     }
 
+    test "Creates with classic version by default" {
+        let deployment = arm { add_resource (appInsights { name "foo" }) }
+        let json = deployment.Template |> Writer.toJson |> JObject.Parse
+        let version = json.SelectToken("resources[?(@.name=='foo')].apiVersion").ToString()
+        Expect.equal version "2014-04-01" "Incorrect API version"
+    }
+
     test "Create generated keys correctly" {
         let generatedKey = AppInsights.getInstrumentationKey(ResourceId.create(Arm.Insights.components, ResourceName "foo", "group"))
         Expect.equal generatedKey.Value "reference(resourceId('group', 'Microsoft.Insights/components', 'foo'), '2014-04-01').InstrumentationKey" "Incorrect generated key"
     }
+
+    test "Creates LA-enabled workspace" {
+        let workspace = logAnalytics { name "la" }
+        let ai = appInsights { name "ai"; log_analytics_workspace workspace }
+        let deployment = arm {
+            add_resources [ workspace; ai ]
+        }
+        let json = deployment.Template |> Writer.toJson |> JObject.Parse
+        let version = json.SelectToken("resources[?(@.name=='ai')].apiVersion").ToString()
+        let resourceId = json.SelectToken("resources[?(@.name=='ai')].properties.WorkspaceResourceId").ToString()
+        let dependencies = json.SelectToken("resources[?(@.name=='ai')].dependsOn").Children() |> Seq.map string |> Seq.toArray
+
+        Expect.equal resourceId "[resourceId('Microsoft.OperationalInsights/workspaces', 'la')]" "Incorrect workspace id"
+        Expect.equal version "2020-02-02-preview" "Incorrect API version"
+        Expect.equal ai.InstrumentationKey.Value ("reference(resourceId('Microsoft.Insights/components', 'ai'), '2020-02-02-preview').InstrumentationKey") "Incorrect Instrumentation Key reference"
+        Expect.sequenceEqual dependencies [ "[resourceId('Microsoft.OperationalInsights/workspaces', 'la')]" ] "Incorrect dependencies"
+   }
 ]

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -97,6 +97,7 @@
     },
     {
       "apiVersion": "2014-04-01",
+      "dependsOn": [],
       "kind": "web",
       "location": "northeurope",
       "name": "farmerwebapp1979-ai",
@@ -236,6 +237,7 @@
     },
     {
       "apiVersion": "2014-04-01",
+      "dependsOn": [],
       "kind": "web",
       "location": "northeurope",
       "name": "farmerfuncs1979-ai",


### PR DESCRIPTION
This PR closes #770 

The changes in this PR are as follows:

* Adds an extra keyword for linking a Log Analytics Workspace to an App Instance instance.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let workspace = logAnalytics {
    name "loganalytics-workspace"
}

let myAppInsights = appInsights {
    name "appInsights"
    log_analytics_workspace workspace
}
```
