### PR TITLE
VM linked to unmanaged vnet should  not depend on vnet

### DIFF
--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -90,7 +90,6 @@ type VmConfig =
               DataDisks = this.DataDisks
               Tags = this.Tags }
 
-            let vnetName = this.VNet.resourceId(this).Name
             let subnetName = this.Subnet.resourceId this
             let nsgId = this.NetworkSecurityGroup |> Option.map(fun nsg -> nsg.ResourceId)
 
@@ -102,7 +101,7 @@ type VmConfig =
                    PublicIpAddress =
                         this.PublicIp
                         |> Option.map (fun x -> x.toLinkedResource this) |} ]
-              VirtualNetwork = vnetName
+              VirtualNetwork = this.VNet.toLinkedResource this
               PrivateIpAllocation = this.PrivateIpAllocation
               NetworkSecurityGroup = nsgId
               Tags = this.Tags }
@@ -110,7 +109,7 @@ type VmConfig =
             // VNET
             match this.VNet with
             | DeployableResource this vnet ->
-                { Name = vnetName
+                { Name = this.VNet.resourceId(this).Name
                   Location = location
                   AddressSpacePrefixes = [ this.AddressPrefix ]
                   Subnets = [


### PR DESCRIPTION
This PR closes #823

The changes in this PR are as follows:

* VirtualMachines: fixes an issue where linking to unmanaged vnet generated a dependency on the vnet. 

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here: dependency bugfix only

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
vm {
    name "myvm"
    username "azureuser"
    link_to_unmanaged_vnet "myvnet"
    subnet_name "default"
}
```
