### PR TITLE
#864 add overload for link_to_service_plan

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,9 @@
 Release Notes
 =============
 
-## PR-938
+## Next
 * Added Basic Types documentation and examples for  unmanaged resources.
+* Web App: add an overload for `link_to_service_plan` that accepts Web App
 
 ## 1.7.3
 * SQL Azure: Support for serverless

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -6,7 +6,7 @@ weight: 22
 ---
 
 #### Overview
-The Web App builder is used to create Azure App Service accounts. It abstracts the Service Plan into the same component, and will also create and configure a linked App Insights resource. If you wish to create a website that connects to an existing service plan, use the `link_to_service_plan` keyword and provide the resource name of the service plan to connect to.
+The Web App builder is used to create Azure App Service accounts. It abstracts the Service Plan into the same component, and will also create and configure a linked App Insights resource. If you wish to create a website that connects to an existing service plan or Web App, use the `link_to_service_plan` keyword and provide the resource name of the service plan or Web App to connect to.
 
 * Web Site (`Microsoft.Web/sites`)
 * Server Farms (`Microsoft.Web/serverfarms`)

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -853,6 +853,7 @@ module Extensions =
         /// A dependency will automatically be set for this instance.
         [<CustomOperation "link_to_service_plan">]
         member this.LinkToServicePlan (state:'T, name) = { this.Get state with ServicePlan = managed serverFarms name } |> this.Wrap state
+        member this.LinkToServicePlan (state:'T, servPlanApp:WebAppConfig) = { this.Get state with ServicePlan = managed serverFarms servPlanApp.ServicePlanName } |> this.Wrap state
         member this.LinkToServicePlan (state:'T, name:string) = this.LinkToServicePlan (state, ResourceName name)
         member this.LinkToServicePlan (state:'T, config:ServicePlanConfig) = this.LinkToServicePlan (state, config.Name)
         /// Instead of creating a new service plan instance, configure this webapp to point to another unmanaged service plan instance.

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -44,6 +44,13 @@ let tests = testList "Web App Tests" [
         Expect.isEmpty (resources |> getResource<Insights.Components>) "Should be no AI component"
         Expect.isEmpty (resources |> getResource<Web.ServerFarm>) "Should be no server farm"
     }
+    test "Web Apps link together" {
+        let first = webApp { name "first"; link_to_service_plan (servicePlan { name "firstSp" }) }
+        let second = webApp { name "test"; link_to_service_plan first } |> getResources
+        let wa = second |> getResource<Web.Site> |> List.head
+        Expect.containsAll wa.Dependencies [ ResourceId.create(serverFarms, ResourceName "firstSp") ] "Missing dependencies"
+        Expect.isEmpty (second |> getResource<Web.ServerFarm>) "Should be no server farm"
+    }
     test "Web App does not create dependencies for unmanaged linked resources" {
         let resources = webApp { name "test"; link_to_unmanaged_app_insights (components.resourceId "test"); link_to_unmanaged_service_plan (serverFarms.resourceId "test2") } |> getResources
         let wa = resources |> getResource<Web.Site> |> List.head


### PR DESCRIPTION
This PR closes #864 

The changes in this PR are as follows:

* add overload to pass webappconfig to `link_to_service_plan`,
* add unit test,
* adjust documentation for web app.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ X ] **Tested my code** end-to-end against a live Azure subscription.
* [ X ] **Updated the documentation** in the docs folder for the affected changes.
* [ X ] **Written unit tests** against the modified code that I have made.
* [ X ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ X ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
arm {
  location Location.NorthEurope
  add_resources [
    webApp { name "first"; link_to_service_plan (servicePlan { name "firstSp" }) }
    webApp { name "test"; link_to_service_plan first }
  ]
}
```
