### PR TITLE
ContainerApps support for storage

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.4
+* Container Apps: Support for mounted storage
+
 ## PR-938
 * Added Basic Types documentation and examples for  unmanaged resources.
 

--- a/docs/content/api-overview/resources/container-apps.md
+++ b/docs/content/api-overview/resources/container-apps.md
@@ -53,6 +53,7 @@ The Container Apps builder (`containerApp`) is used to define one or more contai
 | add_secret_expressions | As per `add_secret_parameters`, but the values are sourced from an ARM expressions instead of as parameters. Useful for e.g. storage keys etc. |
 | add_env_variable | Adds a static, plain text environment variable. |
 | add_env_variables | Adds static, plain text environment variables. |
+| add_volumes | Adds volumes to a container app so they are accessible to containers. |
 
 ##### Scale Rules
 
@@ -80,6 +81,7 @@ The Container builder (`container`) is used to define one or more containers for
 | private_docker_image | Sets a private container image. |
 | cpu_cores | Specifies the CPU cores allocated to the container (maximum 2.0). |
 | memory | Specifies the memory in gigabytes allocated to the container (maximum 4.0). |
+| add_volume_mount | Adds a volume mount on a container from a volume in the container app. |
 
 #### Example
 
@@ -87,6 +89,13 @@ The Container builder (`container`) is used to define one or more containers for
 open Farmer
 open Farmer.Builders
 open Farmer.Arm
