### PR TITLE
containerApp evn var collections

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 
 ## 1.7.1
+* Container Apps: Support for collections of env vars, fix ACR credentials linking 
 * Event Hub: Don't create the `$Default` consumer group explicitly. It will automatically be created by Azure when the resource is created.
 
 ## 1.7.0

--- a/docs/content/api-overview/resources/container-apps.md
+++ b/docs/content/api-overview/resources/container-apps.md
@@ -48,8 +48,11 @@ The Container Apps builder (`containerApp`) is used to define one or more contai
 | add_containers | Adds a list of containers to this container app. All containers in the app share resources and scaling. |
 | add_simple_container | Adds a single container that references a public docker image and version. |
 | add_secret_parameter | Adds an application secret to the entire container app. This is passed as a secure parameter to the template, and an environment variable is automatically created which references the secret. |
+| add_secret_parameters | Adds application secrets to the entire container app. This is passed as secure parameters to the template, and environment variables are automatically created which reference the secret. |
 | add_secret_expression | As per `add_secret_parameter`, but the value is sourced from an ARM expression instead of as a parameter. Useful for e.g. storage keys etc. |
+| add_secret_expressions | As per `add_secret_parameters`, but the values are sourced from an ARM expressions instead of as parameters. Useful for e.g. storage keys etc. |
 | add_env_variable | Adds a static, plain text environment variable. |
+| add_env_variables | Adds static, plain text environment variables. |
 
 ##### Scale Rules
 

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -34,7 +34,12 @@ type ContainerAppConfig =
       ImageRegistryCredentials : ImageRegistryAuthentication list
       Containers : ContainerConfig list
       Dependencies : Set<ResourceId> }
-
+    member this.ResourceId = containerApps.resourceId this.Name
+    member this.LatestRevisionFqdn =
+        ArmExpression
+            .reference(containerApps, this.ResourceId)
+            .Map(sprintf "%s.latestRevisionFqdn")
+            
 type ContainerEnvironmentConfig =
     { Name : ResourceName
       InternalLoadBalancerState : FeatureFlag

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -280,6 +280,11 @@ type ContainerAppBuilder () =
             EnvironmentVariables = state.EnvironmentVariables.Add (EnvVar.create key.Value key.Value)
         }
 
+    /// Adds an application secrets to the Azure Container App.
+    [<CustomOperation "add_secret_parameters">]
+    member __.AddSecretParameters (state:ContainerAppConfig, keys:#seq<_>) =
+        keys |> Seq.fold (fun s k -> __.AddSecretParameter(s,k)) state
+
     /// Adds an application secret to the Azure Container App.
     [<CustomOperation "add_secret_expression">]
     member _.AddSecretExpression (state:ContainerAppConfig, key, expression) =
@@ -293,12 +298,23 @@ type ContainerAppBuilder () =
                 | None -> state.Dependencies
         }
 
+    /// Adds an application secrets to the Azure Container App.
+    [<CustomOperation "add_secret_expressions">]
+    member __.AddSecretExpressions (state:ContainerAppConfig, xs: #seq<_>) =
+        xs |> Seq.fold (fun s (k,e) -> __.AddSecretExpression(s,k,e)) state
+
+
     /// Adds a public environment variable to the Azure Container App environment variables.
     [<CustomOperation "add_env_variable">]
     member _.AddEnvironmentVariable (state:ContainerAppConfig, name, value) =
         { state with
             EnvironmentVariables = state.EnvironmentVariables.Add (EnvVar.create name value)
         }
+
+    /// Adds a public environment variables to the Azure Container App environment variables.
+    [<CustomOperation "add_env_variables">]
+    member __.AddEnvironmentVariables (state:ContainerAppConfig, vars:#seq<_>) =
+        vars |> Seq.fold (fun s (k,v) -> __.AddEnvironmentVariable(s,k,v)) state
 
     [<CustomOperation "add_simple_container">]
     member this.AddSimpleContainer (state:ContainerAppConfig, dockerImage, dockerVersion) =


### PR DESCRIPTION
The changes in this PR are as follows:

* Adds support for passing a collection of env variables of a given type to `containerApp` 
Why is this useful? In the absence of broad support for `_.For` in this library this makes iterators possible and brings it to parity with some other CEs.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
                containerApp {
                    name "multienv"
                    add_simple_container "mcr.microsoft.com/dotnet/samples" "aspnetapp"
                    ingress_target_port 80us
                    ingress_transport Auto
                    add_http_scale_rule "http-scaler" { ConcurrentRequests = 10 }
                    add_cpu_scale_rule "cpu-scaler" { Utilisation = 50 }
                    add_secret_parameters ["servicebusconnectionkey"]
                    add_env_variables ["ServiceBusQueueName","wishrequests"]
                    add_secret_expressions ["containerlogs", containerLogs.PrimarySharedKey]
                }
```
