### PR TITLE
DiagnosticsSettings correctly works for SQL.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* DiagnosticSettings now supports resources that contain multiple segments e.g. SQL Databases.
 
 ## 1.6.31
 * WebApps: Fix flakey deployments of web apps with multiple custom domains.

--- a/src/Farmer/Arm/DiagnosticSetting.fs
+++ b/src/Farmer/Arm/DiagnosticSetting.fs
@@ -25,8 +25,16 @@ type DiagnosticSettings =
     interface IArmResource with
         member this.ResourceId = diagnosticSettingsType(this.MetricsSource.Type).resourceId this.Name
         member this.JsonModel =
+            let resourceName =
+                [
+                    this.MetricsSource.Name
+                    yield! this.MetricsSource.Segments
+                    ResourceName "Microsoft.Insights"
+                    this.Name
+                ]
+                |> List.reduce (/)
             {| diagnosticSettingsType(this.MetricsSource.Type)
-                .Create(this.MetricsSource.Name/"Microsoft.Insights"/this.Name,this.Location, this.Dependencies, this.Tags) with
+                .Create(resourceName, this.Location, this.Dependencies, this.Tags) with
                 properties =
                     {| LogAnalyticsDestinationType =
                         match this.Sinks.LogAnalyticsWorkspace with

--- a/src/Tests/DiagnosticSettings.fs
+++ b/src/Tests/DiagnosticSettings.fs
@@ -92,12 +92,25 @@ let tests = testList "Diagnostic Settings" [
                 name "myDiagnosticSetting"
                 metrics_source logicAppResource
                 capture_logs [ LogSetting.Create "WorkflowRuntime" ]
-            } |> ignore) (sprintf "Should have thrown an exception for not specifying at least on data sink")
+            } |> ignore) "Should have thrown an exception for not specifying at least on data sink"
     }
 
     test "Can't create test with retention period outside 1 and 365" {
         for days in [ 0<Days>; 366<Days> ] do
             Expect.throws (fun _ -> LogSetting.Create("", days) |> ignore) (sprintf "Should have thrown for %d" days)
             Expect.throws (fun _ -> MetricSetting.Create("", days) |> ignore) (sprintf "Should have thrown for %d" days)
+    }
+
+    ftest "Supports segmented names such as SQL databases" {
+        let config =
+            let storageAccount = storageAccount { name "foo" }
+            diagnosticSettings {
+                name "myDiagnosticSetting"
+                add_destination storageAccount
+                metrics_source (Arm.Sql.databases.resourceId(ResourceName "sqlserver", ResourceName "sqldatabase"))
+                capture_logs [ Logging.Sql.Servers.Databases.AutomaticTuning ]
+            }
+        let result = asAzureResource config
+        Expect.equal result.Name "sqlserver/sqldatabase/Microsoft.Insights/myDiagnosticSetting" "Incorrect Name"
     }
 ]


### PR DESCRIPTION
This PR closes #905 

The changes in this PR are as follows:

* Use all segments in the DiagnosticsSettings ARM writer to correctly calculate the name of the diagnostics settings instance.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
    let databaseServerDiagnostics = diagnosticSettings {
        name "my-diagnostics"
        add_destination myLogAnalyticsWorkspace
        metrics_source (Arm.Sql.databases.resourceId (myServer.Name.ResourceName, myDb.Name))
        capture_logs [
            Logging.Sql.Servers.Databases.AutomaticTuning
        ]
    }
```
