### PR TITLE
Fix setting of stack using Runtime.DotNet60

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -490,7 +490,7 @@ type WebAppConfig =
                     | Php _, _ -> Some "php"
                     | Python _, Windows -> Some "python"
                     | DotNetCore _, Windows -> Some "dotnetcore"
-                    | AspNet _, _ | DotNet "5.0", Windows -> Some "dotnet"
+                    | AspNet _, _ | DotNet _, Windows -> Some "dotnet"
                     | _ -> None
                     |> Option.map(fun stack -> "CURRENT_STACK", stack)
                     |> Option.toList

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -316,8 +316,9 @@ let tests = testList "Web App Tests" [
 
     test "Supports .NET 6" {
         let app = webApp { name "net6"; runtime_stack Runtime.DotNet60 }
-        let site:Site = app |> getResourceAtIndex 2
-        Expect.equal site.SiteConfig.NetFrameworkVersion "v6.0" "Wrong dotnet version"
+        let site = app |> getResources |> getResource<Web.Site> |> List.head
+        Expect.equal site.NetFrameworkVersion.Value "v6.0" "Wrong dotnet version"
+        Expect.equal site.Metadata.Head ("CURRENT_STACK", "dotnet") "Stack should be dotnet"
     }
 
     test "Supports .NET 5 on Linux" {


### PR DESCRIPTION
Currently when using `runtime_stack Runtime.DotNet60` on a WebApp you end up with the below in Azure.
![image](https://user-images.githubusercontent.com/36571008/180262786-3b93eb94-11f2-4117-abf8-cbe994770135.png)

To fix this it seems that you need to set [some metadata](https://dailydevsblog.com/troubleshoot/resolved-netframeworkversion-in-azure-app-services-api-app-133535/) for `CURRENT_STACK`.

I have deployed locally and it seems to have done the business.
![image](https://user-images.githubusercontent.com/36571008/180264113-8160fabf-b67e-463e-a2cc-5be1cec90cab.png)


The changes in this PR are as follows:

* Ensure `CURRENT_STACK` is set when using `Runtime.DotNet60`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
* No real new code to document/notes to add.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
   webApp { 
        name "net6"; 
        runtime_stack Runtime.DotNet60
   }
```