+
+let storageName = $"{Guid.NewGuid().ToString().[0..5]}containerqueue"
+let myStorageAccount = storageAccount {
+    name storageName
+    add_queue queueName
+    add_file_share "certs"
+}
 
 containerEnvironment {
     name "my-container-app"
@@ -97,17 +106,21 @@ containerEnvironment {
             reference_registry_credentials [
                 ContainerRegistry.registries.resourceId "myazurecontainerregistry"
             ]
+            add_volumes [ Volume.emptyDir "empty-v"
+                          Volume.azureFile "certs-v" "certs" myStorageAccount.Name.ResourceName.Value StorageAccessMode.ReadOnly ]
             add_containers [
                 container {
                     name "myservice1"
                     public_docker_image containerRegistryDomain containerRegistry "myimage1" version
                     memory 0.2<Gb>
-                }
+                    add_volume_mounts [ "empty-v", "/tmp" ]
+               }
                 container {
                     name "myservice2"
                     public_docker_image containerRegistryDomain containerRegistry "myimage2" version
                     cpu_cores 0.5<VCores>
                     memory 1.0<Gb>
+                    add_volume_mounts [ "certs-v", "/certs" ]
                 }
             ]
             replicas 1 5

--- a/docs/content/api-overview/resources/container-apps.md
+++ b/docs/content/api-overview/resources/container-apps.md
@@ -107,7 +107,7 @@ containerEnvironment {
                 ContainerRegistry.registries.resourceId "myazurecontainerregistry"
             ]
             add_volumes [ Volume.emptyDir "empty-v"
-                          Volume.azureFile "certs-v" "certs" myStorageAccount.Name.ResourceName.Value StorageAccessMode.ReadOnly ]
+                          Volume.azureFile "certs-v" (ResourceName "certs") myStorageAccount.Name StorageAccessMode.ReadOnly ]
             add_containers [
                 container {
                     name "myservice1"

--- a/samples/scripts/container-app.fsx
+++ b/samples/scripts/container-app.fsx
@@ -28,11 +28,11 @@ let env =
             containerApp {
                 name "queuereaderapp"
                 add_volumes [ Volume.emptyDir "empty-v"
-                              Volume.azureFile "certs-v" "certs" myStorageAccount.Name.ResourceName.Value StorageAccessMode.ReadOnly ]
+                              Volume.azureFile "certs-v" (ResourceName "certs") myStorageAccount.Name StorageAccessMode.ReadOnly ]
                 add_containers [
                     container {
                         name "queuereaderapp"
-                        public_docker_image "mcr.microsoft.com/azuredocs/containerapps-queuereader" ""
+                        public_docker_image "mcr.microsoft.com/azuredocs/containerapps-queuereader" "latest"
                         cpu_cores 0.25<VCores>
                         memory 0.5<Gb>
                         ephemeral_storage 1.<Gb>

--- a/samples/scripts/container-app.fsx
+++ b/samples/scripts/container-app.fsx
@@ -1,4 +1,4 @@
-#r @"..\..\src\Farmer\bin\Debug\net5.0\Farmer.dll"
+#r @"../../src/Farmer/bin/Debug/netstandard2.0/Farmer.dll"
 
 open Farmer
 open Farmer.Builders
@@ -10,6 +10,7 @@ let storageName = $"{Guid.NewGuid().ToString().[0..5]}containerqueue"
 let myStorageAccount = storageAccount {
     name storageName
     add_queue queueName
+    add_file_share "certs"
 }
 
 let env =
@@ -26,18 +27,22 @@ let env =
             }
             containerApp {
                 name "queuereaderapp"
+                add_volumes [ Volume.emptyDir "empty-v"
+                              Volume.azureFile "certs-v" "certs" myStorageAccount.Name.ResourceName.Value StorageAccessMode.ReadOnly ]
                 add_containers [
                     container {
                         name "queuereaderapp"
                         public_docker_image "mcr.microsoft.com/azuredocs/containerapps-queuereader" ""
                         cpu_cores 0.25<VCores>
                         memory 0.5<Gb>
+                        ephemeral_storage 1.<Gb>
+                        add_volume_mounts [ "empty-v", "/tmp"
+                                            "certs-v", "/certs" ]
                     }
                 ]
                 replicas 1 10
                 add_env_variable "QueueName" queueName
                 add_secret_expression "queueconnectionstring" myStorageAccount.Key
-                add_queue_scale_rule "queue-scaler" myStorageAccount queueName 10
             }
         ]
     }

--- a/src/Farmer/Arm/ApplicationGateway.fs
+++ b/src/Farmer/Arm/ApplicationGateway.fs
@@ -21,13 +21,6 @@ let applicationGatewaySslProfiles = ResourceType ("Microsoft.Network/application
 let applicationGatewayTrustedRootCertificates = ResourceType ("Microsoft.Network/applicationGateways/trustedRootCertificates", "2020-11-01")
 let applicationGatewayUrlPathMaps = ResourceType ("Microsoft.Network/applicationGateways/urlPathMap", "2020-11-01")
 
-
-module private ResourceId =
-    let asId (resourceId: ResourceId) =
-        {| id = resourceId.Eval() |}
-
-let private curry a b = a,b
-
 type ApplicationGateway =
     { Name : ResourceName
       Location : Location
@@ -262,7 +255,7 @@ type ApplicationGateway =
                                     affinityCookieName = settings.AffinityCookieName |> Option.toObj
                                     authenticationCertificates =
                                         settings.AuthenticationCertificates
-                                        |> List.map (curry this.Name >> applicationGatewayAuthenticationCertificates.resourceId >> ResourceId.asId)
+                                        |> List.map (tuple this.Name >> applicationGatewayAuthenticationCertificates.resourceId >> ResourceId.AsIdObject)
                                     connectionDraining = settings.ConnectionDraining |> Option.map (fun drain ->
                                         {|
                                           drainTimeoutInSec = drain.DrainTimeoutInSeconds
@@ -274,13 +267,13 @@ type ApplicationGateway =
                                     path = settings.Path |> Option.toObj
                                     pickHostNameFromBackendAddress = settings.PickHostNameFromBackendAddress
                                     port = settings.Port
-                                    probe = settings.Probe |> Option.map (curry this.Name >> ApplicationGatewayProbes.resourceId >> ResourceId.asId) |> Option.defaultValue Unchecked.defaultof<_>
+                                    probe = settings.Probe |> Option.map (tuple this.Name >> ApplicationGatewayProbes.resourceId >> ResourceId.AsIdObject) |> Option.defaultValue Unchecked.defaultof<_>
                                     probeEnabled = settings.ProbeEnabled
                                     protocol = settings.Protocol.ArmValue
                                     requestTimeout = settings.RequestTimeoutInSeconds
                                     trustedRootCertificates =
                                         settings.TrustedRootCertificates
-                                        |> List.map (curry this.Name >> applicationGatewayTrustedRootCertificates.resourceId >> ResourceId.asId)
+                                        |> List.map (tuple this.Name >> applicationGatewayTrustedRootCertificates.resourceId >> ResourceId.AsIdObject)
                                 |}
                             |}
                         )
@@ -292,7 +285,7 @@ type ApplicationGateway =
                         )
                         enableFips = this.EnableFips |> Option.toNullable
                         enableHttp2 = this.EnableHttp2 |> Option.toNullable
-                        firewallPolicy = this.FirewallPolicy |> Option.map ResourceId.asId |> Option.defaultValue Unchecked.defaultof<_>
+                        firewallPolicy = this.FirewallPolicy |> Option.map ResourceId.AsIdObject |> Option.defaultValue Unchecked.defaultof<_>
                         frontendPorts = this.FrontendPorts |> List.map (fun frontend ->
                             {|
                                 name = frontend.Name.Value
@@ -304,7 +297,7 @@ type ApplicationGateway =
                             {|
                                 name = gwip.Name.Value
                                 properties =
-                                    {| subnet = gwip.Subnet |> Option.map ResourceId.asId |> Option.defaultValue Unchecked.defaultof<_> |}
+                                    {| subnet = gwip.Subnet |> Option.map ResourceId.AsIdObject |> Option.defaultValue Unchecked.defaultof<_> |}
                             |}
                         )
                         httpListeners = this.HttpListeners |> List.map (fun listener ->
@@ -318,14 +311,14 @@ type ApplicationGateway =
                                       statusCode = cfg.StatusCode.ArmValue
                                     |}
                                   )
-                                  firewallPolicy = listener.FirewallPolicy |> Option.map ResourceId.asId |> Option.defaultValue Unchecked.defaultof<_>
-                                  frontendIPConfiguration = (this.Name,listener.FrontendIpConfiguration) |> applicationGatewayFrontendIPConfigurations.resourceId |> ResourceId.asId
-                                  frontendPort = (this.Name,listener.FrontendPort) |> applicationGatewayFrontendPorts.resourceId |> ResourceId.asId
+                                  firewallPolicy = listener.FirewallPolicy |> Option.map ResourceId.AsIdObject |> Option.defaultValue Unchecked.defaultof<_>
+                                  frontendIPConfiguration = (this.Name,listener.FrontendIpConfiguration) |> applicationGatewayFrontendIPConfigurations.resourceId |> ResourceId.AsIdObject
+                                  frontendPort = (this.Name,listener.FrontendPort) |> applicationGatewayFrontendPorts.resourceId |> ResourceId.AsIdObject
                                   hostNames = listener.HostNames
                                   protocol = listener.Protocol.ArmValue
                                   requireServerNameIndication = listener.RequireServerNameIndication
-                                  sslCertificate = listener.SslCertificate |> Option.map (curry this.Name >> applicationGatewaySslCertificates.resourceId >> ResourceId.asId) |> Option.defaultValue Unchecked.defaultof<_>
-                                  sslProfile = listener.SslProfile |> Option.map (curry this.Name >> applicationGatewaySslProfiles.resourceId >> ResourceId.asId) |> Option.defaultValue Unchecked.defaultof<_>
+                                  sslCertificate = listener.SslCertificate |> Option.map (tuple this.Name >> applicationGatewaySslCertificates.resourceId >> ResourceId.AsIdObject) |> Option.defaultValue Unchecked.defaultof<_>
+                                  sslProfile = listener.SslProfile |> Option.map (tuple this.Name >> applicationGatewaySslProfiles.resourceId >> ResourceId.AsIdObject) |> Option.defaultValue Unchecked.defaultof<_>
                                 |}
                           |}
                         )
