### PR TITLE
Adds support for provisioning private link services

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.4
+* Private Link Services: Adds support for provisioning private link services
+
 ## 1.7.2
 * Container Apps: Fix ResourceId
 * Operations Management: Add basic support for Operations Management to configure & deploy Solutions.

--- a/docs/content/api-overview/resources/private-link-service.md
+++ b/docs/content/api-overview/resources/private-link-service.md
@@ -1,0 +1,113 @@
+---
+title: "Private Link Service"
+date: 2022-06-16T17:40:05-04:00
+chapter: false
+weight: 12
+---
+
+#### Overview
+The Private Link Service builder (`privateLink`) creates a private link service to access resources behind a load balancer privately from a private endpoint instead of traversing the internet.
+
+* Private Link Services (`Microsoft.Network/privateLinkServices`)
+
+#### Builder Keywords
+
+| Applies To | Keyword | Purpose |
+|-|-|-|
+| privateLink | name | Specifies the name of the private link service |
+| privateLink | depends_on | Specify any dependencies that must be deployed before this. |
+| privateLink | add_auto_approved_subscriptions | To auto-approve private endpoints, the subscription for those must be added here. |
+| privateLink | add_visible_to_subscriptions | To allow subscription to request access for their private endpoints, they must be added here. |
+| privateLink | add_load_balancer_frontend_ids | Adds the resource ID for the load balancer frontend IP configurations that are accessible through this private link service. |
+| privateLink | add_ip_configs | Adds the subnet where the private endpoints will connect to this service. |
+| privateLinkIpConfig | name | Optionally name the IP config |
+| privateLinkIpConfig | private_ip_allocation | Specifies static or dynamic allocation within the subnet - defaults to Dyanmic |
+| privateLinkIpConfig | private_ip_address_version | Specifies IPv4 or IPv6 - defaults to IPv4. |
+| privateLinkIpConfig | primary | Specify this is the primary IP config if connecting to multiple subnets - defaults to false |
+| privateLinkIpConfig | link_to_subnet | Required - the resource ID of the subnet where private link endpoints will be connected to this service. |
+
+#### Example
+
+```fsharp
+open Farmer
+open Farmer.Builders
+
+let vnet = vnet {
+    name "private-net"
+    add_address_spaces [
+        "10.100.0.0/16"
+    ]
+    add_subnets [
+        subnet {
+            name "default"
+            prefix "10.100.0.0/24"
+        }
+        subnet {
+            name "backend-services"
+            prefix "10.100.1.0/24"
+        }
+        subnet {
+            name "private-endpoints"
+            prefix "10.100.255.0/24"
+            private_link_service_network_policies Disabled
+        }
+    ]
+}
+let lb =
+    loadBalancer {
+        name "lb"
+        sku LoadBalancer.Sku.Standard
+        depends_on vnet
+        add_frontends [
+            frontend {
+                name "lb-frontend"
+                private_ip_allocation_method AllocationMethod.DynamicPrivateIp
+                link_to_subnet (ResourceId.create(Farmer.Arm.Network.subnets, vnet.Name, ResourceName "default"))
+            }
+        ]
+        add_backend_pools [
+            backendAddressPool {
+                name "lb-backend"
+            }
+        ]
+        add_probes [
+            loadBalancerProbe {
+                name "httpGet"
+                protocol Farmer.LoadBalancer.LoadBalancerProbeProtocol.HTTP
+                port 80
+                request_path "/"
+            }
+        ]
+        add_rules [
+            loadBalancingRule {
+                name "rule1"
+                frontend_ip_config "lb-frontend"
+                backend_address_pool "lb-backend"
+                frontend_port 80
+                backend_port 80
+                protocol TransmissionProtocol.TCP
+                probe "httpGet"
+            }
+        ]
+    }
+    privateLink {
+        name "pls"
+        depends_on lb
+        add_auto_approved_subscriptions [ System.Guid.NewGuid() ]
+        add_load_balancer_frontend_ids [
+            ResourceId.create(Farmer.Arm.LoadBalancer.loadBalancerFrontendIPConfigurations, lb.Name, ResourceName "lb-frontend")
+        ]
+        add_ip_configs [
+            privateLinkIpConfig {
+                link_to_subnet (ResourceId.create(Farmer.Arm.Network.subnets, vnet.Name, ResourceName "private-endpoints"))
+            }
+        ]
+    }
+arm {
+    add_resources [
+        vnet
+        lb
+        pls
+    ]
+}
+```

