### PR TITLE
Add private DNS support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## vNext
+* DNS: Add support for private DNS zones and records
+
 ## 1.6.32
 
 * Updated documentation on main page from `Writer.quickDeploy` to `Writer.quickWrite`

--- a/docs/content/api-overview/resources/dns.md
+++ b/docs/content/api-overview/resources/dns.md
@@ -37,7 +37,6 @@ If you wish to create a *new* NS record set, you **must** give it a `name` field
 #### TODO
 The following items are currently unsupported:
 - CAA records
-- Private Zone (untested)
 - Virtual network support for Private Zones
 - Tags
 
@@ -56,6 +55,7 @@ Each Record type has its own custom builder. All builders share the following co
 | name | Sets the name of the record set (default to `@`). |
 | depends_on | Deploy this DNS record after another resource is successfully deployed. |
 | ttl | Sets the time-to-live of the record set. |
+| zone_type | When set to `Private` changes the resource type from `Microsoft.Network/dnsZone/x` to `Microsoft.Network/privateDnsZone/x`. (default to Public) |
 | link_to_dns_zone | Add the record to a DNS zone in the same deployment. |
 | link_to_unmanaged_dns_zone | Add the record to an existing DNS zone. |
 

--- a/src/Farmer/Arm/Dns.fs
+++ b/src/Farmer/Arm/Dns.fs
@@ -11,12 +11,22 @@ let cnameRecord = ResourceType ("Microsoft.Network/dnsZones/CNAME", "2018-05-01"
 let txtRecord = ResourceType ("Microsoft.Network/dnsZones/TXT", "2018-05-01")
 let mxRecord = ResourceType ("Microsoft.Network/dnsZones/MX", "2018-05-01")
 let nsRecord = ResourceType ("Microsoft.Network/dnsZones/NS", "2018-05-01")
-let soaRecord = ResourceType ("Microsoft.Network/dnszones/SOA", "2018-05-01")
+let soaRecord = ResourceType ("Microsoft.Network/dnsZones/SOA", "2018-05-01")
 let srvRecord = ResourceType ("Microsoft.Network/dnsZones/SRV", "2018-05-01")
 let ptrRecord = ResourceType ("Microsoft.Network/dnsZones/PTR", "2018-05-01")
 
+let privateZones = ResourceType ("Microsoft.Network/privateDnsZones", "2020-06-01")
+let privateARecord = ResourceType ("Microsoft.Network/privateDnsZones/A", "2020-06-01")
+let privateAaaaRecord = ResourceType ("Microsoft.Network/privateDnsZones/AAAA", "2020-06-01")
+let privateCnameRecord = ResourceType ("Microsoft.Network/privateDnsZones/CNAME", "2020-06-01")
+let privateTxtRecord = ResourceType ("Microsoft.Network/privateDnsZones/TXT", "2020-06-01")
+let privateMxRecord = ResourceType ("Microsoft.Network/privateDnsZones/MX", "2020-06-01")
+let privateSoaRecord = ResourceType ("Microsoft.Network/privateDnsZones/SOA", "2020-06-01")
+let privateSrvRecord = ResourceType ("Microsoft.Network/privateDnsZones/SRV", "2020-06-01")
+let privatePtrRecord = ResourceType ("Microsoft.Network/privateDnsZones/PTR", "2020-06-01")
+
 type DnsRecordType with
-    member this.ResourceType =
+    member private this.publicResourceType =
         match this with
         | CName _ -> cnameRecord
         | A _ -> aRecord
@@ -27,16 +37,39 @@ type DnsRecordType with
         | MX _ -> mxRecord
         | SRV _ -> srvRecord
         | SOA _ -> soaRecord
+    member private this.privateResourceType =
+        match this with
+        | CName _ -> privateCnameRecord
+        | A _ -> privateARecord
+        | AAAA _ -> privateAaaaRecord
+        | NS _ -> raiseFarmer "Private DNS zones do not support NS records"
+        | PTR _ -> privatePtrRecord
+        | TXT _ -> privateTxtRecord
+        | MX _ -> privateMxRecord
+        | SRV _ -> privateSrvRecord
+        | SOA _ -> privateSoaRecord
+    member this.ResourceType zoneType = 
+        match zoneType with 
+        | Public -> this.publicResourceType
+        | Private -> this.privateResourceType
 
 type DnsZone =
     { Name : ResourceName
       Dependencies : Set<ResourceId>
       Properties : {| ZoneType : string |} }
+    
+    member private this.zoneResource = 
+        match this.Properties.ZoneType with
+        | "Public" -> zones
+        | "Private" -> privateZones
+        | _ -> raiseFarmer "Invalid value for ZoneType"
 
     interface IArmResource with
-        member this.ResourceId = zones.resourceId this.Name
+        member this.ResourceId =
+            this.zoneResource.resourceId this.Name
+
         member this.JsonModel =
-            {| zones.Create(this.Name, Location.Global, this.Dependencies) with
+            {| this.zoneResource.Create(this.Name, Location.Global, this.Dependencies) with
                 properties = {| zoneType = this.Properties.ZoneType |}
             |}
 
@@ -51,11 +84,21 @@ module DnsRecords =
             .Map(fun r -> r + ".NSRecords")
             .WithOwner(sourceZoneResId)
 
+    let private ttlKey zoneType = match zoneType with | Public -> "TTL" | Private -> "ttl"
+    let private cnameRecordKey zoneType = match zoneType with | Public -> "CNAMERecord" | Private -> "cnameRecord"
+    let private mxRecordKey zoneType = match zoneType with | Public -> "MXRecords" | Private -> "mxRecords"
+    let private txtRecordKey zoneType = match zoneType with | Public -> "TXTRecords" | Private -> "txtRecords"
+    let private ptrRecordKey zoneType = match zoneType with | Public -> "PTRRecords" | Private -> "ptrRecords"
+    let private aRecordKey zoneType = match zoneType with | Public -> "ARecords" | Private -> "aRecords"
+    let private aaaRecordKey zoneType = match zoneType with | Public -> "AAAARecords" | Private -> "aaaaRecords"
+    let private srvRecordKey zoneType = match zoneType with | Public -> "SRVRecords" | Private -> "srvRecords"
+    let private soaRecordKey zoneType = match zoneType with | Public -> "SOARecord" | Private -> "soaRecord"
 
     type DnsRecord =
         { Name : ResourceName
           Dependencies : Set<ResourceId>
           Zone : LinkedResource
+          ZoneType: DnsZoneType
           Type : DnsRecordType
           TTL : int }
         /// Includes the DnsZone if deployed in the same template (Managed).
@@ -63,13 +106,15 @@ module DnsRecords =
             match this.Zone with
             | Managed id -> this.Dependencies |> Set.add id
             | Unmanaged _ -> this.Dependencies
+        member private this.RecordType = 
+            this.Type.ResourceType this.ZoneType
         interface IArmResource with
-            member this.ResourceId = this.Type.ResourceType.resourceId (this.Zone.Name, this.Name)
+            member this.ResourceId = this.RecordType.resourceId (this.Zone.Name, this.Name)
 
             member this.JsonModel =
-                {| this.Type.ResourceType.Create(this.Zone.Name/this.Name, dependsOn = this.dependsOn) with
+                {| this.RecordType.Create(this.Zone.Name/this.Name, dependsOn = this.dependsOn) with
                     properties = [
-                        "TTL", box this.TTL
+                        (ttlKey this.ZoneType), box this.TTL
 
                         match this.Type with
                         | A (Some targetResource, _)
@@ -80,14 +125,14 @@ module DnsRecords =
                             ()
 
                         match this.Type with
-                        | CName (_, Some cnameRecord) -> "CNAMERecord", box {| cname = cnameRecord |}
-                        | MX records -> "MXRecords", records |> List.map (fun mx -> {| preference = mx.Preference; exchange = mx.Exchange |}) |> box
+                        | CName (_, Some cnameRecord) -> (cnameRecordKey this.ZoneType), box {| cname = cnameRecord |}
+                        | MX records -> (mxRecordKey this.ZoneType), records |> List.map (fun mx -> {| preference = mx.Preference; exchange = mx.Exchange |}) |> box
                         | NS (NsRecords.Records records) -> "NSRecords", records |> List.map (fun ns -> {| nsdname = ns |}) |> box
                         | NS (NsRecords.SourceZone sourceZone) -> "NSRecords", (sourceZoneNSRecordReference sourceZone).Eval() |> box
-                        | TXT records -> "TXTRecords", records |> List.map (fun txt -> {| value = [ txt ] |}) |> box
-                        | PTR records -> "PTRRecords", records |> List.map (fun ptr -> {| ptrdname = ptr |}) |> box
-                        | A (_, records) -> "ARecords", records |> List.map (fun a -> {| ipv4Address = a |}) |> box
-                        | AAAA (_, records) -> "AAAARecords", records |> List.map (fun aaaa -> {| ipv6Address = aaaa |}) |> box
+                        | TXT records -> (txtRecordKey this.ZoneType), records |> List.map (fun txt -> {| value = [ txt ] |}) |> box
+                        | PTR records -> (ptrRecordKey this.ZoneType), records |> List.map (fun ptr -> {| ptrdname = ptr |}) |> box
+                        | A (_, records) -> (aRecordKey this.ZoneType), records |> List.map (fun a -> {| ipv4Address = a |}) |> box
+                        | AAAA (_, records) -> (aaaRecordKey this.ZoneType), records |> List.map (fun aaaa -> {| ipv6Address = aaaa |}) |> box
                         | SRV records ->
                             let records =
                                 records
@@ -96,7 +141,7 @@ module DnsRecords =
                                        weight = srv.Weight |> Option.toNullable
                                        port = srv.Port |> Option.toNullable
                                        target =  Option.toObj srv.Target |})
-                            "SRVRecords", box records
+                            (srvRecordKey this.ZoneType), box records
                         | SOA record ->
                             let record =
                                 {| host = Option.toObj record.Host
@@ -106,7 +151,7 @@ module DnsRecords =
                                    retryTime = record.RetryTime |> Option.toNullable
                                    expireTime = record.ExpireTime |> Option.toNullable
                                    minimumTTL = record.MinimumTTL |> Option.toNullable |}
-                            "SOARecord", box record
+                            (soaRecordKey this.ZoneType), box record
                         | CName (_, None) -> ()
                     ] |> Map
                 |}

--- a/src/Farmer/Builders/Builders.Dns.fs
+++ b/src/Farmer/Builders/Builders.Dns.fs
@@ -13,8 +13,9 @@ type DnsZoneRecordConfig =
       Dependencies : Set<ResourceId>
       Type : DnsRecordType
       TTL : int
-      Zone : LinkedResource option }
-    static member Create(name, ttl, zone, recordType, ?dependencies:Set<ResourceId>) =
+      Zone : LinkedResource option
+      DnsZoneType : DnsZoneType }
+    static member Create(name, ttl, zone, recordType, ?dependencies:Set<ResourceId>, ?zoneType) =
         { Name =
               if name = ResourceName.Empty then raiseFarmer "You must set a DNS zone name"
               name
@@ -24,12 +25,13 @@ type DnsZoneRecordConfig =
               | Some ttl -> ttl
               | None -> raiseFarmer "You must set a TTL"
           Zone = zone
+          DnsZoneType = zoneType |> Option.defaultValue Public
           Type = recordType }
     interface IBuilder with
         member this.ResourceId =
             match this.Zone with
             | Some zone ->