@@ -372,12 +365,12 @@ type ApplicationGateway =
                                     {|
                                         includePath = cfg.IncludePath
                                         includeQueryString = cfg.IncludeQueryString
-                                        pathRules = cfg.PathRules |> List.map (curry this.Name >> applicationGatewayPathRules.resourceId >> ResourceId.asId)
+                                        pathRules = cfg.PathRules |> List.map (tuple this.Name >> applicationGatewayPathRules.resourceId >> ResourceId.AsIdObject)
                                         redirectType = cfg.RedirectType.ArmValue
-                                        requestRoutingRules = cfg.RequestRoutingRules |> List.map (curry this.Name >> applicationGatewayRequestRoutingRules.resourceId >> ResourceId.asId)
-                                        targetListener = applicationGatewayHttpListeners.resourceId(this.Name,cfg.TargetListener) |> ResourceId.asId
+                                        requestRoutingRules = cfg.RequestRoutingRules |> List.map (tuple this.Name >> applicationGatewayRequestRoutingRules.resourceId >> ResourceId.AsIdObject)
+                                        targetListener = applicationGatewayHttpListeners.resourceId(this.Name,cfg.TargetListener) |> ResourceId.AsIdObject
                                         targetUrl = cfg.TargetUrl
-                                        urlPathMaps = cfg.UrlPathMaps |> List.map (curry this.Name >> applicationGatewayUrlPathMaps.resourceId >> ResourceId.asId)
+                                        urlPathMaps = cfg.UrlPathMaps |> List.map (tuple this.Name >> applicationGatewayUrlPathMaps.resourceId >> ResourceId.AsIdObject)
                                     |}
                             |}
                         )
