### PR TITLE
Support Virtual Applications

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.6.32
+* WebApps: Support virtual applications with `add_virtual_application`/`add_virtual_application_preloaded`
+
 ## 1.6.31
 * WebApps: Fix flakey deployments of web apps with multiple custom domains.
 * Deployments: Fix `ResourceId` generation when using a resource with a template.
@@ -10,7 +13,6 @@ Release Notes
 ## 1.6.30
 * WebApps/Functions: Specify connection string types
 * WebApps/Functions: Allow adding IP restriction string with CIDR
-* WebApps: Support virtual applications with `add_virtual_application`/`add_virtual_application_preloaded`
 * Application Insights: Support for Workspace-enabled instances.
 * VMs: Priority and Spot Instance Settings
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes
 
 ## 1.6.30
 * WebApps/Functions: Allow adding IP restriction string with CIDR
+* WebApps: Support virtual applications with `add_virtual_application`/`add_virtual_application_preloaded`
 
 ## 1.6.29
 * CLI: include `--only-show-error` option when executing Azure CLI commands.

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -1,6 +1,6 @@
 ---
 title: "Web App"
-date: 2020-02-05T08:53:46+01:00
+date: 2022-04-05T11:05:00-04:00
 chapter: false
 weight: 22
 ---
@@ -62,8 +62,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | docker_port | Adds `WEBSITES_PORT` setting to map custom docker port to app service port 80 |
 | Web App | link_to_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. Use this operator when the given VNET is in the same deployment |
 | Web App | link_to_unmanaged_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. Use this operator when the given VNET is *not* in the same deployment |
-| Web App | add_virtual_application | Adds a virtual application, allowing you to run multiple sub-applications by providing the virtual path to map to a physical directory containing the application |
-| Web App | add_virtual_application_preloaded | Adds a virtual application, with preloading enabled for that application |
+| Web App | add_virtual_applications | Adds list of `virtualApplication` definitions to the webapp |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |
@@ -103,6 +102,22 @@ The following keywords exist on the web app:
 | use_keyvault | Tells the web app to create a brand new KeyVault for this App Service's secrets. |
 | link_to_keyvault | Tells the web app to use an existing Farmer-managed KeyVault which you have defined elsewhere. All secret settings will automatically be mapped into KeyVault. |
 | link_to_unmanaged_keyvault | Tells the web app to use an existing non-Farmer managed KeyVault which you have defined elsewhere.  All secret settings will automatically be mapped into KeyVault. |
+
+#### Virtual Applications `virtualApplication`
+Virtual applications can be defined for a webapp which allows you to specify alternative directories for the application executables or enable a single web app to host multiple applications at once. By default, the following `virtualApplication` is provided for you:
+
+```fsharp
+virtualApplication {
+    virtual_path "/"
+    physical_path "wwwroot"
+}
+```
+
+| Keyword                                 | Purpose                                                                  |
+| --------------------------------------- | ------------------------------------------------------------------------ |
+| virtual_path                            | Provides the virtual path mapping                                        |
+| physical_path                           | Specifies the physical directory used (relative to the "site" directory) |
+| preloaded                               | Enables the "preload" feature of the virtual application                 |
 
 #### Examples
 
