### PR TITLE
Fix multiple custom domains

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 1.6.31
+* WebApps: Fix flakey deployments of web apps with multiple custom domains.
+* Deployments: Fix `ResourceId` generation when using a resource with a template.
+
 ## 1.6.30
 * WebApps/Functions: Allow adding IP restriction string with CIDR
 

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -363,26 +363,17 @@ type HostNameBinding =
     { Location: Location
       SiteId: LinkedResource
       DomainName: string
-      SslState: SslState
-      DependsOn: ResourceId Set }
+      SslState: SslState}
         member this.SiteResourceId =
-            match this.SiteId with
-            | Managed id -> id.Name
-            | Unmanaged id -> id.Name
+            this.SiteId.Name
         member this.ResourceName =
             this.SiteResourceId / this.DomainName
-        member this.Dependencies =
-            [ match this.SiteId with
-              | Managed resid -> resid
-              | _ -> ()
-
-              yield! this.DependsOn ]
         member this.ResourceId =
             hostNameBindings.resourceId (this.SiteResourceId, ResourceName this.DomainName)
         interface IArmResource with
             member this.ResourceId = hostNameBindings.resourceId this.ResourceName
             member this.JsonModel =
-                {| hostNameBindings.Create(this.ResourceName, this.Location, this.Dependencies) with
+                {| hostNameBindings.Create(this.ResourceName, this.Location) with
                     properties =
                         match this.SslState with
                         | SniBased thumbprint ->

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -514,26 +514,34 @@ type WebAppConfig =
                 { site with AppSettings = None; ConnectionStrings = None } // Don't deploy production slot settings as they could cause an app restart
                 for (_,slot) in this.CommonWebConfig.Slots |> Map.toSeq do
                     slot.ToSite site
-                
-            // Host Name Bindings must be deployed sequentially to avoid an error, as the site cannot be modified concurrently.
-            // To do so we add a dependency to the previous binding.
-            let mutable previousHostNameBinding = None
-            for customDomain in this.CustomDomains |> Map.toSeq |> Seq.map snd do
-                let dependsOn = 
-                    match previousHostNameBinding with 
-                    | Some previous -> Set.singleton previous
-                    | None -> Set.empty
+             
+            // Need to rename `location` binding to prevent conflict with `location` operator in resource group
+            let resourceLocation = location
 
+            // Host Name Bindings must be deployed sequentially to avoid an error, as the site cannot be modified concurrently.
+            // To do so we add a dependency to the previous binding deployment.
+            let mutable previousHostNameCertificateLinkingDeployment = None
+            for customDomain in this.CustomDomains |> Map.toSeq |> Seq.map snd do
                 let hostNameBinding =
                     { Location = location
                       SiteId =  Managed (Arm.Web.sites.resourceId this.Name.ResourceName)
                       DomainName = customDomain.DomainName
-                      SslState = SslDisabled // Initially create non-secure host name binding, we link the certificate in a nested deployment below if this is a secure domain.
-                      DependsOn = dependsOn }
+                      SslState = SslDisabled } // Initially create non-secure host name binding, we link the certificate in a nested deployment below
 
-                hostNameBinding
+                let dependsOn : ResourceId list = 
+                  match previousHostNameCertificateLinkingDeployment with
+                  | Some previous -> [ previous; this.ResourceId ]
+                  | None -> [ this.ResourceId ]
 
-                previousHostNameBinding <- Some hostNameBinding.ResourceId
+                let hostNameBindingDeployment = resourceGroup {
+                    name "[resourceGroup().name]"
+                    location resourceLocation
+                    add_resource hostNameBinding
+                    depends_on dependsOn
+                }
+
+                yield! ((hostNameBindingDeployment :> IBuilder).BuildResources location)
+
                 match customDomain with
                 | SecureDomain (customDomain, certOptions) ->
                     let cert =
@@ -541,47 +549,49 @@ type WebAppConfig =
                           SiteId = Managed this.ResourceId
                           ServicePlanId = Managed this.ServicePlanId
                           DomainName = customDomain }