@@ -386,14 +379,14 @@ type ApplicationGateway =
                                 name = routingRule.Name.Value
                                 properties =
                                     {|
-                                        backendAddressPool = applicationGatewayBackendAddressPools.resourceId(this.Name,routingRule.BackendAddressPool) |> ResourceId.asId
-                                        backendHttpSettings = applicationGatewayBackendHttpSettingsCollection.resourceId(this.Name,routingRule.BackendHttpSettings) |> ResourceId.asId
-                                        httpListener = applicationGatewayHttpListeners.resourceId(this.Name,routingRule.HttpListener) |> ResourceId.asId
+                                        backendAddressPool = applicationGatewayBackendAddressPools.resourceId(this.Name,routingRule.BackendAddressPool) |> ResourceId.AsIdObject
+                                        backendHttpSettings = applicationGatewayBackendHttpSettingsCollection.resourceId(this.Name,routingRule.BackendHttpSettings) |> ResourceId.AsIdObject
+                                        httpListener = applicationGatewayHttpListeners.resourceId(this.Name,routingRule.HttpListener) |> ResourceId.AsIdObject
                                         priority = routingRule.Priority |> Option.toNullable
-                                        redirectConfiguration =  routingRule.RedirectConfiguration |> Option.map (curry this.Name >> applicationGatewayRedirectConfigurations.resourceId >> ResourceId.asId) |> Option.defaultValue Unchecked.defaultof<_>
-                                        rewriteRuleSet = routingRule.RewriteRuleSet |> Option.map (curry this.Name >> applicationGatewayRewriteRuleSets.resourceId >> ResourceId.asId) |> Option.defaultValue Unchecked.defaultof<_>
+                                        redirectConfiguration =  routingRule.RedirectConfiguration |> Option.map (tuple this.Name >> applicationGatewayRedirectConfigurations.resourceId >> ResourceId.AsIdObject) |> Option.defaultValue Unchecked.defaultof<_>
+                                        rewriteRuleSet = routingRule.RewriteRuleSet |> Option.map (tuple this.Name >> applicationGatewayRewriteRuleSets.resourceId >> ResourceId.AsIdObject) |> Option.defaultValue Unchecked.defaultof<_>
                                         ruleType = routingRule.RuleType.ArmValue
-                                        urlPathMap = routingRule.UrlPathMap |> Option.map (curry this.Name >> applicationGatewayUrlPathMaps.resourceId >> ResourceId.asId) |> Option.defaultValue Unchecked.defaultof<_>
+                                        urlPathMap = routingRule.UrlPathMap |> Option.map (tuple this.Name >> applicationGatewayUrlPathMaps.resourceId >> ResourceId.AsIdObject) |> Option.defaultValue Unchecked.defaultof<_>
                                     |}
                             |}
                         )
@@ -473,7 +466,7 @@ type ApplicationGateway =
                                   ) |> Option.defaultValue Unchecked.defaultof<_>
                                   trustedClientCertificates =
                                     sslProfile.TrustedClientCertificates
-                                    |> List.map (curry this.Name >> applicationGatewayTrustedRootCertificates.resourceId >> ResourceId.asId)
+                                    |> List.map (tuple this.Name >> applicationGatewayTrustedRootCertificates.resourceId >> ResourceId.AsIdObject)
                                 |}
                             |}
                         )
