### PR TITLE
Container Registry name validation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.6.33
+* Container Registry name validation
+
 ## 1.6.32
 * DiagnosticSettings now supports resources that contain multiple segments e.g. SQL Databases.
 * ContainerApps now use the updated resource name (Microsoft.App instead of Microsoft.Web).

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -43,7 +43,10 @@ type ContainerRegistryBuilder() =
 
     [<CustomOperation "name">]
     /// Sets the name of the Azure Container Registry instance.
-    member _.Name (state:ContainerRegistryConfig, name) = { state with Name = ResourceName name }
+    member _.Name (state:ContainerRegistryConfig, name:ResourceName) =
+        { state with Name = ContainerRegistryValidation.ContainerRegistryName.Create(name).OkValue.ResourceName }
+    member this.Name(state:ContainerRegistryConfig, name:string) = this.Name(state, ResourceName name)
+
 
     [<CustomOperation "sku">]
     /// Sets the name of the SKU/Tier for the Container Registry instance.

--- a/src/Farmer/Builders/Builders.ContainerRegistry.fs
+++ b/src/Farmer/Builders/Builders.ContainerRegistry.fs
@@ -43,18 +43,18 @@ type ContainerRegistryBuilder() =
 
     [<CustomOperation "name">]
     /// Sets the name of the Azure Container Registry instance.
-    member _.Name (state:ContainerRegistryConfig, name:ResourceName) =
+    member _.Name (state: ContainerRegistryConfig, name: ResourceName) =
         { state with Name = ContainerRegistryValidation.ContainerRegistryName.Create(name).OkValue.ResourceName }
-    member this.Name(state:ContainerRegistryConfig, name:string) = this.Name(state, ResourceName name)
+    member this.Name(state: ContainerRegistryConfig, name: string) = this.Name(state, ResourceName name)
 
 
     [<CustomOperation "sku">]
     /// Sets the name of the SKU/Tier for the Container Registry instance.
-    member _.Sku (state:ContainerRegistryConfig, sku) = { state with Sku = sku }
+    member _.Sku (state: ContainerRegistryConfig, sku) = { state with Sku = sku }
 
     [<CustomOperation "enable_admin_user">]
     /// Enables the admin user on the Azure Container Registry.
-    member _.EnableAdminUser (state:ContainerRegistryConfig) = { state with AdminUserEnabled = true }
+    member _.EnableAdminUser (state: ContainerRegistryConfig) = { state with AdminUserEnabled = true }
     interface ITaggable<ContainerRegistryConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
 let containerRegistry = ContainerRegistryBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -810,6 +810,20 @@ module ContainerRegistry =
         | Standard
         | Premium
 
+module ContainerRegistryValidation =
+    open Validation
+    type ContainerRegistryName =
+        private | ContainerRegistryName of ResourceName
+        static member Create name =
+            [ containsOnly lettersOrNumbers
+              nonEmptyLengthBetween 5 50              
+            ]
+            |> validate "Container Registry Name" name
+            |> Result.map (ResourceName >> ContainerRegistryName)
+
+        static member Create (ResourceName name) = ContainerRegistryName.Create name
+        member this.ResourceName = match this with ContainerRegistryName name -> name
+
 module Search =
     type HostingMode = Default | HighDensity
     /// The SKU of the search service you want to create. E.g. free or standard.

--- a/src/Tests/ContainerRegistry.fs
+++ b/src/Tests/ContainerRegistry.fs
@@ -77,7 +77,7 @@ let tests = testList "Container Registry" [
             "Non alphanumeric", "abcde!", "can only contain alphanumeric characters. The invalid value is 'abcde!'", "Value contains non-alphanumeric characters"
         ]
 
-        for testName, containerRegisterName, error, why in invalidNameCases ->
+        for testName, containerRegisterName, error, why in invalidNameCases do
             test testName {
                 Expect.equal (ContainerRegistryValidation.ContainerRegistryName.Create containerRegisterName) (Error ("Container Registry Name " + error)) why
             }
@@ -86,7 +86,8 @@ let tests = testList "Container Registry" [
             "Valid Name 1", "abcde", "Should have created a valid Container Registry name"
             "Valid Name 2", "abc123", "Should have created a valid Container Registry name"
         ]
-        for testName, containerRegisterName, why in validNameCases ->
+
+        for testName, containerRegisterName, why in validNameCases do
             test testName {
                 Expect.equal (ContainerRegistryValidation.ContainerRegistryName.Create(containerRegisterName).OkValue.ResourceName) (ResourceName containerRegisterName) why
             }


### PR DESCRIPTION
This PR closes #909 and #863 (duplicate)

The changes in this PR are as follows:
* add Container Registry name validation

Validation rules:
* Resource name may contain alphanumeric characters 
* Resource name must be between 5 and 50 characters