@@ -151,5 +166,28 @@ let wa = webApp {
 let v = keyVault {
     name "isaacvault"
     add_access_policy (AccessPolicy.create (wa.SystemIdentity.PrincipalId, [ KeyVault.Secret.Get; KeyVault.Secret.List ]))
+}
+```
+
+Serving two applications simultaneously (a frontend and a backend) from one web app using virtual applications.
+
+```fsharp
+open Farmer
+open Farmer.Builders
+
+let wa = webApp {
+    name "my-site-with-api"
+    always_on
+    add_virtual_applications [
+        virtualApplication {
+            virtual_path "/"
+            physical_path "frontend" 
+        }
+        virtualApplication {
+            virtual_path "/api"
+            physical_path "backend"
+            preloaded
+        }
+    ]
 }
 ```

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -60,6 +60,8 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | add_allowed_ip_restriction | Adds an 'allow' rule for an ip |
 | Web App | add_denied_ip_restriction | Adds an 'deny' rule for an ip |
 | Web App | docker_port | Adds `WEBSITES_PORT` setting to map custom docker port to app service port 80 |
+| Web App | add_virtual_application | Adds a virtual application, allowing you to run multiple sub-applications by providing the virtual path to map to a physical directory containing the application |
+| Web App | add_virtual_application_preloaded | Adds a virtual application, with preloading enabled for that application |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -313,14 +313,15 @@ type Site =
                            vnetName = this.LinkToSubnet |> Option.map (fun x -> x.ResourceId.Segments[0].Value) |> Option.toObj
                            vnetRouteAllEnabled = this.LinkToSubnet |> function | Some _ -> Nullable true | None -> Nullable()
                            virtualApplications = 
-                                if this.VirtualApplications.IsEmpty
-                                    then null
-                                    else this.VirtualApplications
-                                            |> Seq.map (fun virtualAppKvp ->
-                                                {| virtualPath = virtualAppKvp.Key
-                                                   physicalPath = virtualAppKvp.Value.PhysicalPath
-                                                   preloadEnabled = virtualAppKvp.Value.PreloadEnabled |> Option.toNullable |})
-                                            |> box
+                                if this.VirtualApplications.IsEmpty then
+                                    null
+                                else
+                                    this.VirtualApplications
+                                    |> Seq.map (fun virtualAppKvp ->
+                                        {| virtualPath = virtualAppKvp.Key
+                                           physicalPath = virtualAppKvp.Value.PhysicalPath
+                                           preloadEnabled = virtualAppKvp.Value.PreloadEnabled |> Option.toNullable |})
+                                    |> box
                         |}
                     |}
             |}

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -201,7 +201,8 @@ type Site =
       AutoSwapSlotName: string option
       ZipDeployPath : (string * ZipDeploy.ZipDeployTarget * ZipDeploy.ZipDeploySlot) option
       HealthCheckPath : string option
-      IpSecurityRestrictions : IpSecurityRestriction list }
+      IpSecurityRestrictions : IpSecurityRestriction list
+      VirtualApplications : Map<string, VirtualApplication> }
     /// Shorthand for SiteType.ResourceType
     member this.ResourceType = this.SiteType.ResourceType
     /// Shorthand for SiteType.ResourceName
@@ -303,6 +304,15 @@ type Site =
                             |> Option.toObj
                            healthCheckPath = this.HealthCheckPath |> Option.toObj
                            autoSwapSlotName = this.AutoSwapSlotName |> Option.toObj
+                           virtualApplications = 
+                                if this.VirtualApplications.IsEmpty
+                                    then null
+                                    else this.VirtualApplications
+                                            |> Seq.map (fun virtualAppKvp ->
+                                                {| virtualPath = virtualAppKvp.Key
+                                                   physicalPath = virtualAppKvp.Value.PhysicalPath
+                                                   preloadEnabled = virtualAppKvp.Value.PreloadEnabled |> Option.toNullable |})
+                                            |> box
                         |}
                     |}
             |}

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -274,7 +274,8 @@ type FunctionsConfig =
                     | _ -> None
                   WorkerProcess = this.CommonWebConfig.WorkerProcess
                   HealthCheckPath = this.CommonWebConfig.HealthCheckPath
-                  IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions }
+                  IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions
+                  VirtualApplications = Map [] }
 
             match this.CommonWebConfig.ServicePlan with
             | DeployableResource this.Name.ResourceName resourceId ->

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -779,11 +779,12 @@ type WebAppBuilder() =
     member this.ZoneRedundant(state:WebAppConfig, flag:FeatureFlag) = {state with ZoneRedundant = Some flag}
 
     member _.AddVirtualApplication(state:WebAppConfig, physicalPath, virtualPath, preloadEnabled) = 
-        { state with VirtualApplications =
-                        if state.VirtualApplications.IsEmpty
-                            then Map [ ("/", VirtualApplication.Create "site\\wwwroot" None ) ]
-                            else state.VirtualApplications
-                        |> Map.add physicalPath (VirtualApplication.Create ("site\\" + virtualPath) preloadEnabled) }
+        { state with
+            VirtualApplications =
+                if state.VirtualApplications.IsEmpty
+                    then Map [ ("/", VirtualApplication.Create "site\\wwwroot" None ) ]
+                    else state.VirtualApplications
+                |> Map.add physicalPath (VirtualApplication.Create ("site\\" + virtualPath) preloadEnabled) }
 
     /// Adds Virtual Application definition
     [<CustomOperation "add_virtual_application">] 

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -741,9 +741,6 @@ module WebApp =
     type VirtualApplication =
         { PhysicalPath: string 
           PreloadEnabled: bool option }
-        static member Create physicalPath preloadEnabled =
-            { PhysicalPath = physicalPath
-              PreloadEnabled = preloadEnabled }
     module Extensions =
         /// The Microsoft.AspNetCore.AzureAppServices logging extension.
         let Logging = ExtensionName "Microsoft.AspNetCore.AzureAppServices.SiteExtension"

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -723,6 +723,12 @@ module WebApp =
             { Name = name
               IpAddressCidr = cidr
               Action = action }
+    type VirtualApplication =
+        { PhysicalPath: string 
+          PreloadEnabled: bool option }
+        static member Create physicalPath preloadEnabled =
+            { PhysicalPath = physicalPath
+              PreloadEnabled = preloadEnabled }
     module Extensions =
         /// The Microsoft.AspNetCore.AzureAppServices logging extension.
         let Logging = ExtensionName "Microsoft.AspNetCore.AzureAppServices.SiteExtension"

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -868,32 +868,59 @@ let tests = testList "Web App Tests" [
         Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
     }
 
-
     test "Supports redefining root application directory" {
-        let resources = webApp { name "test"; add_virtual_application "/" "altdirectory" } |> getResources
-        let site = resources |> getResource<Web.Site> |> List.head
+        let wa = webApp {
+            name "test"
+            add_virtual_applications [
+                virtualApplication {
+                    virtual_path "/"
+                    physical_path "altdirectory" 
+                }
+            ]
+        }
 
-        let expectedVirtualApplications = Map [ "/", VirtualApplication.Create "site\\altdirectory" None ]
+        let site = wa |> getResources |> getResource<Web.Site> |> List.head
+
+        let expectedVirtualApplications = Map [ "/", { PhysicalPath = "site\\altdirectory"; PreloadEnabled = None } ]
         Expect.equal site.VirtualApplications expectedVirtualApplications "Should add virtual application definition for root"
     }
 
     test "Supports defining additional virtual applications without changing root" {
-        let resources = webApp { name "test"; add_virtual_application "/subapp" "wwwsubapp" } |> getResources
-        let site = resources |> getResource<Web.Site> |> List.head
+        let wa = webApp {
+            name "test"
+            add_virtual_applications [
+                virtualApplication {
+                    virtual_path "/subapp"
+                    physical_path "wwwsubapp"
+                }
+            ]
+        }
+
+        let site = wa |> getResources |> getResource<Web.Site> |> List.head
 
         let expectedVirtualApplications = Map [
-            ("/", VirtualApplication.Create "site\\wwwroot" None), 1u
-            ("/subapp", VirtualApplication.Create "site\\wwwsubapp" None), 1u
+            ("/", { PhysicalPath = "site\\wwwroot"; PreloadEnabled = None }), 1u
+            ("/subapp", { PhysicalPath = "site\\wwwsubapp"; PreloadEnabled = None }), 1u
         ]
         Expect.distribution (site.VirtualApplications |> Seq.map(fun it -> (it.Key, it.Value))) expectedVirtualApplications "Should add virtual application definition for /subapp, but keep the root app around"
     }
 
     test "Supports virtual applications with preload enabled" {
-        let resources = webApp { name "test"; add_virtual_application_preloaded "/subapp" "wwwroot\\subApp" } |> getResources
-        let site = resources |> getResource<Web.Site> |> List.head
+        let wa = webApp {
+            name "test"
+            add_virtual_applications [
+                virtualApplication {
+                    virtual_path "/subapp"
+                    physical_path "wwwroot\\subApp"
+                    preloaded
+                }
+            ]
+        }
+
+        let site = wa |> getResources |> getResource<Web.Site> |> List.head
         
         let expectedVirtualApplications = Map [
-            ("/subapp", VirtualApplication.Create "site\\wwwroot\\subApp" (Some true)), 1u
+            ("/subapp", { PhysicalPath = "site\\wwwroot\\subApp"; PreloadEnabled = (Some true) }), 1u
         ]
         Expect.distribution (site.VirtualApplications |> Seq.map(fun it -> (it.Key, it.Value))) expectedVirtualApplications "Should add preloaded virtual application definition"
     }


### PR DESCRIPTION
This PR closes #891

The changes in this PR are as follows:

* Adds support for Virtual Applications nested under a Web App

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let wa = webApp {
    name "my-two-in-one-app"

    // Adds a virtual application under the "api" sub-folder of the default app, checking the Preload option
    add_virtual_application_preloaded "/api" "wwwroot\\api"
}
```
