### PR TITLE
Add Connection Strings members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,4 @@ MigrationBackup/
 hugo.exe
 public
 docs/public
+/src/Tests/test-data/*jsonout/deployment.json

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,12 @@ Release Notes
 =============
 
 ## 1.7.1
+* App Insights: Add ConnectionString member.
+* Communication Services: **Breaking Changes**: Clean up and fix issues regarding naming and Location.
+* Communication Services: Add ConnectionString member.
 * Event Hub: Don't create the `$Default` consumer group explicitly. It will automatically be created by Azure when the resource is created.
+* SignalR: Add ConnectionString member.
+* SignalR: **Breaking Change**: Bug fix - Key now returns Key, not ConnectionString.
 
 ## 1.7.0
 * Azure CLI: Escape parameters passed to the az deployment command (breaking change). Any previously escaped parameters need to be unescaped before passing to the tryValidate, tryWhatIf, tryExecute, whatIf and execute functions.

--- a/docs/content/api-overview/resources/app-insights.md
+++ b/docs/content/api-overview/resources/app-insights.md
@@ -26,6 +26,7 @@ The App Insights builder is used to create Application Insights accounts. Use th
 | Member | Purpose |
 |-|-|
 | InstrumentationKey | Gets the ARM expression path to the instrumentation key of this App Insights instance. |
+| ConnectionString | Gets the ARM expression path to the connection string of this App Insights instance. |
 
 #### Example
 

--- a/docs/content/api-overview/resources/communication-services.md
+++ b/docs/content/api-overview/resources/communication-services.md
@@ -13,14 +13,15 @@ The Communication Services builder is used to create Azure Communication Service
 #### Builder Keywords
 | Keyword | Purpose |
 |-|-|
-| name | Sets the name of the Bing Search instance. |
+| name | Sets the name of the Communication Services instance. |
 | data_location | Sets the `dataLocation` property of the instance. Defaults to `United States` |
 
 #### Configuration Members
 
 | Member | Purpose |
 |-|-|
-| Key | Gets the ARM expression path to the Key of this Bing Search instance. |
+| Key | Gets the ARM expression path to the Key of this Communication Services instance. |
+| Key | Gets the ARM expression path to the Connection String of this Communication Services instance. |
 
 #### Example
 ```fsharp
@@ -28,7 +29,7 @@ open Farmer
 open Farmer.Builders
 
 let tags = [ "a", "1"; "b", "2" ]
-let cs = communicationServices {
+let cs = communicationService {
     name "test"
     add_tags tags
     data_location DataLocation.Australia

--- a/docs/content/api-overview/resources/signalr.md
+++ b/docs/content/api-overview/resources/signalr.md
@@ -23,7 +23,8 @@ The SignalR builder creates SignalR services.
 
 | Member | Purpose |
 |-|-|
-| Key | Returns an ARM expression to retrieve the primary connection string of the service. Useful for e.g. supplying the connection string to another resource e.g. KeyVault or an app setting in the App Service. |
+| Key | Returns an ARM expression to retrieve the primary Key of the service. Useful for e.g. supplying the connection string to another resource e.g. KeyVault or an app setting in the App Service. |
+| ConnectionString | Returns an ARM expression to retrieve the primary Connection String of the service. Useful for e.g. supplying the connection string to another resource e.g. KeyVault or an app setting in the App Service. |
 
 #### Example
 

--- a/src/Farmer/Arm/CommunicationServices.fs
+++ b/src/Farmer/Arm/CommunicationServices.fs
@@ -1,18 +1,17 @@
 [<AutoOpen>]
-module Farmer.Arm.CommunicationServices
+module Farmer.Arm.Communication
 
 open Farmer
 
-let resource = ResourceType ("Microsoft.Communication/communicationServices", "2020-08-20-preview")
+let communicationServices = ResourceType ("Microsoft.Communication/communicationServices", "2020-08-20-preview")
 
-type Resource =
+type CommunicationService =
     { Name: ResourceName
-      Location: Location
       DataLocation: DataLocation
       Tags: Map<string,string> }
     interface IArmResource with
-        member this.ResourceId = resource.resourceId this.Name
+        member this.ResourceId = communicationServices.resourceId this.Name
         member this.JsonModel =
-            {| resource.Create(this.Name, this.Location, tags = this.Tags) with
+            {| communicationServices.Create(this.Name, Location.Global, tags = this.Tags) with
                 properties = {| dataLocation = this.DataLocation.ArmValue |}
             |}

--- a/src/Farmer/Builders/Builders.AppInsights.fs
+++ b/src/Farmer/Builders/Builders.AppInsights.fs
@@ -7,13 +7,15 @@ open Farmer.Arm.LogAnalytics
 
 type AppInsights =
     static member getInstrumentationKey (resourceId:ResourceId) =
-        ArmExpression
-            .reference(resourceId)
-            .Map(fun r -> r + ".InstrumentationKey")
-            .WithOwner(resourceId)
+        ArmExpression.reference(resourceId).Map(fun r -> r + ".InstrumentationKey").WithOwner(resourceId)
     static member getInstrumentationKey (name:ResourceName, ?resourceGroup, ?resourceType) =
         let resourceType = resourceType |> Option.defaultValue components
         AppInsights.getInstrumentationKey(ResourceId.create (resourceType, name, ?group = resourceGroup))
+    static member getConnectionString (resourceId:ResourceId) =
+        ArmExpression.reference(resourceId).Map(fun r -> r + ".ConnectionString").WithOwner(resourceId)
+    static member getConnectionString (name:ResourceName, ?resourceGroup, ?resourceType) =
+        let resourceType = resourceType |> Option.defaultValue components
+        AppInsights.getConnectionString(ResourceId.create (resourceType, name, ?group = resourceGroup))
 
 type AppInsightsConfig =
     { Name : ResourceName
@@ -24,6 +26,7 @@ type AppInsightsConfig =
       Tags : Map<string,string> }
     /// Gets the ARM expression path to the instrumentation key of this App Insights instance.
     member this.InstrumentationKey = AppInsights.getInstrumentationKey(this.Name, resourceType = this.InstanceKind.ResourceType)
+    member this.ConnectionString = AppInsights.getConnectionString (this.Name, resourceType = this.InstanceKind.ResourceType)
     interface IBuilder with
         member this.ResourceId = components.resourceId this.Name
         member this.BuildResources location = [

--- a/src/Farmer/Builders/Builders.CommunicationServices.fs
+++ b/src/Farmer/Builders/Builders.CommunicationServices.fs
@@ -2,25 +2,30 @@
 module Farmer.Builders.CommunicationServices
 
 open Farmer
-open Farmer.Arm.CommunicationServices
+open Farmer.Arm.Communication
 
 type CommunicationServices =
-    /// Gets an ARM Expression key for any Bing Search instance.
+    /// Gets an ARM Expression key for any Communication Services instance.
     static member getKey (resourceId: ResourceId) =
-        ArmExpression.create($"listKeys({resourceId.ArmExpression.Value}, '{resource.ApiVersion}').key1", resourceId)
-    static member getKey (name: ResourceName) = CommunicationServices.getKey (resource.resourceId name)
+        ArmExpression.create($"listKeys({resourceId.ArmExpression.Value}, '{communicationServices.ApiVersion}').primaryKey", resourceId)
+    static member getKey (name: ResourceName) = CommunicationServices.getKey (communicationServices.resourceId name)
+
+    static member getConnectionString (resourceId: ResourceId) =
+        ArmExpression.create($"listKeys({resourceId.ArmExpression.Value}, '{communicationServices.ApiVersion}').primaryConnectionString", resourceId)
+    static member getConnectionString (name: ResourceName) = CommunicationServices.getConnectionString (communicationServices.resourceId name)
 
 type CommunicationServicesConfig =
     { Name: ResourceName
       Tags: Map<string,string>
       DataLocation: DataLocation }
-    /// Gets an ARM expression to the key of this Bing Search instance.
-    member this.Key = CommunicationServices.getKey (resource.resourceId this.Name)
+    /// Gets an ARM expression to the key of this Communication Services instance.
+    member this.Key = CommunicationServices.getKey (communicationServices.resourceId this.Name)
+    /// Gets an ARM expression to the connection string of this Communication Services instance.
+    member this.ConnectionString = CommunicationServices.getConnectionString (communicationServices.resourceId this.Name)
     interface IBuilder with
-        member this.ResourceId = resource.resourceId this.Name
-        member this.BuildResources location = [
-            { Name = this.Name
-              Location = location
+        member this.ResourceId = communicationServices.resourceId this.Name
+        member this.BuildResources _ = [
+            { CommunicationService.Name = this.Name
               Tags = this.Tags
               DataLocation = this.DataLocation }
         ]
@@ -34,7 +39,7 @@ type CommunicationServicesBuilder () =
     [<CustomOperation "name">]
     member _.Name (state: CommunicationServicesConfig, name) = { state with Name = ResourceName name }
     [<CustomOperation "data_location">]
-    member _.Sku (state: CommunicationServicesConfig, dataLocation) = { state with DataLocation = dataLocation }
+    member _.DataLocation (state: CommunicationServicesConfig, dataLocation) = { state with DataLocation = dataLocation }
     interface ITaggable<CommunicationServicesConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
 
-let communicationServices = CommunicationServicesBuilder()
+let communicationService = CommunicationServicesBuilder()

--- a/src/Farmer/Builders/Builders.SignalR.fs
+++ b/src/Farmer/Builders/Builders.SignalR.fs
@@ -15,6 +15,7 @@ type SignalRConfig =
       ServiceMode : ServiceMode
       Tags: Map<string,string> }
     member this.ResourceId = signalR.resourceId this.Name
+
     interface IBuilder with
         member this.ResourceId = this.ResourceId
         member this.BuildResources location = [
@@ -24,11 +25,13 @@ type SignalRConfig =
               Capacity = this.Capacity
               AllowedOrigins = this.AllowedOrigins
               ServiceMode = this.ServiceMode
-              Tags = this.Tags  }
+              Tags = this.Tags }
         ]
-    member this.Key =
-        let expr = $"listKeys(resourceId('Microsoft.SignalRService/SignalR', '{this.Name.Value}'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).primaryConnectionString"
+    member private this.GetKeyExpr field =  
+        let expr = $"listKeys(resourceId('Microsoft.SignalRService/SignalR', '{this.Name.Value}'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).{field}"
         ArmExpression.create(expr, this.ResourceId)
+    member this.Key = this.GetKeyExpr "primaryKey"
+    member this.ConnectionString = this.GetKeyExpr "primaryConnectionString"
 
 type SignalRBuilder() =
     member _.Yield _ =

--- a/src/Tests/CommunicationServices.fs
+++ b/src/Tests/CommunicationServices.fs
@@ -2,34 +2,32 @@ module CommunicationServices
 
 open Expecto
 open Farmer
-open Farmer.Builders
 open Farmer.Arm
+open Farmer.Builders
 
 let tests = testList "Communication Services" [
     test "Basic test" {
         let tags = [ "a", "1"; "b", "2" ]
-        let swa = communicationServices {
+        let swa = communicationService {
             name "test"
             add_tags tags
             data_location DataLocation.Australia
         }
         let baseArm = (swa :> IBuilder).BuildResources(Location.WestEurope).[0]
-        let bsArm = baseArm :?> CommunicationServices.Resource
+        let bsArm = baseArm :?> CommunicationService
         Expect.equal bsArm.Name (ResourceName "test") "Name"
-        Expect.equal bsArm.Location Location.WestEurope "Location"
         Expect.equal bsArm.DataLocation DataLocation.Australia "Data Location"
         Expect.equal bsArm.Tags (Map tags) "Tags"
     }
 
     test "Default options test" {
-        let swa = communicationServices {
+        let swa = communicationService {
             name "test"
         }
 
         let baseArm = (swa :> IBuilder).BuildResources(Location.WestEurope).[0]
-        let bsArm = baseArm :?> CommunicationServices.Resource
+        let bsArm = baseArm :?> CommunicationService
         Expect.equal bsArm.Name (ResourceName "test") "Name"
-        Expect.equal bsArm.Location Location.WestEurope "Location"
         Expect.equal bsArm.DataLocation DataLocation.UnitedStates "Data Location"
         Expect.isEmpty bsArm.Tags "Tags"
     }

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -2,13 +2,13 @@ module JsonRegression
 
 open Expecto
 open Farmer
-open Farmer.Builders
 open Farmer.Arm
+open Farmer.AzureFirewall
+open Farmer.Builders
 open Farmer.Network
-open System.IO
 open Farmer.ServiceBus
 open System
-open Farmer.AzureFirewall
+open System.IO
 
 let tests =
     testList "ARM Writer Regression Tests" [
@@ -79,7 +79,7 @@ let tests =
                 add_resources [cosmos; cosmosMongo; vm]
             }
 
-            let communicationServices = communicationServices {
+            let communicationServices = communicationService {
                 name "test"
                 add_tags [ "a", "b" ]
                 data_location DataLocation.Australia

--- a/src/Tests/SignalR.fs
+++ b/src/Tests/SignalR.fs
@@ -70,6 +70,7 @@ let tests = testList "SignalR" [
 
     test "Key is correctly emitted" {
         let mySignalR = signalR { name "my-signalr" }
-        Expect.equal "[listKeys(resourceId('Microsoft.SignalRService/SignalR', 'my-signalr'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).primaryConnectionString]" (mySignalR.Key.Eval()) "Key is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.SignalRService/SignalR', 'my-signalr'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).primaryKey]" (mySignalR.Key.Eval()) "Key is incorrect"
+        Expect.equal "[listKeys(resourceId('Microsoft.SignalRService/SignalR', 'my-signalr'), providers('Microsoft.SignalRService', 'SignalR').apiVersions[0]).primaryConnectionString]" (mySignalR.ConnectionString.Eval()) "Connection String is incorrect"
     }
 ]

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -486,7 +486,7 @@
     },
     {
       "apiVersion": "2020-08-20-preview",
-      "location": "northeurope",
+      "location": "global",
       "name": "test",
       "properties": {
         "dataLocation": "Australia"


### PR DESCRIPTION
The changes in this PR are as follows:

* Adds `ConnectionString` members for App Insights, SignalR and Communication Services
* Clean up Communication Services and fix a bug regarding Location.
* SignalR Key now actually returns the Key.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.