--- a/src/Farmer/Arm/LoadBalancer.fs
+++ b/src/Farmer/Arm/LoadBalancer.fs
@@ -15,7 +15,8 @@ type LoadBalancer =
       FrontendIpConfigs :
           {|  Name : ResourceName
               PrivateIpAllocationMethod : PrivateIpAddress.AllocationMethod
-              PublicIp : ResourceId option |} list
+              PublicIp : ResourceId option
+              Subnet : ResourceId option |} list
       BackendAddressPools : ResourceName list
       LoadBalancingRules :
           {|  /// Name of the load balancing rule
@@ -69,6 +70,8 @@ type LoadBalancer =
                                        privateIPAddress = ip
                                        publicIPAddress =
                                            frontend.PublicIp |> Option.map (fun pip -> {| id = pip.Eval() |} )
+                                           |> Option.defaultValue Unchecked.defaultof<_>
+                                       subnet = frontend.Subnet |> Option.map (fun subnetId -> {| id = subnetId.Eval() |} )
                                            |> Option.defaultValue Unchecked.defaultof<_>
                                    |}
                             |}

--- a/src/Farmer/Arm/PrivateLinkService.fs
+++ b/src/Farmer/Arm/PrivateLinkService.fs
@@ -1,0 +1,64 @@
+module Farmer.Arm.PrivateLink
+
+open System
+open System.Net.Sockets
+open Farmer
+
+let privateLinkServices = ResourceType ("Microsoft.Network/privateLinkServices", "2021-08-01")
+
+type PrivateLinkService =
+  { Name: ResourceName
+    Location: Location
+    Dependencies : ResourceId Set
+    AutoApprovedSubscriptions : Guid list
+    EnableProxyProtocol : bool
+    LoadBalancerFrontendIpConfigIds: ResourceId list
+    IpConfigs : {| Name : ResourceName
+                   PrivateIpAllocationMethod : AllocationMethod
+                   PrivateIpAddressVersion: AddressFamily
+                   Primary : bool
+                   SubnetId : ResourceId |} list
+    VisibleToSubscriptions : Guid list
+    Tags: Map<string,string> }
+  interface IArmResource with
+    member this.ResourceId = privateLinkServices.resourceId this.Name
+    member this.JsonModel =
+      {| privateLinkServices.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
+          properties =
+             {| autoApproval =
+                    match this.AutoApprovedSubscriptions with
+                    | [] -> Unchecked.defaultof<_>
+                    | approvedSubscriptions -> {| subscriptions = approvedSubscriptions |}
+                enableProxyProtocol = this.EnableProxyProtocol
+                loadBalancerFrontendIpConfigurations =
+                    this.LoadBalancerFrontendIpConfigIds |> List.map (fun frontend -> {| id = frontend.Eval() |})
+                ipConfigurations =
+                    this.IpConfigs
+                    |> List.map (fun ipconfig ->
+                        {| name = ipconfig.Name.Value
+                           properties =
+                              {| primary = ipconfig.Primary
+                                 privateIPAllocationMethod =
+                                  match ipconfig.PrivateIpAllocationMethod with
+                                  | DynamicPrivateIp -> "Dynamic"
+                                  | StaticPrivateIp _ -> "Static"
+                                 privateIPAddress = 
+                                  match ipconfig.PrivateIpAllocationMethod with
+                                  | DynamicPrivateIp -> null
+                                  | StaticPrivateIp ip -> string ip
+                                 privateIPAddressVersion =
+                                  match ipconfig.PrivateIpAddressVersion with
+                                  | AddressFamily.InterNetwork -> "IPv4"
+                                  | AddressFamily.InterNetworkV6 -> "IPv6"
+                                  | _ -> raiseFarmer "Unsupported PrivateIpAddressVersion - should be InterNetwork (IPv4) or InterNetworkV6 (IPv6)."
+                                 subnet = {| id = ipconfig.SubnetId.Eval() |}
+                              |}
+                        |}
+                    )
+                visibility =
+                    match this.AutoApprovedSubscriptions @ this.VisibleToSubscriptions |> List.distinct with
+                    | [] -> Unchecked.defaultof<_>
+                    | visibleTo -> {| subscriptions = visibleTo |}
+             |}
+      |}
+