@@ -495,20 +488,20 @@ type ApplicationGateway =
                                 name = pathMap.Name.Value
                                 properties =
                                     {|
-                                       defaultBackendAddressPool = applicationGatewayBackendAddressPools.resourceId(this.Name,pathMap.DefaultBackendAddressPool) |> ResourceId.asId
-                                       defaultBackendHttpSettings = applicationGatewayBackendHttpSettingsCollection.resourceId(this.Name,pathMap.DefaultBackendHttpSettings) |> ResourceId.asId
-                                       defaultRedirectConfiguration = applicationGatewayRedirectConfigurations.resourceId(this.Name,pathMap.DefaultRedirectConfiguration) |> ResourceId.asId
-                                       defaultRewriteRuleSet = applicationGatewayRewriteRuleSets.resourceId(this.Name,pathMap.DefaultRewriteRuleSet) |> ResourceId.asId
+                                       defaultBackendAddressPool = applicationGatewayBackendAddressPools.resourceId(this.Name,pathMap.DefaultBackendAddressPool) |> ResourceId.AsIdObject
+                                       defaultBackendHttpSettings = applicationGatewayBackendHttpSettingsCollection.resourceId(this.Name,pathMap.DefaultBackendHttpSettings) |> ResourceId.AsIdObject
+                                       defaultRedirectConfiguration = applicationGatewayRedirectConfigurations.resourceId(this.Name,pathMap.DefaultRedirectConfiguration) |> ResourceId.AsIdObject
+                                       defaultRewriteRuleSet = applicationGatewayRewriteRuleSets.resourceId(this.Name,pathMap.DefaultRewriteRuleSet) |> ResourceId.AsIdObject
                                        pathRules = pathMap.PathRules |> List.map (fun pathRule ->
                                           {|
                                               name = pathRule.Name.Value
                                               properties =
                                               {|
-                                                backendAddressPool = applicationGatewayBackendAddressPools.resourceId(this.Name,pathRule.BackendAddressPool) |> ResourceId.asId
-                                                backendHttpSettings = applicationGatewayBackendHttpSettingsCollection.resourceId(this.Name,pathRule.BackendHttpSettings) |> ResourceId.asId
-                                                firewallPolicy = pathRule.FirewallPolicy |> ResourceId.asId
-                                                redirectConfiguration = applicationGatewayRedirectConfigurations.resourceId(this.Name,pathRule.RedirectConfiguration) |> ResourceId.asId
-                                                rewriteRuleSet = applicationGatewayRewriteRuleSets.resourceId(this.Name,pathRule.RewriteRuleSet) |> ResourceId.asId
+                                                backendAddressPool = applicationGatewayBackendAddressPools.resourceId(this.Name,pathRule.BackendAddressPool) |> ResourceId.AsIdObject
+                                                backendHttpSettings = applicationGatewayBackendHttpSettingsCollection.resourceId(this.Name,pathRule.BackendHttpSettings) |> ResourceId.AsIdObject
+                                                firewallPolicy = pathRule.FirewallPolicy |> ResourceId.AsIdObject
+                                                redirectConfiguration = applicationGatewayRedirectConfigurations.resourceId(this.Name,pathRule.RedirectConfiguration) |> ResourceId.AsIdObject
+                                                rewriteRuleSet = applicationGatewayRewriteRuleSets.resourceId(this.Name,pathRule.RewriteRuleSet) |> ResourceId.AsIdObject
                                                 paths = pathRule.Paths
                                               |}
                                           |}

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -298,7 +298,7 @@ type ContainerAppBuilder () =
         let key = (ContainerAppSettingKey.Create key).OkValue
         { state with
             Secrets = state.Secrets.Add (key, ParameterSecret (SecureParameter key.Value))
-            EnvironmentVariables = state.EnvironmentVariables.Add (EnvVar.create key.Value key.Value)
+            EnvironmentVariables = state.EnvironmentVariables.Add (EnvVar.createSecure key.Value key.Value)
         }
 
     /// Adds an application secrets to the Azure Container App.

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -152,8 +152,8 @@ let private defaultResources = {| CPU = 0.25<VCores>; Memory = 0.5<Gb>; Ephemera
 module Volume =
     let emptyDir volumeName =
         volumeName, Volume.EmptyDirectory
-    let azureFile volumeName shareName (storageAccountName:string) accessMode =
-        volumeName, Volume.AzureFileShare (ResourceName shareName, Storage.StorageAccountName.Create(storageAccountName).OkValue, accessMode)
+    let azureFile volumeName (shareName:ResourceName) (storageAccount:Storage.StorageAccountName) accessMode =
+        volumeName, Volume.AzureFileShare (shareName, storageAccount, accessMode)
 
 type ContainerAppBuilder () =
     member _.Yield _ =

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -11,13 +11,16 @@ open Farmer.Identity
 type ContainerConfig =
     { ContainerName : string
       DockerImage : Containers.DockerImage option
-      Resources : {| CPU : float<VCores>; Memory : float<Gb> |} }
+      /// Volume mounts for the container
+      VolumeMounts : Map<string, string>
+      Resources : {| CPU : float<VCores>; Memory : float<Gb>; EphemeralStorage: float<Gb> option |} }
     member internal this.BuildContainer : Container =
         match this.DockerImage with
         | Some dockerImage ->
             { Name = this.ContainerName
               DockerImage = dockerImage
-              Resources = this.Resources }
+              Resources = this.Resources
+              VolumeMounts = this.VolumeMounts }
         | None -> raiseFarmer $"Container '{this.ContainerName}' requires a docker image."
 
 type ContainerAppConfig =
@@ -30,6 +33,7 @@ type ContainerAppConfig =
       DaprConfig : {| AppId : string |} option
       Secrets : Map<ContainerAppSettingKey, SecretValue>
       EnvironmentVariables : Map<string, EnvVar>
+      Volumes : Map<string, Volume>
       /// Credentials for image registries used by containers in this environment.
       ImageRegistryCredentials : ImageRegistryAuthentication list
       Containers : ContainerConfig list
@@ -51,12 +55,12 @@ type ContainerEnvironmentConfig =
         member this.ResourceId = managedEnvironments.resourceId this.Name
         member this.BuildResources location = [
             let logAnalyticsResourceId = this.LogAnalytics.resourceId this
-            { Name = this.Name
-              InternalLoadBalancerState = this.InternalLoadBalancerState
-              LogAnalytics = logAnalyticsResourceId
-              Location = location
-              Dependencies = this.Dependencies.Add logAnalyticsResourceId
-              Tags = this.Tags }
+            yield { Name = this.Name
+                    InternalLoadBalancerState = this.InternalLoadBalancerState
+                    LogAnalytics = logAnalyticsResourceId
+                    Location = location
+                    Dependencies = this.Dependencies.Add logAnalyticsResourceId
+                    Tags = this.Tags }
 
             match this.LogAnalytics with
             | DeployableResource this resourceId ->
@@ -69,10 +73,9 @@ type ContainerEnvironmentConfig =
                       Tags = Map.empty }
                     :> IBuilder
                 yield! workspaceConfig.BuildResources location
-            | _ ->
-                ()
+            | _ -> ()
 
-            for containerApp in this.ContainerApps do
+            for containerApp in this.ContainerApps ->
                 { Name = containerApp.Name
                   Environment = managedEnvironments.resourceId this.Name
                   ActiveRevisionsMode = containerApp.ActiveRevisionsMode
@@ -86,7 +89,12 @@ type ContainerEnvironmentConfig =
                   ImageRegistryCredentials = containerApp.ImageRegistryCredentials
                   Containers = containerApp.Containers |> List.map (fun c -> c.BuildContainer)
                   Location = location
+                  Volumes = containerApp.Volumes
                   Dependencies = containerApp.Dependencies }
+
+            for volume in this.ContainerApps
+                          |> Seq.collect (fun app -> app.Volumes |> Seq.choose (ManagedEnvironmentStorage.from (managedEnvironments.resourceId this.Name)))
+                          |> Seq.distinctBy (fun v -> v.Name) -> volume
         ]
 
 type ContainerEnvironmentBuilder() =
