### PR TITLE
fix missing PostDeployTasks for nested resources

### DIFF
--- a/src/Tests/ResourceGroup.fs
+++ b/src/Tests/ResourceGroup.fs
@@ -35,4 +35,18 @@ let tests = testList "Resource Group" [
             |> List.map (fun x -> x.ResourceId.Name.Value)
         Expect.equal nestedResources ["stg1";"stg2";"stg3"] "all three storage accounts should be nested"
     }
+    test "zip_deploy should be performed when declared in a nested resource" {
+        let webApp = webApp {
+            name "webapp"
+            zip_deploy "deploy"
+        }
+        
+        let oneNestedLevel = resourceGroup { add_resource webApp }
+        let twoNestedLevels = resourceGroup { add_resource oneNestedLevel }
+        let threeNestedLevels = arm { add_resource twoNestedLevels }
+        
+        Expect.isNonEmpty
+            (threeNestedLevels :> IDeploymentSource).Deployment.PostDeployTasks
+            "The zip_deploy should create a post deployment task"
+    }
 ]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Fix the fact that post deployment tasks are missing from the deployment when they are declared in some nesting level.
* The unit test demonstrates this issue, 

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
