### PR TITLE
fix resource id for resource group config deployment

### DIFF
--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -48,7 +48,7 @@ type ResourceGroupConfig =
       | None -> 
         $"deployment-{deploymentIndex()}"
 
-    member this.ResourceId = {resourceGroupDeployment.resourceId (this.DeploymentName.GetValue this.GenerateDeploymentName) with ResourceGroup = this.TargetResourceGroup}
+    member this.ResourceId = {resourceGroupDeployment.resourceId (this.DeploymentName.GetValue this.GenerateDeploymentName) with ResourceGroup = this.TargetResourceGroup; Subscription = this.SubscriptionId |> Option.map string}
     member private this.ContentDeployment =
         if this.Parameters.IsEmpty && this.Outputs.IsEmpty && this.Resources.IsEmpty then
             None // this resource group has no content so there's nothing to deploy


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* If resourceGroupConfig includes a subscription, include the subscription in the builder.ResourceId function

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here: Fixes broken behavior.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