-                    hostNameBinding
 
                     // Get the resource group which contains the app service plan
                     let aspRgName = 
                       match this.CommonWebConfig.ServicePlan with
                       | LinkedResource linked -> linked.ResourceId.ResourceGroup
                       | _ -> None
+
                     // Create a nested resource group deployment for the certificate - this isn't strictly necessary when the app & app service plan are in the same resource group
                     // however, when they are in different resource groups this is required to make the deployment succeed (there is an ARM bug which causes a Not Found / Conflict otherwise)
                     // To keep the code simple, I opted to always nest the certificate deployment. - TheRSP 2021-12-14
-                    let certRg = resourceGroup { 
+                    let certificateDeployment = resourceGroup { 
                         name (aspRgName |> Option.defaultValue "[resourceGroup().name]")
                         add_resource 
                           { cert with
                               SiteId = Unmanaged cert.SiteId.ResourceId
                               ServicePlanId = Unmanaged cert.ServicePlanId.ResourceId }
                         depends_on cert.SiteId
-                        depends_on hostNameBinding.ResourceId
+                        depends_on hostNameBindingDeployment.ResourceId
                     }
-                    yield! ((certRg :> IBuilder).BuildResources location)
 
-                    // Need to rename `location` binding to prevent conflict with `location` operator in resource group
-                    let resourceLocation = location
-                    // nested deployment to update hostname binding with specified SSL options
-                    yield! (resourceGroup {
+                    yield! ((certificateDeployment :> IBuilder).BuildResources location)
+
+                    // Deployment to update hostname binding with specified SSL options
+                    let hostNameCertificateLinkingDeployment = resourceGroup { 
                         name "[resourceGroup().name]"
                         location resourceLocation
                         add_resource { hostNameBinding with
                                         SiteId =
-                                            match hostNameBinding.SiteId with
+                                            match hostNameBinding.SiteId with 
                                             | Managed id -> Unmanaged id
-                                            | x -> x
-                                        SslState =
+                                            | x -> x 
+                                        SslState = 
                                             match certOptions with
                                             | AppManagedCertificate -> SniBased (cert.GetThumbprintReference aspRgName)
                                             | CustomCertificate thumbprint -> SniBased thumbprint
-                                        DependsOn = Set.empty // Don't want the dependency in this nested template.
                                       }
-                        depends_on certRg
-                    } :> IBuilder).BuildResources location
-                | _ -> ()
+                        depends_on certificateDeployment.ResourceId
+                     }
+
+                    yield! ((hostNameCertificateLinkingDeployment :> IBuilder).BuildResources location)
+
+                    previousHostNameCertificateLinkingDeployment <- Some hostNameCertificateLinkingDeployment.ResourceId
+                | _ -> () 
 
             yield! (PrivateEndpoint.create location this.ResourceId ["sites"] this.PrivateEndpoints)
         ]

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.6.29</Version>
+    <Version>1.6.31</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -138,7 +138,7 @@ type ResourceId with
               this.Type.Type
               this.Name.Value
               for segment in this.Segments do segment.Value ]
-            |> List.map (sprintf "'%s'")
+            |> List.map (fun x -> if x.StartsWith("[") then x.Trim('[' ,']') else sprintf $"'%s{x}'") // Fixes case where a template e.g. [resourceGroup().name] is used.
             |> String.concat ", "
             |> sprintf "resourceId(%s)"
             |> ArmExpression.create

--- a/src/Tests/Template.fs
+++ b/src/Tests/Template.fs
@@ -193,6 +193,15 @@ let tests = testList "Template" [
         Expect.equal id "[resourceId('Microsoft.Network/connections', 'test', 'segment1', 'segment2')]" "resourceId template function should match"
     }
 