--- a/src/Farmer/Builders/Builders.PrivateLink.fs
+++ b/src/Farmer/Builders/Builders.PrivateLink.fs
@@ -1,0 +1,113 @@
+[<AutoOpen>]
+module Farmer.Builders.PrivateLink
+
+open Farmer
+open Farmer.Arm.PrivateLink
+open System
+open System.Net.Sockets
+open Farmer.Builders
+
+type PrivateLinkServiceIpConfig =
+    {
+        Name : ResourceName
+        PrivateIpAllocationMethod : AllocationMethod
+        PrivateIpAddressVersion: AddressFamily
+        Primary : bool
+        SubnetId : ResourceId option
+    }
+    static member internal BuildResource (ipConfig:PrivateLinkServiceIpConfig) =
+        match ipConfig.SubnetId with
+        | None -> raiseFarmer "Private link service IP config requires a subnet"
+        | Some subnetId when subnetId.Type <> Farmer.Arm.Network.subnets ->
+            raiseFarmer "Private link service IP config subnet resource ID must be a subnet resource Id"
+        | Some subnetId ->
+            {| Name = ipConfig.Name.IfEmpty $"{subnetId.Name.Value}-{subnetId.Segments.Head.Value}"
+               Primary = ipConfig.Primary
+               PrivateIpAllocationMethod = ipConfig.PrivateIpAllocationMethod
+               PrivateIpAddressVersion = ipConfig.PrivateIpAddressVersion
+               SubnetId = subnetId
+            |}
+
+type PrivateLinkServiceIpConfigBuilder() =
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            PrivateIpAllocationMethod = AllocationMethod.DynamicPrivateIp
+            PrivateIpAddressVersion = AddressFamily.InterNetwork
+            Primary = false
+            SubnetId = None
+        }
+    [<CustomOperation "name">]
+    member _.Name(state:PrivateLinkServiceIpConfig, name) = { state with Name = ResourceName name }
+    [<CustomOperation "private_ip_allocation">]
+    member _.PrivateIpAllocation(state: PrivateLinkServiceIpConfig, allocationMethod: AllocationMethod) = { state with PrivateIpAllocationMethod = allocationMethod }
+    [<CustomOperation "private_ip_address_version">]
+    member _.PrivateIpAddressVersion(state: PrivateLinkServiceIpConfig, addressFamily: AddressFamily) = { state with PrivateIpAddressVersion = addressFamily }
+    [<CustomOperation "primary">]
+    member _.Primary(state: PrivateLinkServiceIpConfig, primary: bool) = { state with Primary = primary }
+    [<CustomOperation "link_to_subnet">]
+    member _.SubnetId(state: PrivateLinkServiceIpConfig, subnetId: ResourceId) = { state with SubnetId = Some subnetId }
+
+let privateLinkIpConfig = PrivateLinkServiceIpConfigBuilder()
+
+type PrivateLinkServiceConfig =
+    {
+        Name: ResourceName
+        Dependencies : ResourceId Set
+        AutoApprovedSubscriptions : Guid list
+        EnableProxyProtocol : bool option
+        LoadBalancerFrontendIpConfigIds: ResourceId list
+        IpConfigs : PrivateLinkServiceIpConfig list
+        VisibleToSubscriptions : Guid list
+        Tags: Map<string,string>
+    }
+    interface IBuilder with
+        member this.ResourceId = privateLinkServices.resourceId (this.Name)
+        member this.BuildResources location =
+            [
+                {
+                    PrivateLinkService.Name = this.Name
+                    Location = location
+                    Dependencies = this.Dependencies
+                    AutoApprovedSubscriptions = this.AutoApprovedSubscriptions
+                    EnableProxyProtocol = this.EnableProxyProtocol |> Option.defaultValue false
+                    LoadBalancerFrontendIpConfigIds = this.LoadBalancerFrontendIpConfigIds
+                    IpConfigs = this.IpConfigs |> List.map PrivateLinkServiceIpConfig.BuildResource
+                    VisibleToSubscriptions = this.VisibleToSubscriptions
+                    Tags = this.Tags
+                }
+            ]
+
+type PrivateLinkBuilder() =
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            Dependencies = Set.empty
+            AutoApprovedSubscriptions = []
+            EnableProxyProtocol = None
+            LoadBalancerFrontendIpConfigIds = []
+            IpConfigs = []
+            VisibleToSubscriptions = []
+            Tags = Map.empty
+        }
+    interface IDependable<PrivateLinkServiceConfig> with member _.Add state newDeps = { state with Dependencies = state.Dependencies + newDeps }
+    interface ITaggable<StorageAccountConfig> with member _.Add state tags = { state with Tags = state.Tags |> Map.merge tags }
+    [<CustomOperation "name">]
+    member _.Name(state:PrivateLinkServiceConfig, name) = { state with Name = ResourceName name }
+    [<CustomOperation "add_auto_approved_subscriptions">]
+    member _.AddAutoApprovedSubscriptions(state:PrivateLinkServiceConfig, subscriptions) =
+        { state with AutoApprovedSubscriptions = state.AutoApprovedSubscriptions @ subscriptions }
+    [<CustomOperation "add_load_balancer_frontend_ids">]
+    member _.AddLoadBalancerFrontendIpConfigs(state:PrivateLinkServiceConfig, lbFrontendIpConfigs) =
+        { state with LoadBalancerFrontendIpConfigIds = state.LoadBalancerFrontendIpConfigIds @ lbFrontendIpConfigs }
+    [<CustomOperation "add_ip_configs">]
+    member _.AddIpConfigs(state:PrivateLinkServiceConfig, ipConfigs) =
+        { state with IpConfigs = state.IpConfigs @ ipConfigs }
+    [<CustomOperation "proxy_protocol">]
+    member _.ProxyProtocol(state:PrivateLinkServiceConfig, flag:FeatureFlag) =
+        { state with EnableProxyProtocol = Some flag.AsBoolean }
+    [<CustomOperation "add_visible_to_subscriptions">]
+    member _.AddVisibleToSubscriptions(state:PrivateLinkServiceConfig, subscriptions) =
+        { state with VisibleToSubscriptions = state.VisibleToSubscriptions @ subscriptions }
+
+let privateLink = PrivateLinkBuilder()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -92,6 +92,7 @@
     <Compile Include="Arm\AvailabilityTest.fs" />
     <Compile Include="Arm/KeyVault.fs" />
     <Compile Include="Arm\LoadBalancer.fs" />