-                this.Type.ResourceType.resourceId (zone.Name, this.Name)
+                (this.Type.ResourceType this.DnsZoneType).resourceId (zone.Name, this.Name)
             | None -> raiseFarmer "DNS record must be linked to a zone to properly assign the resourceId."
         member this.BuildResources _ =
             match this.Zone with
@@ -38,19 +40,20 @@ type DnsZoneRecordConfig =
                     { DnsRecord.Name = this.Name
                       Dependencies = this.Dependencies
                       Zone = zone
+                      ZoneType = this.DnsZoneType
                       TTL = this.TTL
                       Type = this.Type }
                 ]
             | None -> raiseFarmer "DNS record must be linked to a zone."
 
-type CNameRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; CName : string option; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option }
-type ARecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv4Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option  }
-type AaaaRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv6Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option }
+type CNameRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; CName : string option; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option; ZoneType: DnsZoneType }
+type ARecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv4Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option; ZoneType: DnsZoneType  }
+type AaaaRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; Ipv6Addresses : string list; TTL: int option; Zone: LinkedResource option; TargetResource: ResourceId option; ZoneType: DnsZoneType }
 type NsRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; NsdNames : NsRecords; TTL: int option; Zone: LinkedResource option }
-type PtrRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; PtrdNames : string list; TTL: int option; Zone: LinkedResource option; }
-type TxtRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; TxtValues : string list; TTL: int option; Zone: LinkedResource option; }
-type MxRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; MxValues : {| Preference : int; Exchange : string |} list; TTL: int option; Zone: LinkedResource option; }
-type SrvRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; SrvValues : SrvRecord list; TTL: int option; Zone: LinkedResource option; }
+type PtrRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; PtrdNames : string list; TTL: int option; Zone: LinkedResource option; ZoneType: DnsZoneType }
+type TxtRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; TxtValues : string list; TTL: int option; Zone: LinkedResource option; ZoneType: DnsZoneType }
+type MxRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; MxValues : {| Preference : int; Exchange : string |} list; TTL: int option; Zone: LinkedResource option; ZoneType: DnsZoneType }
+type SrvRecordProperties =  { Name: ResourceName; Dependencies: Set<ResourceId>; SrvValues : SrvRecord list; TTL: int option; Zone: LinkedResource option; ZoneType: DnsZoneType }
 type SoaRecordProperties =
     { Name: ResourceName
       Dependencies: Set<ResourceId>
@@ -62,7 +65,8 @@ type SoaRecordProperties =
       ExpireTime : int64 option
       MinimumTTL : int64 option
       TTL: int option
-      Zone: LinkedResource option }
+      Zone: LinkedResource option
+      ZoneType: DnsZoneType }
 
 type DnsZone =
     static member getNameServers (resourceId:ResourceId) =
