### PR TITLE
Container groups subnetIds, zone, and log analytics support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ Release Notes
 ## 1.6.33
 * Container Registry: Adds name validation
 * Container Groups: Deploy container groups to a specific zone.
+* Container Groups: Diagnostics support to send logs to a Log Analytics workspace.
 * DNS: Add support for private DNS zones and records
 * PostgreSQL: Added possibility to set vnet rules for PostgreSQL.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.6.33
 * Container Registry: Adds name validation
+* Container Groups: Deploy container groups to a specific zone.
 * DNS: Add support for private DNS zones and records
 * PostgreSQL: Added possibility to set vnet rules for PostgreSQL.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Release Notes
 * Container Registry: Adds name validation
 * Container Groups: Deploy container groups to a specific zone.
 * Container Groups: Diagnostics support to send logs to a Log Analytics workspace.
+* Container Groups: Support for attaching to subnets directly without requiring a network profile.
 * DNS: Add support for private DNS zones and records
 * PostgreSQL: Added possibility to set vnet rules for PostgreSQL.
 * WebApps: Support virtual applications with `add_virtual_application`/`add_virtual_application_preloaded`

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -31,6 +31,9 @@ The Container Group builder (`containerGroup`) defines a Container Group.
 | add_udp_port | Adds a UDP port to be externally accessible. |
 | add_volumes | Adds volumes to a container group so they are accessible to containers. |
 | availability_zone | Deploys a container group to a specific availability zone. |
+| diagnostics_workspace | Sends logs to a diagnostics workspace included in the same deployment. |
+| diagnostics_workspace_key | Sends logs to a diagnostics workspace by workspace ID and key. |
+| link_to_diagnostics_workspace | Sends logs to an existing diagnostics workspace referenced by resource ID. |
 | depends_on | Specifies the resource or resource ID of resources that must exist before the container group is created. |
 
 #### Container Instance Builder
@@ -141,9 +144,12 @@ let containerGroupUser = userAssignedIdentity {
     name "aciUser"
 }
 
+let containerGroupLoggingWorkspace = logAnalytics { name "webapplogs" }
+
 let group = containerGroup {
     name "webApp"
     operating_system Linux
+    diagnostics_workspace LogType.ContainerInstanceLogs containerGroupLoggingWorkspace
     restart_policy AlwaysRestart
     add_identity containerGroupUser
     add_udp_port 123us

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -30,6 +30,7 @@ The Container Group builder (`containerGroup`) defines a Container Group.
 | add_tcp_port | Adds a TCP port to be externally accessible. |
 | add_udp_port | Adds a UDP port to be externally accessible. |
 | add_volumes | Adds volumes to a container group so they are accessible to containers. |
+| availability_zone | Deploys a container group to a specific availability zone. |
 | depends_on | Specifies the resource or resource ID of resources that must exist before the container group is created. |
 
 #### Container Instance Builder

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -22,7 +22,10 @@ The Container Group builder (`containerGroup`) defines a Container Group.
 | restart_policy | Sets the restart policy (default Always) |
 | public_dns | Sets the DNS host label when using a public IP. |
 | private_ip | Indicates the container should use a system-assigned private IP address for use in a virtual network. |
-| network_profile | Name of a network profile resource for the subnet in a virtual network where the container group will attach. |
+| network_profile (deprecated) | Name of a network profile resource for the subnet in a virtual network where the container group will attach. |
+| vnet | Resource ID of a virtual network where the container group will attach. |
+| link_to_vnet | Resource ID of an existing virtual network where the container group will attach. |
+| subnet | Name of the subnet in a virtual network where the container group will attach. |
 | add_identity | Adds a managed identity to the the container group. |
 | system_identity | Activates the system identity of the container group. |
 | add_registry_credentials | Adds a container image registry credential with a secure parameter for the password. |

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -6,7 +6,7 @@ open Farmer.ContainerGroup
 open Farmer.Identity
 open System
 
-let containerGroups = ResourceType ("Microsoft.ContainerInstance/containerGroups", "2019-12-01")
+let containerGroups = ResourceType ("Microsoft.ContainerInstance/containerGroups", "2021-10-01")
 
 type ContainerGroupIpAddress =
     { Type : IpAddressType
@@ -58,6 +58,7 @@ type ContainerProbe =
 type ContainerGroup =
     { Name : ResourceName
       Location : Location
+      AvailabilityZone : string option
       ContainerInstances :
         {| Name : ResourceName
            Image : Containers.DockerImage
@@ -274,4 +275,5 @@ type ContainerGroup =
                                     |}
                           ]
                        |}
+                   zones = this.AvailabilityZone |> Option.map Array.singleton |> Option.defaultValue null
             |}

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1103,10 +1103,15 @@ type ImageRegistryCredential =
 
 [<RequireQualifiedAccess>]
 type ImageRegistryAuthentication =
-/// Credentials for the container registry are included with the password as a template parameter.
-| Credential of ImageRegistryCredential
-/// Credentials for the container registry will be listed by ARM expression.
-| ListCredentials of ResourceId
+    /// Credentials for the container registry are included with the password as a template parameter.
+    | Credential of ImageRegistryCredential
+    /// Credentials for the container registry will be listed by ARM expression.
+    | ListCredentials of ResourceId
+
+[<RequireQualifiedAccess>]
+type LogAnalyticsWorkspace =
+    | WorkspaceResourceId of LinkedResource
+    | WorkspaceKey of WorkspaceId:string * WorkspaceKey:string
 
 module ContainerGroup =
     type PortAccess = PublicPort | InternalPort
@@ -1115,6 +1120,9 @@ module ContainerGroup =
         | PublicAddress
         | PublicAddressWithDns of DnsName:string
         | PrivateAddress
+    type LogType =
+        | ContainerInstanceLogs
+        | ContainerInsights
     /// A secret file that will be attached to a container group.
     type SecretFile =
         /// A secret file which will be encoded as base64 data.

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -605,4 +605,26 @@ async {
         Expect.equal gpu.Sku "V100" "Wrong SKU"
         Expect.equal container.Image "myrepo/gpucontainers:latest" "Incorrect image tag"
     }
+
+    test "Container group created in a specific zone" {
+        let deployment =
+            arm {
+                add_resources [
+                    containerGroup {
+                        name "zonal-container-group"
+                        add_instances [
+                            containerInstance {
+                                name "httpserver"
+                                image "nginx"
+                            }
+                        ]
+                        availability_zone "2"
+                    }
+                ]
+            }
+        let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+        let zones = jobj.SelectToken "resources[?(@.name=='zonal-container-group')].zones"
+        Expect.hasLength zones 1 "Incorrect number of zones"
+        Expect.sequenceEqual zones [JValue "2"] "Incorrect value for zone"
+    }
 ]

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -424,7 +424,7 @@
       "type": "Microsoft.Cdn/profiles/endpoints"
     },
     {
-      "apiVersion": "2019-12-01",
+      "apiVersion": "2021-10-01",
       "dependsOn": [],
       "identity": {
         "type": "None"


### PR DESCRIPTION
The changes in this PR are as follows:

* Container Groups: Deploy container groups to a specific zone.
* Container Groups: Diagnostics support to send logs to a Log Analytics workspace.
* Container Groups: Support for attaching to subnets directly without requiring a network profile.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let containerGroupLoggingWorkspace = logAnalytics { name "webapplogs" }

containerGroup {
    name "zonal-container-group"
    diagnostics_workspace LogType.ContainerInstanceLogs containerGroupLoggingWorkspace
    add_instances [
        containerInstance {
            name "httpserver"
            image "nginx"
        }
    ]
    availability_zone "2"
```