+    <Compile Include="Arm\PrivateLinkService.fs" />
     <Compile Include="Arm/RoleAssignment.fs" />
     <Compile Include="Arm/Search.fs" />
     <Compile Include="Arm/ServiceBus.fs" />
@@ -166,6 +167,7 @@
     <Compile Include="Builders/Builders.ApplicationGateway.fs" />
     <Compile Include="Builders/Builders.LogicApps.fs" />
     <Compile Include="Builders/Builders.OperationsManagement.fs" />
+    <Compile Include="Builders\Builders.PrivateLink.fs" />
     <Compile Include="Aliases.fs" />
   </ItemGroup>
 </Project>

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -47,6 +47,7 @@ let allTests =
                 NetworkSecurityGroup.tests
                 OperationsManagement.tests
                 PostgreSQL.tests
+                PrivateLink.tests
                 ResourceGroup.tests
                 ServiceBus.tests
                 SignalR.tests

--- a/src/Tests/PrivateLink.fs
+++ b/src/Tests/PrivateLink.fs
@@ -1,0 +1,105 @@
+module PrivateLink
+
+open Expecto
+open Farmer
+open Farmer.Builders
+open Newtonsoft.Json.Linq
+
+let tests = testList "Private Link" [
+    test "Creates a private link service for a load balancer" {
+        let vnet = vnet {
+            name "private-net"
+            add_address_spaces [
+                "10.100.0.0/16"
+            ]
+            add_subnets [
+                subnet {
+                    name "default"
+                    prefix "10.100.0.0/24"
+                }
+                subnet {
+                    name "backend-services"
+                    prefix "10.100.1.0/24"
+                }
+                subnet {
+                    name "private-endpoints"
+                    prefix "10.100.255.0/24"
+                    private_link_service_network_policies Disabled
+                }
+            ]
+        }
+        let lb =
+            loadBalancer {
+                name "lb"
+                sku LoadBalancer.Sku.Standard
+                depends_on vnet
+                add_frontends [
+                    frontend {
+                        name "lb-frontend"
+                        private_ip_allocation_method AllocationMethod.DynamicPrivateIp
+                        link_to_subnet (ResourceId.create(Farmer.Arm.Network.subnets, vnet.Name, ResourceName "default"))
+                    }
+                ]
+                add_backend_pools [
+                    backendAddressPool {
+                        name "lb-backend"
+                    }
+                ]
+                add_probes [
+                    loadBalancerProbe {
+                        name "httpGet"
+                        protocol Farmer.LoadBalancer.LoadBalancerProbeProtocol.HTTP
+                        port 80
+                        request_path "/"
+                    }
+                ]
+                add_rules [
+                    loadBalancingRule {
+                        name "rule1"
+                        frontend_ip_config "lb-frontend"
+                        backend_address_pool "lb-backend"
+                        frontend_port 80
+                        backend_port 80
+                        protocol TransmissionProtocol.TCP
+                        probe "httpGet"
+                    }
+                ]
+            }
+        let pls =
+            privateLink {
+                name "pls"
+                depends_on lb
+                add_auto_approved_subscriptions [ System.Guid.NewGuid() ]
+                add_load_balancer_frontend_ids [
+                    ResourceId.create(Farmer.Arm.LoadBalancer.loadBalancerFrontendIPConfigurations, lb.Name, ResourceName "lb-frontend")
+                ]
+                add_ip_configs [
+                    privateLinkIpConfig {
+                        link_to_subnet (ResourceId.create(Farmer.Arm.Network.subnets, vnet.Name, ResourceName "private-endpoints"))
+                    }
+                ]
+            }
+        let deployment = arm {
+            add_resources [
+                lb
+                vnet
+                pls
+            ]
+        }
+        let json = deployment.Template |> Writer.toJson |> JToken.Parse
+        let privateLinkProps = json.SelectToken("resources[?(@.name=='pls')].properties")
+        let ipconfigs = privateLinkProps.SelectToken("ipConfigurations") :?> JArray
+        let ipconfig = ipconfigs.[0]
+        Expect.equal (string ipconfig.["name"]) "private-net-private-endpoints" "Incorrect name for ipconfig"
+        let ipconfigProps = ipconfig.["properties"]
+        Expect.equal ipconfigProps.["primary"] (JValue false) "Incorrect value for ipconfig.properties.primary"
+        Expect.equal ipconfigProps.["privateIPAddressVersion"] (JValue "IPv4") "Incorrect value for ipconfig.properties.privateIPAddressVersion"
+        Expect.equal ipconfigProps.["privateIPAllocationMethod"] (JValue "Dynamic") "Incorrect value for ipconfig.properties.privateIPAllocationMethod"
+        Expect.equal ipconfigProps.["subnet"].["id"] (JValue "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'private-net', 'private-endpoints')]") "Incorrect value for ipconfig.properties.subnet.id"
+        Expect.hasLength ipconfigs 1 "Incorrect number of ip configurations"
+        let frontendIpConfigs = privateLinkProps.SelectToken("loadBalancerFrontendIpConfigurations") :?> JArray
+        Expect.hasLength frontendIpConfigs 1 "Incorrect number of lb frontend ip configurations"
+        let frontendIpConfigId = frontendIpConfigs.[0].["id"]
+        Expect.equal frontendIpConfigId (JValue "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'lb', 'lb-frontend')]") "Incorrect expression for frontend IP config"
+    }
+]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="LoadBalancer.fs" />
     <Compile Include="NetworkSecurityGroup.fs" />
     <Compile Include="OperationsManagement.fs" />