+    test "Generates deployment Resource Id with template name" {
+        let deployment = resourceGroup {
+            name "[resourceGroup.name()]"
+        }
+        let id = deployment.ResourceId.Eval()
+        let expectedDeploymentIndex = ResourceGroup.deploymentIndex() - 1
+        Expect.equal id $"[resourceId(resourceGroup.name(), 'Microsoft.Resources/deployments', concat(resourceGroup.name(),'-deployment-{expectedDeploymentIndex}'))]" "resourceId template function should match"
+    }
+
     test "Fails if ARM expression is already quoted" {
         Expect.throws(fun () -> ArmExpression.create "[test]" |> ignore ) ""
     }

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -627,23 +627,23 @@ let tests = testList "Web App Tests" [
         let thumbprint = ArmExpression.literal "1111583E8FABEF4C0BEF694CBC41C28FB81CD111"
         let resources = webApp { name webappName; custom_domain ("customDomain.io",thumbprint) } |> getResources
         let wa = resources |> getResource<Web.Site> |> List.head
-        let nested = resources |> getResource<ResourceGroup.ResourceGroupDeployment>
-
-        //Testing certificate
-        let cert = nested.[0].Resources |> getResource<Web.Certificate> |> List.head
+        let nested = resources |> getResource<ResourceGroupDeployment>
         let expectedDomainName = "customDomain.io"
-        Expect.equal cert.DomainName expectedDomainName $"Certificate domain name should have {expectedDomainName}"
 
-        //Testing HostnameBinding
-        let hostnameBinding = resources |> getResource<Web.HostNameBinding> |> List.head
+        // Testing HostnameBinding
+        let hostnameBinding = nested.[0].Resources |> getResource<Web.HostNameBinding> |> List.head
         let expectedSslState = SslState.SslDisabled
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
         Expect.equal hostnameBinding.DomainName expectedDomainName $"HostnameBinding domain name should have {expectedDomainName}"
         Expect.equal hostnameBinding.SslState expectedSslState $"HostnameBinding should have a {expectedSslState} Ssl state"
         Expect.equal hostnameBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
 
-        //Testing ResourceGroupDeployment
-        let bindingDeployment = nested.[1]
+        // Testing certificate
+        let cert = nested.[1].Resources |> getResource<Web.Certificate> |> List.head
+        Expect.equal cert.DomainName expectedDomainName $"Certificate domain name should have {expectedDomainName}"
+
+        // Testing hostname/certificate link.
+        let bindingDeployment = nested.[2]
         let innerResource = bindingDeployment.Resources |> getResource<Web.HostNameBinding> |> List.head
         let innerExpectedSslState = SslState.SniBased thumbprint
         Expect.stringStarts bindingDeployment.DeploymentName.Value "[concat" "resourceGroupDeployment name should start as a valid ARM expression"
@@ -658,22 +658,22 @@ let tests = testList "Web App Tests" [
         let resources = webApp { name webappName; custom_domain "customDomain.io" } |> getResources
         let wa = resources |> getResource<Web.Site> |> List.head
         let nested = resources |> getResource<ResourceGroup.ResourceGroupDeployment>
-
-        //Testing certificate
-        let cert = nested.[0].Resources |> getResource<Web.Certificate> |> List.head
         let expectedDomainName = "customDomain.io"
-        Expect.equal cert.DomainName expectedDomainName $"Certificate domain name should have {expectedDomainName}"
-
-        //Testing HostnameBinding
-        let hostnameBinding = resources |> getResource<Web.HostNameBinding> |> List.head
+        
+        // Testing HostnameBinding
+        let hostnameBinding = nested.[0].Resources |> getResource<Web.HostNameBinding> |> List.head
         let expectedSslState = SslState.SslDisabled
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
         Expect.equal hostnameBinding.DomainName expectedDomainName $"HostnameBinding domain name should have {expectedDomainName}"
         Expect.equal hostnameBinding.SslState expectedSslState $"HostnameBinding should have a {expectedSslState} Ssl state"
         Expect.equal hostnameBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
+        
+        // Testing certificate
+        let cert = nested.[1].Resources |> getResource<Web.Certificate> |> List.head
+        Expect.equal cert.DomainName expectedDomainName $"Certificate domain name should have {expectedDomainName}"
 
-        //Testing ResourceGroupDeployment
-        let bindingDeployment = nested.[1]
+        // Testing hostname/certificate link.
+        let bindingDeployment = nested.[2]
         let innerResource = bindingDeployment.Resources |> getResource<Web.HostNameBinding> |> List.head
         let innerExpectedSslState = SslState.SniBased cert.Thumbprint
         Expect.equal bindingDeployment.Resources.Length 1 "resourceGroupDeployment stage should only contain one resource"
@@ -687,7 +687,12 @@ let tests = testList "Web App Tests" [
         let wa = resources |> getResource<Web.Site> |> List.head
 
         //Testing HostnameBinding
-        let hostnameBinding = resources |> getResource<Web.HostNameBinding> |> List.head
+        let hostnameBinding = 
+            resources 
+              |> getResource<ResourceGroupDeployment>
+              |> Seq.map(fun x -> getResource<Web.HostNameBinding>(x.Resources))
+              |> Seq.concat
+              |> Seq.head
         let expectedSslState = SslState.SslDisabled
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
         let expectedDomainName = "customDomain.io"
@@ -695,9 +700,6 @@ let tests = testList "Web App Tests" [
         Expect.equal hostnameBinding.DomainName expectedDomainName $"HostnameBinding domain name should have {expectedDomainName}"
         Expect.equal hostnameBinding.SslState expectedSslState $"HostnameBinding should have a {expectedSslState} Ssl state"
         Expect.equal hostnameBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
-
-        let nestedDeployments = resources |> getResource<ResourceGroupDeployment>
-        Expect.isEmpty nestedDeployments $"Only secured domains need nested deployments"
     }
 
     test "Supports multiple custom domains" {
@@ -713,15 +715,19 @@ let tests = testList "Web App Tests" [
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
 
         //Testing HostnameBinding
-        let hostnameBindings = resources |> getResource<Web.HostNameBinding> 
-        let secureBinding = hostnameBindings |> List.filter (fun x->x.DomainName = "secure.io") |> List.head
-        let insecureBinding = hostnameBindings |> List.filter (fun x->x.DomainName = "insecure.io") |> List.head
+        let hostnameBindings = 
+            resources 
+              |> getResource<ResourceGroupDeployment>
+              |> Seq.map(fun x -> getResource<Web.HostNameBinding>(x.Resources))
+              |> Seq.concat
+        let secureBinding = hostnameBindings |> Seq.filter (fun x -> x.DomainName = "secure.io") |> Seq.head
+        let insecureBinding = hostnameBindings |> Seq.filter (fun x -> x.DomainName = "insecure.io") |> Seq.head
         
         Expect.equal secureBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
         Expect.equal insecureBinding.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
     }
 
-    test "Assigns dependencies to host names when deploying multiple custom domains" {
+    test "Assigns correct dependencies when deploying multiple custom domains" {
         let webappName = "test"
         let resources = 
             webApp {
@@ -732,25 +738,44 @@ let tests = testList "Web App Tests" [
 
         let exepectedSiteId = (Managed (Arm.Web.sites.resourceId wa.Name))
 
-        //Testing HostnameBinding
-        let hostnameBindings = resources |> getResource<Web.HostNameBinding> 
+        // Testing HostnameBinding
+        let hostnameBindings = 
+          resources 
+            |> getResource<ResourceGroupDeployment>
+            |> Seq.map(fun x -> getResource<Web.HostNameBinding>(x.Resources))
+            |> Seq.concat
+            |> Seq.toList
+
         let secureBinding1 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure1.io") |> List.head
         let secureBinding2 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure2.io") |> List.head
         let secureBinding3 = hostnameBindings |> List.filter(fun x -> x.DomainName = "secure3.io") |> List.head
-        let nestedResourceGroupHostNameUpdates = 
-            resources 
-            |> getResource<ResourceGroupDeployment> 
-            |> Seq.map(fun x -> getResource<Web.HostNameBinding>(x.Resources))
-            |> Seq.filter(fun x -> x.Length > 0)
 
-        Expect.all nestedResourceGroupHostNameUpdates (fun x -> x.Head.DependsOn.IsEmpty) "No dependencies expected on nested template"
         Expect.equal secureBinding1.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
         Expect.equal secureBinding2.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
         Expect.equal secureBinding3.SiteId exepectedSiteId $"HostnameBinding SiteId should be {exepectedSiteId}"
-        Expect.isEmpty secureBinding1.DependsOn "First host name binding should have no dependency"
-        Expect.contains (secureBinding2.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure1.io')]" "Second host name binding should depend on first"
-        Expect.contains (secureBinding3.DependsOn |> Seq.map(ResourceId.Eval)) "[resourceId('Microsoft.Web/sites/hostNameBindings', 'test', 'secure2.io')]" "Third host name binding depends on second"
+
+        // Testing dependencies.
+        let deployments = resources |> getResource<ResourceGroupDeployment> |> Seq.toList
+
+        let dependenciesOnOtherDeployments =
+          deployments
+            |> Seq.map(fun rg -> rg.Dependencies |> Seq.filter(fun dep -> deployments |> Seq.exists(fun x -> x.DeploymentName = dep.Name)))
+            |> Seq.map(fun deps -> deps |> Seq.map(fun dep -> dep.Name))
+            |> Seq.toList
+
+        let siteDependency =
+           deployments[0].Dependencies
+           |> Set.filter(fun x -> x.Type = wa.ResourceType)
+           |> Set.map(fun x -> x.Name)
+           |> Seq.head
+           
+        Expect.hasLength deployments 9 "Should have three deploys per custom domain"
+        Expect.isEmpty dependenciesOnOtherDeployments[0] "First deploy should not depend on another"
+        Expect.equal siteDependency.Value webappName "First deployment should have a dependency on the site"
+
+        seq { 1 .. 1 .. 8 } |> Seq.iter(fun x -> Expect.contains dependenciesOnOtherDeployments[x] deployments[x - 1].ResourceId.Name "Each subsequent deploy should depend on previous deploy")
     }
+
     test "Supports adding ip restriction for allowed ip" {
         let ip = "1.2.3.4/32"
         let resources = webApp { name "test"; add_allowed_ip_restriction "test-rule" ip } |> getResources
@@ -759,6 +784,7 @@ let tests = testList "Web App Tests" [
         let expectedRestriction = IpSecurityRestriction.Create "test-rule" (IPAddressCidr.parse ip) Allow
         Expect.equal site.IpSecurityRestrictions [ expectedRestriction ] "Should add allowed ip security restriction"
     }
+
     test "Supports adding ip restriction for denied ip" {
         let ip = IPAddressCidr.parse "1.2.3.4/32"
         let resources = webApp { name "test"; add_denied_ip_restriction "test-rule" ip } |> getResources
@@ -767,6 +793,7 @@ let tests = testList "Web App Tests" [
         let expectedRestriction = IpSecurityRestriction.Create "test-rule" ip Deny
         Expect.equal site.IpSecurityRestrictions [ expectedRestriction ] "Should add denied ip security restriction"
     }
+
     test "Supports adding different ip restrictions to site and slot" {
         let siteIp = IPAddressCidr.parse "1.2.3.4/32"
         let slotIp = IPAddressCidr.parse "4.3.2.1/32"


### PR DESCRIPTION
This PR fixes conflicts seen when attempting to deploy multiple custom domains due to a race in the deploy. 

The changes in this PR are as follows:
* Deployments of custom domains are forced to run sequentially using a dependency on the previous deployment.
* Fixes issue seen when assigning a dependency to a nested deployment which contains a template string in its name.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
There aren't any changes to the API, the behaviour underneath is all that has changed.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
 webApp {
	name webappName
	custom_domains ["secure1.io" ; "secure2.io" ; "secure3.io"]
}
```