@@ -85,7 +89,11 @@ type DnsZoneConfig =
     member this.NameServers = DnsZone.getNameServers this.Name
 
     interface IBuilder with
-        member this.ResourceId = zones.resourceId this.Name
+        member this.ResourceId = 
+            match this.ZoneType with 
+            | Public -> zones.resourceId this.Name
+            | Private -> privateZones.resourceId this.Name
+
         member this.BuildResources _ = [
             { DnsZone.Name = this.Name
               Dependencies = this.Dependencies
@@ -94,14 +102,18 @@ type DnsZoneConfig =
             for record in this.Records do
                 { DnsRecord.Name = record.Name
                   Dependencies = record.Dependencies
-                  Zone = Managed (zones.resourceId this.Name)
+                  Zone = Managed (
+                    match this.ZoneType with 
+                    | Public -> zones.resourceId this.Name
+                    | Private -> privateZones.resourceId this.Name)
+                  ZoneType = this.ZoneType
                   TTL = record.TTL
                   Type = record.Type }
         ]
 
 type DnsCNameRecordBuilder() =
-    member _.Yield _ = { CNameRecordProperties.CName = None; Name = ResourceName.Empty; Dependencies = Set.empty; TTL = None; Zone = None; TargetResource = None }
-    member _.Run(state : CNameRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, CName(state.TargetResource, state.CName), state.Dependencies)
+    member _.Yield _ = { CNameRecordProperties.CName = None; Name = ResourceName.Empty; Dependencies = Set.empty; TTL = None; Zone = None; TargetResource = None; ZoneType = Public }
+    member _.Run(state : CNameRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, CName(state.TargetResource, state.CName), state.Dependencies, state.ZoneType)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -122,6 +134,10 @@ type DnsCNameRecordBuilder() =
     member _.RecordTargetResource(state:CNameRecordProperties, targetResource:IArmResource) = { state with TargetResource = Some targetResource.ResourceId }
     member _.RecordTargetResource(state:CNameRecordProperties, targetResource:IBuilder) = { state with TargetResource = Some targetResource.ResourceId }
 
+    /// Sets the zone_type of the record.
+    [<CustomOperation "zone_type">]
+    member _.RecordZoneType(state:CNameRecordProperties, zoneType) = { state with ZoneType = zoneType }
+
     /// Builds a record for an existing DNS zone that is not managed by this Farmer deployment.
     [<CustomOperation "link_to_unmanaged_dns_zone">]
     member _.LinkToUnmanagedDnsZone(state:CNameRecordProperties, zone:ResourceId) = { state with Zone = Some (Unmanaged zone) }
@@ -136,8 +152,8 @@ type DnsCNameRecordBuilder() =
     interface IDependable<CNameRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsARecordBuilder() =
-    member _.Yield _ = { ARecordProperties.Ipv4Addresses = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None; TargetResource = None }
-    member _.Run(state : ARecordProperties)  = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, A(state.TargetResource, state.Ipv4Addresses), state.Dependencies)
+    member _.Yield _ = { ARecordProperties.Ipv4Addresses = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None; TargetResource = None; ZoneType = Public }
+    member _.Run(state : ARecordProperties)  = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, A(state.TargetResource, state.Ipv4Addresses), state.Dependencies, state.ZoneType)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -168,12 +184,16 @@ type DnsARecordBuilder() =
     member _.LinkToDnsZone(state:ARecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
     member _.LinkToDnsZone(state:ARecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
 
+    /// Sets the zone_type of the record.
+    [<CustomOperation "zone_type">]
+    member _.RecordZoneType(state:ARecordProperties, zoneType) = { state with ZoneType = zoneType }
+
     /// Enable support for additional dependencies.
     interface IDependable<ARecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsAaaaRecordBuilder() =
-    member _.Yield _ = { AaaaRecordProperties.Ipv6Addresses = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None; TargetResource = None }
-    member _.Run(state : AaaaRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, AAAA(state.TargetResource, state.Ipv6Addresses), state.Dependencies)
+    member _.Yield _ = { AaaaRecordProperties.Ipv6Addresses = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None; TargetResource = None; ZoneType = Public }
+    member _.Run(state : AaaaRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, AAAA(state.TargetResource, state.Ipv6Addresses), state.Dependencies, state.ZoneType)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -203,6 +223,10 @@ type DnsAaaaRecordBuilder() =
     member _.LinkToDnsZone(state:AaaaRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
     member _.LinkToDnsZone(state:AaaaRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
     member _.LinkToDnsZone(state:AaaaRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Sets the zone_type of the record.
+    [<CustomOperation "zone_type">]
+    member _.RecordZoneType(state:AaaaRecordProperties, zoneType) = { state with ZoneType = zoneType }
 
     /// Enable support for additional dependencies.
     interface IDependable<AaaaRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
@@ -261,8 +285,8 @@ type DnsNsRecordBuilder() =
     interface IDependable<NsRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsPtrRecordBuilder() =
-    member _.Yield _ = { PtrRecordProperties.PtrdNames = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None }
-    member _.Run(state : PtrRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, PTR state.PtrdNames, state.Dependencies)
+    member _.Yield _ = { PtrRecordProperties.PtrdNames = []; Name = ResourceName "@"; Dependencies = Set.empty; TTL = None; Zone = None; ZoneType = Public }
+    member _.Run(state : PtrRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, PTR state.PtrdNames, state.Dependencies, state.ZoneType)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -287,12 +311,16 @@ type DnsPtrRecordBuilder() =
     member _.LinkToDnsZone(state:PtrRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
     member _.LinkToDnsZone(state:PtrRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
 
+    /// Sets the zone_type of the record.
+    [<CustomOperation "zone_type">]
+    member _.RecordZoneType(state:PtrRecordProperties, zoneType) = { state with ZoneType = zoneType }
+
     /// Enable support for additional dependencies.
     interface IDependable<PtrRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsTxtRecordBuilder() =
-    member _.Yield _ = { TxtRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; TxtValues = []; TTL = None; Zone = None; }
-    member _.Run(state : TxtRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, TXT state.TxtValues, state.Dependencies)
+    member _.Yield _ = { TxtRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; TxtValues = []; TTL = None; Zone = None; ZoneType = Public }
+    member _.Run(state : TxtRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, TXT state.TxtValues, state.Dependencies, state.ZoneType)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -317,12 +345,16 @@ type DnsTxtRecordBuilder() =
     member _.LinkToDnsZone(state:TxtRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
     member _.LinkToDnsZone(state:TxtRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
 
+    /// Sets the zone_type of the record.
+    [<CustomOperation "zone_type">]
+    member _.RecordZoneType(state:TxtRecordProperties, zoneType) = { state with ZoneType = zoneType }
+
     /// Enable support for additional dependencies.
     interface IDependable<TxtRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsMxRecordBuilder() =
-    member _.Yield _ = { MxRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; MxValues = []; TTL = None; Zone = None }
-    member _.Run(state : MxRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, MX state.MxValues, state.Dependencies)
+    member _.Yield _ = { MxRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; MxValues = []; TTL = None; Zone = None; ZoneType = Public }
+    member _.Run(state : MxRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, MX state.MxValues, state.Dependencies, state.ZoneType)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -349,12 +381,16 @@ type DnsMxRecordBuilder() =
     member _.LinkToDnsZone(state:MxRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
     member _.LinkToDnsZone(state:MxRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
 
+    /// Sets the zone_type of the record.
+    [<CustomOperation "zone_type">]
+    member _.RecordZoneType(state:MxRecordProperties, zoneType) = { state with ZoneType = zoneType }
+
     /// Enable support for additional dependencies.
     interface IDependable<MxRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
 type DnsSrvRecordBuilder() =
-    member _.Yield _ = { SrvRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; SrvValues = []; TTL = None; Zone = None; }
-    member _.Run(state : SrvRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, SRV state.SrvValues, state.Dependencies)
+    member _.Yield _ = { SrvRecordProperties.Name = ResourceName "@"; Dependencies = Set.empty; SrvValues = []; TTL = None; Zone = None; ZoneType = Public }
+    member _.Run(state : SrvRecordProperties) = DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, SRV state.SrvValues, state.Dependencies, state.ZoneType)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -380,6 +416,10 @@ type DnsSrvRecordBuilder() =
     member _.LinkToDnsZone(state:SrvRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
     member _.LinkToDnsZone(state:SrvRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
 
+    /// Sets the zone_type of the record.
+    [<CustomOperation "zone_type">]
+    member _.RecordZoneType(state:SrvRecordProperties, zoneType) = { state with ZoneType = zoneType }
+
     /// Enable support for additional dependencies.
     interface IDependable<SrvRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
 
@@ -395,7 +435,8 @@ type DnsSoaRecordBuilder() =
           ExpireTime = None
           MinimumTTL = None
           TTL = None
-          Zone = None }
+          Zone = None
+          ZoneType = Public }
 
     member _.Run(state : SoaRecordProperties) =
         let value =
@@ -406,7 +447,7 @@ type DnsSoaRecordBuilder() =
               RetryTime = state.RetryTime
               ExpireTime = state.ExpireTime
               MinimumTTL = state.MinimumTTL }
-        DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, SOA value, state.Dependencies)
+        DnsZoneRecordConfig.Create(state.Name, state.TTL, state.Zone, SOA value, state.Dependencies, state.ZoneType)
 
     /// Sets the name of the record set.
     [<CustomOperation "name">]
@@ -458,6 +499,10 @@ type DnsSoaRecordBuilder() =
     member _.LinkToDnsZone(state:SoaRecordProperties, zone:ResourceId) = { state with Zone = Some (Managed zone) }
     member _.LinkToDnsZone(state:SoaRecordProperties, zone:IArmResource) = { state with Zone = Some (Managed zone.ResourceId) }
     member _.LinkToDnsZone(state:SoaRecordProperties, zone:IBuilder) = { state with Zone = Some (Managed zone.ResourceId) }
+
+    /// Sets the zone_type of the record.
+    [<CustomOperation "zone_type">]
+    member _.RecordZoneType(state:SoaRecordProperties, zoneType) = { state with ZoneType = zoneType }
 
     /// Enable support for additional dependencies.
     interface IDependable<SoaRecordProperties> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.6.31</Version>
+    <Version>1.6.32</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Tests/Dns.fs
+++ b/src/Tests/Dns.fs
@@ -79,14 +79,17 @@ let tests = testList "DNS Zone" [
             |> Array.ofList
 
         Expect.equal dnsRecords.[1].Name "farmer.com/www" "DNS CNAME record name is wrong"
+        Expect.equal dnsRecords.[1].Type "Microsoft.Network/dnsZones/CNAME" "DNS record type is wrong"
         Expect.equal dnsRecords.[1].CnameRecord.Cname "farmer.com" "DNS CNAME record is wrong"
         Expect.equal dnsRecords.[1].TTL (Nullable 3600L) "DNS record TTL is wrong"
 
         Expect.equal dnsRecords.[2].Name "farmer.com/aName" "DNS A record name is wrong"
+        Expect.equal dnsRecords.[2].Type "Microsoft.Network/dnsZones/A" "DNS record type is wrong"
         Expect.sequenceEqual (dnsRecords.[2].ARecords |> Seq.map (fun x -> x.Ipv4Address)) [ "192.168.0.1" ] "DNS A record IP address is wrong"
         Expect.equal dnsRecords.[2].TTL (Nullable(7200L)) "DNS record TTL is wrong"
 
         Expect.equal dnsRecords.[3].Name "farmer.com/soaName" "DNS SOA record name is wrong"
+        Expect.equal dnsRecords.[3].Type "Microsoft.Network/dnsZones/SOA" "DNS record type is wrong"
         Expect.equal dnsRecords.[3].SoaRecord.Host "ns1-09.azure-dns.com." "DNS SOA record host wrong"
         Expect.equal dnsRecords.[3].SoaRecord.Email "azuredns-hostmaster.microsoft.com" "DNS SOA record email wrong"
         Expect.equal dnsRecords.[3].SoaRecord.SerialNumber (Nullable 1L) "DNS SOA record serial number wrong"
@@ -97,6 +100,7 @@ let tests = testList "DNS Zone" [
         Expect.equal dnsRecords.[3].TTL (Nullable 3600L) "DNS record TTL is wrong"
 
         Expect.equal dnsRecords.[4].Name "farmer.com/_sip._tcp.name" "DNS SRV record name is wrong"
+        Expect.equal dnsRecords.[4].Type "Microsoft.Network/dnsZones/SRV" "DNS record type is wrong"
         Expect.equal dnsRecords.[4].SrvRecords.[0].Priority (Nullable 100) "DNS SRV record priority wrong"
         Expect.equal dnsRecords.[4].SrvRecords.[0].Weight (Nullable 1) "DNS SRV record weight wrong"
         Expect.equal dnsRecords.[4].SrvRecords.[0].Port (Nullable 5061) "DNS SRV record port wrong"
@@ -104,6 +108,7 @@ let tests = testList "DNS Zone" [
         Expect.equal dnsRecords.[4].TTL (Nullable 3600L) "DNS record TTL is wrong"
 
         Expect.equal dnsRecords.[5].Name "farmer.com/txtName" "DNS TXT record name is wrong"
+        Expect.equal dnsRecords.[5].Type "Microsoft.Network/dnsZones/TXT" "DNS record type is wrong"
         Expect.sequenceEqual dnsRecords.[5].TxtRecords.[0].Value.[0] "somevalue" "DNS TXT record value is wrong"
         Expect.equal dnsRecords.[5].TTL (Nullable 3600L) "DNS record TTL is wrong"
     }
@@ -305,5 +310,248 @@ let tests = testList "DNS Zone" [
                 ]
             } |> ignore
         ) "Should fail when add_nsd_reference was already called"
+    }
+    test "Private DNS Zone is created with records" {
+        let resources =
+            arm {
+                add_resources [
+                    dnsZone {
+                        name "farmer.com"
+                        zone_type Private
+                        add_records [
+                            cnameRecord {
+                                name "www"
+                                ttl 3600
+                                cname "farmer.com"
+                            }
+                            aRecord {
+                                name "aName"
+                                ttl 7200
+                                add_ipv4_addresses [ "192.168.0.1" ]
+                            }
+                            aaaaRecord {
+                                name "aaaaName"
+                                ttl 7200
+                                add_ipv6_addresses [ "2001:0db8:85a3:0000:0000:8a2e:0370:7334" ]
+                            }
+                            ptrRecord {
+                                name "ptrName"
+                                ttl 3600
+                                add_ptrd_names [ "farmer.com" ]
+                            }
+                            txtRecord {
+                                name "txtName"
+                                ttl 3600
+                                add_values [
+                                    "somevalue"
+                                ]
+                            }
+                            mxRecord {
+                                name "mxName"
+                                ttl 7200
+                                add_values [
+                                    0, "farmer-com.mail.protection.outlook.com";
+                                    1, "farmer2-com.mail.protection.outlook.com";
+                                ]
+                            }
+                            srvRecord {
+                                name "_sip._tcp.name"
+                                ttl 3600
+                                add_values [
+                                    {   Priority = Some 100
+                                        Weight = Some 1
+                                        Port = Some 5061
+                                        Target = Some "farmer.online.com."}
+                                ]
+                            }
+                            soaRecord {
+                                name "soaName"
+                                host "azureprivatedns.net"
+                                ttl 3600
+                                email "azuredns-hostmaster.microsoft.com"
+                                serial_number 1L
+                                minimum_ttl 300L
+                                refresh_time 3600L
+                                retry_time 300L
+                                expire_time 2419200L
+                            }
+                        ]
+                    }
+                ]
+            }
+    
+        let dnsZones =
+            resources
+            |> findAzureResources<Zone> client.SerializationSettings
+            |> Array.ofList
+    
+        Expect.equal dnsZones.[0].Name "farmer.com" "DNS Zone name is wrong"
+        Expect.equal dnsZones.[0].Type "Microsoft.Network/privateDnsZones" "DNS Zone type is wrong"
+        Expect.equal dnsZones.[0].ZoneType (Nullable ZoneType.Private) "DNS Zone ZoneType is wrong"
+
+        let jsn = resources.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/www')].type").ToString()) "Microsoft.Network/privateDnsZones/CNAME" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/www')].dependsOn[0]").ToString()) "[resourceId('Microsoft.Network/privateDnsZones', 'farmer.com')]" "DNS dependsOn is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/www')].properties.cnameRecord.cname").ToString()) "farmer.com" "DNS CNAME record is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/www')].properties.ttl").ToString()) "3600" "DNS TTL is wrong"
+
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/aName')].type").ToString()) "Microsoft.Network/privateDnsZones/A" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/aName')].dependsOn[0]").ToString()) "[resourceId('Microsoft.Network/privateDnsZones', 'farmer.com')]" "DNS dependsOn is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/aName')].properties.aRecords[0].ipv4Address").ToString()) "192.168.0.1" "DNS A record is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/aName')].properties.ttl").ToString()) "7200" "DNS TTL is wrong"
+
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/aaaaName')].type").ToString()) "Microsoft.Network/privateDnsZones/AAAA" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/aaaaName')].dependsOn[0]").ToString()) "[resourceId('Microsoft.Network/privateDnsZones', 'farmer.com')]" "DNS dependsOn is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/aaaaName')].properties.aaaaRecords[0].ipv6Address").ToString()) "2001:0db8:85a3:0000:0000:8a2e:0370:7334" "DNS AAAA record is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/aaaaName')].properties.ttl").ToString()) "7200" "DNS TTL is wrong"
+
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/ptrName')].type").ToString()) "Microsoft.Network/privateDnsZones/PTR" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/ptrName')].dependsOn[0]").ToString()) "[resourceId('Microsoft.Network/privateDnsZones', 'farmer.com')]" "DNS dependsOn is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/ptrName')].properties.ptrRecords[0].ptrdname").ToString()) "farmer.com" "DNS PTR record is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/ptrName')].properties.ttl").ToString()) "3600" "DNS TTL is wrong"
+
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/txtName')].type").ToString()) "Microsoft.Network/privateDnsZones/TXT" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/txtName')].dependsOn[0]").ToString()) "[resourceId('Microsoft.Network/privateDnsZones', 'farmer.com')]" "DNS dependsOn is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/txtName')].properties.txtRecords[0].value[0]").ToString()) "somevalue" "DNS TXT record is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/txtName')].properties.ttl").ToString()) "3600" "DNS TTL is wrong"
+
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/mxName')].type").ToString()) "Microsoft.Network/privateDnsZones/MX" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/mxName')].dependsOn[0]").ToString()) "[resourceId('Microsoft.Network/privateDnsZones', 'farmer.com')]" "DNS dependsOn is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/mxName')].properties.mxRecords[0].exchange").ToString()) "farmer-com.mail.protection.outlook.com" "DNS MX record exchange is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/mxName')].properties.mxRecords[0].preference").ToString()) "0" "DNS MX record preference is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/mxName')].properties.mxRecords[1].exchange").ToString()) "farmer2-com.mail.protection.outlook.com" "DNS MX record exchange is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/mxName')].properties.mxRecords[1].preference").ToString()) "1" "DNS MX record preference is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/mxName')].properties.ttl").ToString()) "7200" "DNS TTL is wrong"
+
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/_sip._tcp.name')].type").ToString()) "Microsoft.Network/privateDnsZones/SRV" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/_sip._tcp.name')].dependsOn[0]").ToString()) "[resourceId('Microsoft.Network/privateDnsZones', 'farmer.com')]" "DNS dependsOn is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/_sip._tcp.name')].properties.srvRecords[0].port").ToString()) "5061" "DNS SRV record port is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/_sip._tcp.name')].properties.srvRecords[0].priority").ToString()) "100" "DNS SRV record priority is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/_sip._tcp.name')].properties.srvRecords[0].target").ToString()) "farmer.online.com." "DNS SRV record target is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/_sip._tcp.name')].properties.srvRecords[0].weight").ToString()) "1" "DNS SRV record weight is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/_sip._tcp.name')].properties.ttl").ToString()) "3600" "DNS TTL is wrong"
+
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].type").ToString()) "Microsoft.Network/privateDnsZones/SOA" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].dependsOn[0]").ToString()) "[resourceId('Microsoft.Network/privateDnsZones', 'farmer.com')]" "DNS dependsOn is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].properties.soaRecord.email").ToString()) "azuredns-hostmaster.microsoft.com" "DNS SOA record email is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].properties.soaRecord.expireTime").ToString()) "2419200" "DNS SOA record expireTime is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].properties.soaRecord.host").ToString()) "azureprivatedns.net" "DNS SOA record host is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].properties.soaRecord.minimumTTL").ToString()) "300" "DNS SOA record minimumTTL is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].properties.soaRecord.refreshTime").ToString()) "3600" "DNS SOA record refreshTime is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].properties.soaRecord.retryTime").ToString()) "300" "DNS SOA record retryTime is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].properties.soaRecord.serialNumber").ToString()) "1" "DNS SOA record serialNumber is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='farmer.com/soaName')].properties.ttl").ToString()) "3600" "DNS TTL is wrong"
+    }
+    test "Disallow adding private NS records" {
+        Expect.throws ( fun _ ->
+            arm {
+                add_resources [
+                    dnsZone {
+                        name "farmer.com"
+                        zone_type Private
+                        add_records [
+                            nsRecord {
+                                name "subdomain"
+                                ttl (int (TimeSpan.FromDays 2.).TotalSeconds)
+                                add_nsd_names [ "ns01.foo.bar " ]
+                            }
+                        ]
+                    }
+                ]
+            } |> ignore
+        ) "Should fail when adding NS record to private zone"
+    }
+    test "Can link dns record to unmanaged private DNS zone" {
+        let resources =
+            arm {
+                add_resources [
+                    cnameRecord {
+                        name "www"
+                        ttl 3600
+                        cname "farmer.com"
+                        zone_type Private
+                        link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
+                    }
+                    aRecord {
+                        name "aName"
+                        ttl 7200
+                        add_ipv4_addresses [ "192.168.0.1" ]
+                        zone_type Private
+                        link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
+                    }
+                    aaaaRecord {
+                        name "aaaaName"
+                        ttl 7200
+                        add_ipv6_addresses [ "2001:0db8:85a3:0000:0000:8a2e:0370:7334" ]
+                        zone_type Private
+                        link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
+                    }
+                    ptrRecord {
+                        name "ptrName"
+                        ttl 3600
+                        add_ptrd_names [ "farmer.com" ]
+                        zone_type Private
+                        link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
+                    }
+                    txtRecord {
+                        name "txtName"
+                        ttl 3600
+                        add_values [
+                            "somevalue"
+                        ]
+                        zone_type Private
+                        link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
+                    }
+                    mxRecord {
+                        name "mxName"
+                        ttl 7200
+                        add_values [
+                            0, "farmer-com.mail.protection.outlook.com";
+                            1, "farmer2-com.mail.protection.outlook.com";
+                        ]
+                        zone_type Private
+                        link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
+                    }
+                    srvRecord {
+                        name "_sip._tcp.name"
+                        ttl 3600
+                        add_values [
+                            {   Priority = Some 100
+                                Weight = Some 1
+                                Port = Some 5061
+                                Target = Some "farmer.online.com."}
+                        ]
+                        zone_type Private
+                        link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
+                    }
+                    soaRecord {
+                        name "soaName"
+                        host "azureprivatedns.net"
+                        ttl 3600
+                        email "azuredns-hostmaster.microsoft.com"
+                        serial_number 1L
+                        minimum_ttl 300L
+                        refresh_time 3600L
+                        retry_time 300L
+                        expire_time 2419200L
+                        zone_type Private
+                        link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
+                    }
+                ]
+            }
+            
+        let jsn = resources.Template |> Writer.toJson 
+        let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+        
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='private.farmer.com/www')].type").ToString()) "Microsoft.Network/privateDnsZones/CNAME" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='private.farmer.com/aName')].type").ToString()) "Microsoft.Network/privateDnsZones/A" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='private.farmer.com/aaaaName')].type").ToString()) "Microsoft.Network/privateDnsZones/AAAA" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='private.farmer.com/ptrName')].type").ToString()) "Microsoft.Network/privateDnsZones/PTR" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='private.farmer.com/txtName')].type").ToString()) "Microsoft.Network/privateDnsZones/TXT" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='private.farmer.com/mxName')].type").ToString()) "Microsoft.Network/privateDnsZones/MX" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='private.farmer.com/_sip._tcp.name')].type").ToString()) "Microsoft.Network/privateDnsZones/SRV" "DNS record type is wrong"
+        Expect.equal (jobj.SelectToken("resources[?(@.name=='private.farmer.com/soaName')].type").ToString()) "Microsoft.Network/privateDnsZones/SOA" "DNS record type is wrong"
     }
 ]


### PR DESCRIPTION
Add private dns support

This PR closes #907 

The changes in this PR are as follows:

* Adds support for private DNS zones and records

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
arm {
  add_resources [
    dnsZone {
      name "privatefarmer.com"
      zone_type Private
      add_records [
        cnameRecord {
          name "www"
          ttl 3600
          cname "farmer.com"
        }
        aRecord {
          name "aName"
          ttl 7200
          add_ipv4_addresses [ "192.168.0.1" ]
        }
      ]
    }
    
  // Unmanaged record
  cnameRecord {
      name "www"
      ttl 3600
      cname "farmer.com"
      zone_type Private
      link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
    }
    
  // Unmanaged record
  aRecord {
      name "aName"
      ttl 7200
      add_ipv4_addresses [ "192.168.0.1" ]
      zone_type Private
      link_to_unmanaged_dns_zone (Farmer.Arm.Dns.zones.resourceId "private.farmer.com")
    }
  ]
}
```