@@ -121,6 +129,7 @@ type ContainerEnvironmentBuilder() =
     [<CustomOperation "add_containers">]
     member _.AddContainerApps  (state:ContainerEnvironmentConfig, containerApps:ContainerAppConfig list) =
         { state with ContainerApps = containerApps @ state.ContainerApps }
+
     /// Support for adding tags to this Container App Environment.
     interface ITaggable<ContainerEnvironmentConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
     /// Support for adding dependencies to this Container App Environment.
@@ -138,7 +147,13 @@ let private supportedResourceCombinations =
         2.0<VCores>, 4.<Gb>
     ]
 
-let private defaultResources = {| CPU = 0.25<VCores>; Memory = 0.5<Gb> |}
+let private defaultResources = {| CPU = 0.25<VCores>; Memory = 0.5<Gb>; EphemeralStorage = None |}
+
+module Volume =
+    let emptyDir volumeName =
+        volumeName, Volume.EmptyDirectory
+    let azureFile volumeName shareName (storageAccountName:string) accessMode =
+        volumeName, Volume.AzureFileShare (ResourceName shareName, Storage.StorageAccountName.Create(storageAccountName).OkValue, accessMode)
 
 type ContainerAppBuilder () =
     member _.Yield _ =
@@ -150,6 +165,7 @@ type ContainerAppBuilder () =
           ScaleRules = Map.empty
           Secrets = Map.empty
           IngressMode = None
