### PR TITLE
Use vault-secrets from unmanaged resource groups

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.1
+* Deployments: Use vault-secrets from unmanaged resource groups
+
 ## 1.7.0
 * Azure CLI: Escape parameters passed to the az deployment command (breaking change). Any previously escaped parameters need to be unescaped before passing to the tryValidate, tryWhatIf, tryExecute, whatIf and execute functions.
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -58,6 +58,7 @@ type ResourceType with
       | [||] | [| _ |] -> ResourceId.create (this, name)
       | parts -> ResourceId.create (this, (ResourceName parts.[0]), (Array.map ResourceName parts.[1..]))
     member this.resourceId name = this.resourceId (ResourceName name)
+    member this.resourceId (name, groupName) = ResourceId.create(this, ResourceName name, group= groupName)
     member this.resourceId (firstSegment, [<ParamArray>] remainingSegments:ResourceName []) = ResourceId.create (this, firstSegment, remainingSegments)
 
 [<AutoOpen>]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Make creating a vault.resourceId a little bit easier:
    Instead of writing: (ResourceId.create(Arm.KeyVault.vaults, ResourceName "vault-name", group= "vault-rg"))
    we can write: vaults.resourceId("vault-name", "vault-rg")
* Add a sample for referencing existent vault secrets from farmer-unmanaged resource groups.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
