### PR TITLE
Fix diagnostics storage account reference for existing storage account

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.7.4
 * Container Apps: Support for mounted storage
+* Virtual Machines: Fix reference to an existing storage account in boot diagnostics.
 * Web App: add an overload for `link_to_service_plan` that accepts Web App
 * Added Basic Types documentation and examples for unmanaged resources.
 

--- a/src/Farmer/Arm/Compute.fs
+++ b/src/Farmer/Arm/Compute.fs
@@ -150,10 +150,17 @@ type VirtualMachine =
                     diagnosticsProfile =
                         match this.StorageAccount with
                         | Some storageAccount ->
+                            let resourceId = storageAccounts.resourceId storageAccount
+                            let storageUriExpr =
+                                ArmExpression
+                                    .reference(storageAccounts, resourceId)
+                                    .Map(fun r -> r + ".primaryEndpoints.blob")
+                                    .WithOwner(resourceId)
+                                    .Eval()
                             box
                                 {| bootDiagnostics =
                                     {| enabled = true
-                                       storageUri = $"[reference('{storageAccount.Value}').primaryEndpoints.blob]"
+                                       storageUri = storageUriExpr
                                     |}
                                 |}
                         | None ->

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -20,7 +20,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference('isaacsvmstorage').primaryEndpoints.blob]"
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2019-06-01').primaryEndpoints.blob]"
           }
         },
         "hardwareProfile": {


### PR DESCRIPTION
This PR closes #939

The changes in this PR are as follows:

* Virtual Machines: Fix reference to an existing storage account in boot diagnostics.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Bugfix only, no doc to update. Uses existing unit test.