+    <Compile Include="PrivateLink.fs" />
     <Compile Include="ResourceGroup.fs" />
     <Compile Include="Storage.fs" />
     <Compile Include="ServiceBus.fs" />


### PR DESCRIPTION
The changes in this PR are as follows:

* Private Link Services: Adds support for provisioning private link services

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let vnet = vnet {
    name "private-net"
    add_address_spaces [
        "10.100.0.0/16"
    ]
    add_subnets [
        subnet {
            name "default"
            prefix "10.100.0.0/24"
        }
        subnet {
            name "backend-services"
            prefix "10.100.1.0/24"
        }
        subnet {
            name "private-endpoints"
            prefix "10.100.255.0/24"
            private_link_service_network_policies Disabled
        }
    ]
}
let lb =
    loadBalancer {
        name "lb"
        sku LoadBalancer.Sku.Standard
        depends_on vnet
        add_frontends [
            frontend {
                name "lb-frontend"
                private_ip_allocation_method AllocationMethod.DynamicPrivateIp
                link_to_subnet (ResourceId.create(Farmer.Arm.Network.subnets, vnet.Name, ResourceName "default"))
            }
        ]
        add_backend_pools [
            backendAddressPool {
                name "lb-backend"
            }
        ]
        add_probes [
            loadBalancerProbe {
                name "httpGet"
                protocol Farmer.LoadBalancer.LoadBalancerProbeProtocol.HTTP
                port 80
                request_path "/"
            }
        ]
        add_rules [
            loadBalancingRule {
                name "rule1"
                frontend_ip_config "lb-frontend"
                backend_address_pool "lb-backend"
                frontend_port 80
                backend_port 80
                protocol TransmissionProtocol.TCP
                probe "httpGet"
            }
        ]
    }
let pls =
    privateLink {
        name "pls"
        depends_on lb
        add_auto_approved_subscriptions [ System.Guid("bce46fd2-07e2-4d06-b182-c7e1bc24fc37") ]
        add_load_balancer_frontend_ids [
            ResourceId.create(Farmer.Arm.LoadBalancer.loadBalancerFrontendIPConfigurations, lb.Name, ResourceName "lb-frontend")
        ]
        add_ip_configs [
            privateLinkIpConfig {
                link_to_subnet (ResourceId.create(Farmer.Arm.Network.subnets, vnet.Name, ResourceName "private-endpoints"))
            }
        ]
    }
let deployment = arm {
    add_resources [
        lb
        vnet
        pls
    ]
}
```
