### PR TITLE
workaround ContainerApps bug in volume mounts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.5
+* Container Apps: Workaround for empty mounted volumes bug
+
 ## 1.7.4
 * Container Apps: Support for mounted storage
 * Private Link Services: Adds support for provisioning private link services

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -169,7 +169,8 @@ type ContainerApp =
                                                :> obj
                                             volumeMounts =
                                                 container.VolumeMounts
-                                                |> Seq.map (fun kvp -> {| volumeName=kvp.Key; mountPath=kvp.Value |}) |> List.ofSeq
+                                                |> Seq.map (fun kvp -> {| volumeName=kvp.Key; mountPath=kvp.Value |})
+                                                |> List.ofSeq |> function [] -> Unchecked.defaultof<_> | vms -> vms
                                       |}
                                   |]
                                   scale =
@@ -280,7 +281,7 @@ type ContainerApp =
                                                {| name = volumeName
                                                   storageType = "EmptyDir"
                                                   storageName = null |}
-                                  ]
+                                  ] |> function [] -> Unchecked.defaultof<_> | vs -> vs
                         |}
                    |}
             |}

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1091,12 +1091,10 @@ module Containers =
                 match repo.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries) |> List.ofArray with
                 | first::rest when (first.Contains ".") -> DockerImage.PrivateImage(first, (rest |> String.concat "/"), Version=Some version)
                 | _ -> DockerImage.PublicImage(repo, Version=Some version)
-                | _ -> raiseFarmer $"Malformed docker image tag - incorrect number of repository segments: '{tag}'"
             | [| repo |] ->
                 match repo.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries) |> List.ofArray with
                 | first::rest when (first.Contains ".") -> DockerImage.PrivateImage(first, (rest |> String.concat "/"), None)
                 | _ -> DockerImage.PublicImage(repo, None)
-                | _ -> raiseFarmer $"Malformed docker image tag - incorrect number of repository segments: '{tag}'"
             | _ -> raiseFarmer $"Malformed docker image tag - incorrect number of version segments: '{tag}'"
 
 /// Credential for accessing an image registry.


### PR DESCRIPTION
This PR fixes current master and works around ContainerApps bug that can't handle empty volumes/mounts on redeployment.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
seemed reasonable