### PR TITLE
Container Group DNS configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 
 ## 1.6.33
+* Container Groups: Specify DNS nameservers and search domains.
 * Container Registry: Adds name validation
 * DNS: Add support for private DNS zones and records
 * PostgreSQL: Added possibility to set vnet rules for PostgreSQL.

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -30,6 +30,9 @@ The Container Group builder (`containerGroup`) defines a Container Group.
 | add_tcp_port | Adds a TCP port to be externally accessible. |
 | add_udp_port | Adds a UDP port to be externally accessible. |
 | add_volumes | Adds volumes to a container group so they are accessible to containers. |
+| dns_nameservers | Specify DNS nameservers for the containers in a vnet-attached container group. |
+| dns_options | Specify DNS options (e.g. 'ndots:2') for the containers in a vnet-attached container group. |
+| dns_search_domains | Specify DNS search domains for the containers in a vnet-attached container group. |
 | depends_on | Specifies the resource or resource ID of resources that must exist before the container group is created. |
 
 #### Container Instance Builder

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -605,4 +605,48 @@ async {
         Expect.equal gpu.Sku "V100" "Wrong SKU"
         Expect.equal container.Image "myrepo/gpucontainers:latest" "Incorrect image tag"
     }
+
+    test "Specify DNS nameservers and search domains" {
+        let deployment =
+            arm {
+                add_resources [
+                    vnet {
+                        name "mynetwork"
+                        add_address_spaces [
+                            "10.30.32.0/20"
+                        ]
+                        add_subnets [
+                            subnet {
+                                name "containers"
+                                prefix "10.30.41.0/24"
+                                add_delegations [ SubnetDelegationService.ContainerGroups ]
+                            }
+                        ]
+                    }
+                    networkProfile {
+                        name "netprofile"
+                        vnet "mynetwork"
+                        subnet "containers"
+                    }
+                    containerGroup {
+                        name "container-group-with-custom-dns"
+                        dns_nameservers [ "8.8.8.8"; "1.1.1.1" ]
+                        dns_search_domains [ "example.com"; "example.local" ]
+                        network_profile "netprofile"
+                        add_instances [
+                            containerInstance {
+                                name "httpserver"
+                                image "nginx"
+                            }
+                        ]
+                    }
+                ]
+            }
+        let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+        let dnsConfig = jobj.SelectToken "resources[?(@.name=='container-group-with-custom-dns')].properties.dnsConfig"
+        let nameservers = dnsConfig.SelectToken "nameServers"
+        let searchDomains = dnsConfig.SelectToken "searchDomains"
+        Expect.sequenceEqual nameservers [JValue "8.8.8.8"; JValue "1.1.1.1"] "Incorrect nameservers."
+        Expect.equal searchDomains (JValue "example.com example.local") "Incorrect search domains."
+    }
 ]

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -424,7 +424,7 @@
       "type": "Microsoft.Cdn/profiles/endpoints"
     },
     {
-      "apiVersion": "2019-12-01",
+      "apiVersion": "2021-03-01",
       "dependsOn": [],
       "identity": {
         "type": "None"


### PR DESCRIPTION
This PR closes #893 

The changes in this PR are as follows:

* Container Groups: Specify DNS nameservers and search domains.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
arm {
    add_resources [
        vnet {
            name "mynetwork"
            add_address_spaces [
                "10.30.32.0/20"
            ]
            add_subnets [
                subnet {
                    name "containers"
                    prefix "10.30.41.0/24"
                    add_delegations [ SubnetDelegationService.ContainerGroups ]
                }
            ]
        }
        networkProfile {
            name "netprofile"
            vnet "mynetwork"
            subnet "containers"
        }
        containerGroup {
            name "container-group-with-custom-dns"
            dns_nameservers [ "8.8.8.8"; "1.1.1.1" ]
            dns_search_domains [ "example.com"; "example.local" ]
            network_profile "netprofile"
            add_instances [
                containerInstance {
                    name "httpserver"
                    image "nginx"
                }
            ]
        }
    ]
}
```
