### PR TITLE
fix ContainerEnvironmentConfig ResourceId

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.2
+* Container Apps: Fix ResourceId
+
 ## 1.7.1
 * App Insights: Add ConnectionString member.
 * Communication Services: **Breaking Changes**: Clean up and fix issues regarding naming and Location.

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -48,7 +48,7 @@ type ContainerEnvironmentConfig =
       Dependencies: Set<ResourceId>
       Tags: Map<string,string> }
     interface IBuilder with
-        member this.ResourceId = containerApps.resourceId this.Name
+        member this.ResourceId = managedEnvironments.resourceId this.Name
         member this.BuildResources location = [
             let logAnalyticsResourceId = this.LogAnalytics.resourceId this
             { Name = this.Name


### PR DESCRIPTION
This PR closes ResourceId issue mentioned in #922

The changes in this PR are as follows:

* `ContainerEnvironmentConfig` to use managedEnvironments-based ResourceId.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here: 
seems pretty straight-forward.
