### PR TITLE
Adds WebServerFarms member to the SubnetDelegationService type

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## PR-933
+* Network: Added Microsoft.Web/serverFarms to the SubnetDelegationService as a new static member WebServerFarms
+
+
 ## 1.7.2
 * Container Apps: Fix ResourceId
 * Operations Management: Add basic support for Operations Management to configure & deploy Solutions.

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1654,6 +1654,8 @@ module Network =
         static member ServiceFabricMeshNetworks = SubnetDelegationService "Microsoft.ServiceFabricMesh/networks"
         /// Microsoft.Sql/managedInstances
         static member SqlManagedInstances = SubnetDelegationService "Microsoft.Sql/managedInstances"
+        /// Microsoft.Web/serverFarms
+        static member WebServerFarms = SubnetDelegationService "Microsoft.Web/serverFarms"
 
     type EndpointServiceType = EndpointServiceType of string
     with


### PR DESCRIPTION
The changes in this PR are as follows:

* Added `Microsoft.Web/serverFarms` to the `SubnetDelegationService` as a new static member `WebServerFarms`

Before the change adding a server farm delegation required a magic string usage:

```fsharp
add_delegations [SubnetDelegationService.SubnetDelegationService("Microsoft.Web/serverFarms")]
```

After the change it can be expressed with:
```fsharp
add_delegations [SubnetDelegationService.WebServerFarms]
```

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp

open Farmer
open Farmer.Builders

let virtualNetwork = vnet {
      name "my-vnet"
      build_address_spaces [
          addressSpace {
              space "10.0.0.0/8"
              subnets [
                  subnetSpec {
                      name "functions"
                      size 24
                      add_delegations [SubnetDelegationService.WebServerFarms]
                  }
              ]
          }
      ]
  }

  let functionsServicePlan = servicePlan {
      name "my-service-plan"
      sku Sku.S1
  }

  let functionsApp = functions {
      name "my-functions-app"
      depends_on virtualNetwork
      depends_on functionsServicePlan
      link_to_service_plan functionsServicePlan
      link_to_vnet (virtualNetwork, ResourceName "functions")
  }

  let deployment = arm {
      location Location.NorthEurope
      add_resources [virtualNetwork; functionsServicePlan; functionsApp]
  }
```
