### PR TITLE
Put logic apps in alphabetical order in API overview list

### DIFF
--- a/docs/content/api-overview/resources/logic-apps.md
+++ b/docs/content/api-overview/resources/logic-apps.md
@@ -2,7 +2,7 @@
 title: "Logic Apps"
 date: 2022-04-27T00:55:30+02:00
 chapter: false
-weight: 4
+weight: 12
 ---
 
 #### Overview


### PR DESCRIPTION
This changes the `weight` of the logic app API doc so it should appear in alphabetical order.