+          Volumes = Map.empty
           Identity = ManagedIdentity.Empty
           EnvironmentVariables = Map.empty
           DaprConfig = None
@@ -328,8 +344,16 @@ type ContainerAppBuilder () =
                 ContainerConfig.ContainerName = state.Name.Value
                 DockerImage = Some (Containers.PublicImage (dockerImage, Some dockerVersion))
                 Resources = defaultResources
+                VolumeMounts = Map.empty
             }
         this.AddContainers(state, [ container ])
+
+    /// Adds volumes to the container app so they can be mounted on containers.
+    [<CustomOperation "add_volumes">]
+    member _.AddVolumes(state:ContainerAppConfig, volumes) =
+        let newVolumes = volumes |> Map.ofSeq
+        let updatedVolumes = state.Volumes |> Map.fold (fun current key vol -> Map.add key vol current) newVolumes
+        { state with Volumes = updatedVolumes }
 
     /// Support for adding dependencies to this Container App.
     interface IDependable<ContainerAppConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
@@ -338,7 +362,8 @@ type ContainerBuilder () =
     member _.Yield _ =
         { ContainerName = ""
           DockerImage = None
-          Resources = defaultResources }
+          Resources = defaultResources
+          VolumeMounts = Map.empty }
     /// Set docker credentials
     [<CustomOperation "name">]
     member _.ContainerName (state:ContainerConfig, name) =
@@ -362,12 +387,22 @@ type ContainerBuilder () =
         let roundedCpuCount = System.Math.Round(numCores, 2) * 1.<VCores>
         { state with Resources = {| state.Resources with CPU = roundedCpuCount |} }
 
+    [<CustomOperation "ephemeral_storage">]
+    member _.EphemeralStorage (state:ContainerConfig, size:float<Gb>) =
+        let size = size / 1.<Gb>
+        let roundedSize = System.Math.Round(size, 2) * 1.<Gb>
+        { state with Resources = {| state.Resources with EphemeralStorage = Some roundedSize |} }
+
     [<CustomOperation "memory">]
     member _.Memory (state:ContainerConfig, memory:float<Gb>) =
         let memory = memory / 1.<Gb>
         if memory > 4. then raiseFarmer $"'{state.ContainerName}' exceeds maximum memory of 4.0 Gb for containers in containerApps."
         let roundedMemory = System.Math.Round(memory, 2) * 1.<Gb>
         { state with Resources = {| state.Resources with Memory = roundedMemory |} }
+
+    [<CustomOperation "add_volume_mounts">]
+    member _.AddVolumeMounts (state:ContainerConfig, mounts:#seq<_>) =
+        { state with VolumeMounts = mounts |> Seq.fold (fun s (volumeName, mountPath) -> s |> Map.add volumeName mountPath) state.VolumeMounts }
 
 let containerEnvironment = ContainerEnvironmentBuilder()
 let containerApp = ContainerAppBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1,4 +1,4 @@
-namespace Farmer
+﻿namespace Farmer
 
 open System
 
@@ -1117,6 +1117,7 @@ type LogAnalyticsWorkspace =
     | WorkspaceResourceId of LinkedResource
     | WorkspaceKey of WorkspaceId:string * WorkspaceKey:string
 
+
 module ContainerGroup =
     type PortAccess = PublicPort | InternalPort
     type RestartPolicy = NeverRestart | AlwaysRestart | RestartOnFailure
@@ -2206,6 +2207,16 @@ module ContainerApp =
     type Transport = HTTP1 | HTTP2 | Auto
     type IngressMode = External of port:uint16 * Transport option | InternalOnly
     type ActiveRevisionsMode = Single | Multiple
+    
+    type StorageAccessMode = ReadOnly | ReadWrite
+    with member this.ArmValue = this.ToString()
+
+    [<RequireQualifiedAccess>]
+    type Volume =
+        /// Mounts an empty directory on the container group.
+        | EmptyDirectory
+        /// Mounts an Azure File Share in the same resource group, performing a key lookup.
+        | AzureFileShare of ShareName:ResourceName * StorageAccountName:Storage.StorageAccountName * StorageAccessMode
 
 namespace Farmer.DiagnosticSettings
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -2,6 +2,11 @@ namespace Farmer
 
 open System
 
+/// Common generic functions to support internals
+[<AutoOpen>]
+module internal Functional =
+    let tuple a b = a,b
+
 /// Represents a name of an ARM resource
 type ResourceName =
     | ResourceName of string
@@ -147,6 +152,8 @@ type ResourceId with
     /// Evaluates the expression for emitting into an ARM template. That is, wraps it in [].
     member this.Eval() = this.ArmExpression.Eval()
     static member Eval (resourceId: ResourceId) = resourceId.ArmExpression.Eval()
+    static member internal AsIdObject (resourceId: ResourceId) =
+        {| id = resourceId.Eval() |}
 
 type ArmExpression with
     static member reference (resourceId:ResourceId) =

--- a/src/Tests/ContainerApps.fs
+++ b/src/Tests/ContainerApps.fs
@@ -68,7 +68,7 @@ let fullContainerAppDeployment =
                     active_revision_mode Single
                     reference_registry_credentials [(acr :> IBuilder).ResourceId]
                     add_volumes [ Volume.emptyDir "empty-v"
-                                  Volume.azureFile "certs-v" "certs" storage.Name.ResourceName.Value StorageAccessMode.ReadOnly ]
+                                  Volume.azureFile "certs-v" (ResourceName "certs") storage.Name StorageAccessMode.ReadOnly ]
                     add_containers [
                         container {
                             name "servicebus"


### PR DESCRIPTION
This PR adds support for [poorly documented storage mounting](https://github.com/Azure/azure-rest-api-specs/blob/a35c42d40e8a633a062e594d667f7e6da4c47faf/specification/app/resource-manager/Microsoft.App/stable/2022-03-01/CommonDefinitions.json#L489).

The changes in this PR are as follows:

* Adds DSL similar to ACI wrt storage/volume/mounts 
* Fixes my earlier AppGateway helper functions naming (contracted "curry tuple" to "tuple" instead of "curry")
* Switched the target ContainerApps API from -preview to stable
* Fixes param->secret->env bug

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.


```fsharp
            containerApp {
                name "queuereaderapp"
                add_volumes [ Volume.emptyDir "empty-v"
                              Volume.azureFile "certs-v" (ResourceName "certs") myStorageAccount.Name StorageAccessMode.ReadOnly ]
                add_containers [
                    container {
                        name "queuereaderapp"
                        public_docker_image "mcr.microsoft.com/azuredocs/containerapps-queuereader" ""
                        cpu_cores 0.25<VCores>
                        memory 0.5<Gb>
                        add_volume_mounts [ "empty-v", "/tmp"
                                            "certs-v", "/certs" ]
                    }
                ]
```

For Azure File volumes we create additional proxy resource [ManagedEnvironmentStorage](https://github.com/Azure/azure-rest-api-specs/blob/a35c42d40e8a633a062e594d667f7e6da4c47faf/specification/app/resource-manager/Microsoft.App/stable/2022-03-01/ManagedEnvironmentsStorages.json#L281) under the hood. 

Not clear on the purpose of `ephemeralStorage`, but it's in the ARM spec, so I've added it.

Current UI is useless at showing any of this.