### PR TITLE
Adds privateEndpoint builder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.7
+* Private Endpoints: Adds `privateEndpoint` builder and option to set custom network interface name.
+
 ## 1.7.6
 * Virtual Machines: Support for adding a VM network interface to a load balancer backend.
 

--- a/docs/content/api-overview/resources/private-endpoint.md
+++ b/docs/content/api-overview/resources/private-endpoint.md
@@ -1,0 +1,44 @@
+---
+title: "Private Endpoint"
+date: 2022-08-05T16:13:00-04:00
+chapter: false
+weight: 12
+---
+
+#### Overview
+The Private Endpoint builder (`privateEndpoint`) creates a private endpoint for accessing Azure resources or a private link service without traversing the Internet.
+
+* Private Endpoint (`Microsoft.Network/privateEndpoints`)
+
+#### Builder Keywords
+
+| Applies To | Keyword | Purpose |
+|-|-|-|
+| privateEndpoint | name | Specifies the name of the private endpoint. |
+| privateEndpoint | subnet_reference | Attaches the private endpoint to a referenced subnet. |
+| privateEndpoint | link_to_subnet | Attaches the private endpoint to a subnet deployed in the same deployment. |
+| privateEndpoint | link_to_unmanaged_subnet | Attaches the private endpoint to an existing subnet. |
+| privateEndpoint | resource | Specifies the ARM resource ID of the service it is connecting to. |
+| privateEndpoint | custom_nic_name | Optionally specify the name for the NIC generated for the private endpoint. |
+| privateEndpoint | add_group_ids | Specify one or more group IDs the private link service provides. |
+
+#### Configuration Members
+
+| Member | Purpose |
+|-|-|
+| CustomNicEndpointIP <index> | If the `custom_nic_name` is set, this gets an ARM Expression to get the private endpoint IP address by 0-based index. |
+| CustomNicFirstEndpointIP | If the `custom_nic_name` is set, this gets an ARM Expression to get the first private endpoint IP address. |
+
+#### Example
+
+```fsharp
+open Farmer
+open Farmer.Builders
+
+let myPrivateEndpoint = privateEndpoint {
+    name "private-endpoint"
+    custom_nic_name "private-endpoint-nic"
+    link_to_subnet (subnets.resourceId (ResourceName "my-net", ResourceName "priv-endpoints" ))
+    resource (Unmanaged existingPrivateLinkId)
+}
+```

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -39,7 +39,7 @@ let localNetworkGateways =
     ResourceType("Microsoft.Network/localNetworkGateways", "")
 
 let privateEndpoints =
-    ResourceType("Microsoft.Network/privateEndpoints", "2020-07-01")
+    ResourceType("Microsoft.Network/privateEndpoints", "2021-05-01")
 
 let virtualNetworkPeering =
     ResourceType("Microsoft.Network/virtualNetworks/virtualNetworkPeerings", "2020-05-01")
@@ -504,6 +504,7 @@ type NetworkInterface =
                                     |}
 
 
+
                             |})
                 |}
 
@@ -657,6 +658,7 @@ type PrivateEndpoint =
         Location: Location
         Subnet: SubnetReference
         Resource: LinkedResource
+        CustomNetworkInterfaceName: string option
         GroupIds: string list
     }
 
@@ -671,6 +673,7 @@ type PrivateEndpoint =
                 Location = location
                 Subnet = subnet
                 Resource = Managed resourceId
+                CustomNetworkInterfaceName = None
                 GroupIds = groupIds
             }
             :> IArmResource)
@@ -691,6 +694,7 @@ type PrivateEndpoint =
                 properties =
                     {|
                         subnet = {| id = this.Subnet.ResourceId.Eval() |}
+                        customNetworkInterfaceName = this.CustomNetworkInterfaceName |> Option.toObj
                         privateLinkServiceConnections =
                             [
                                 {|

--- a/src/Farmer/Builders/Builders.PrivateEndpoint.fs
+++ b/src/Farmer/Builders/Builders.PrivateEndpoint.fs
@@ -1,0 +1,94 @@
+[<AutoOpen>]
+module Farmer.Builders.PrivateEndpoint
+
+open Farmer
+open Farmer.Arm
+open Farmer.Arm.Network
+
+type PrivateEndpointConfig =
+    {
+        Name: ResourceName
+        Subnet: SubnetReference option
+        Resource: LinkedResource option
+        CustomNetworkInterfaceName: string option
+        GroupIds: string list
+    }
+
+    interface IBuilder with
+        member this.ResourceId = privateEndpoints.resourceId this.Name
+
+        member this.BuildResources location =
+            [
+                match this.Subnet, this.Resource with
+                | Some subnet, Some resource ->
+                    {
+                        PrivateEndpoint.Name = this.Name
+                        Location = location
+                        Subnet = subnet
+                        Resource = resource
+                        CustomNetworkInterfaceName = this.CustomNetworkInterfaceName
+                        GroupIds = []
+                    }
+                | _ ->
+                    raiseFarmer
+                        $"Subnet and Resource must be specified. Subnet: '{this.Subnet}' Resource: '{this.Resource}'"
+            ]
+
+    /// If a CustomNetworkInterfaceName is set via 'custom_nic_name', this returns the private IP.
+    member this.CustomNicEndpointIP(idx: int) : ArmExpression option =
+        this.CustomNetworkInterfaceName
+        |> Option.map (fun customNicName ->
+            let nicId = ResourceId.create (networkInterfaces, ResourceName customNicName)
+
+            $"reference({nicId.ArmExpression.Value}, '{networkInterfaces.ApiVersion}').ipConfigurations[{idx}].properties.privateIpAddress"
+            |> ArmExpression.create)
+
+    member this.CustomNicFirstEndpointIP = this.CustomNicEndpointIP 0
+
+type PrivateEndpointBuilder() =
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            Subnet = None
+            Resource = None
+            CustomNetworkInterfaceName = None
+            GroupIds = []
+        }
+
+    [<CustomOperation "name">]
+    member _.Name(state: PrivateEndpointConfig, name: string) = { state with Name = ResourceName name }
+
+    [<CustomOperation "subnet_reference">]
+    member _.Subnet(state: PrivateEndpointConfig, subnetReference: SubnetReference) =
+        { state with
+            Subnet = Some subnetReference
+        }
+
+    [<CustomOperation "link_to_subnet">]
+    member _.LinkToSubnet(state: PrivateEndpointConfig, subnetId: ResourceId) =
+        { state with
+            Subnet = Some(SubnetReference.Direct(Managed subnetId))
+        }
+
+    [<CustomOperation "link_to_unmanaged_subnet">]
+    member _.LinkToUnmanagedSubnet(state: PrivateEndpointConfig, subnetId: ResourceId) =
+        { state with
+            Subnet = Some(SubnetReference.Direct(Unmanaged subnetId))
+        }
+
+    [<CustomOperation "resource">]
+    member _.Resource(state: PrivateEndpointConfig, resource: LinkedResource) = { state with Resource = Some resource }
+
+    [<CustomOperation "custom_nic_name">]
+    member _.CustomNetworkInterfaceName(state: PrivateEndpointConfig, customNicName: string) =
+        { state with
+            CustomNetworkInterfaceName = Some customNicName
+        }
+
+    [<CustomOperation "add_group_ids">]
+    member _.AddGroupIds(state: PrivateEndpointConfig, groupIds: string list) =
+        { state with
+            GroupIds = state.GroupIds @ groupIds
+        }
+
+let privateEndpoint = PrivateEndpointBuilder()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -168,6 +168,7 @@
     <Compile Include="Builders/Builders.LogicApps.fs" />
     <Compile Include="Builders/Builders.OperationsManagement.fs" />
     <Compile Include="Builders\Builders.PrivateLink.fs" />
+    <Compile Include="Builders\Builders.PrivateEndpoint.fs" />
     <Compile Include="Aliases.fs" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -1,12 +1,13 @@
 module Network
 
+open System
 open Expecto
+open Newtonsoft.Json.Linq
 open Farmer
+open Farmer.Arm
 open Farmer.Builders
 open Farmer.Network
 open Microsoft.Rest
-open System
-open Farmer.Arm
 
 let netClient =
     new Microsoft.Azure.Management.Network.NetworkManagementClient(
@@ -611,5 +612,83 @@ let tests =
 
                         template.Template |> Writer.toJson |> ignore)
                     "Adding a subnet resource without linking to a vnet is not allowed"
+            }
+            test "Create private endpoint" {
+                let myNet =
+                    vnet {
+                        name "my-net"
+                        add_address_spaces [ "10.40.0.0/16" ]
+
+                        add_subnets
+                            [
+                                subnet {
+                                    name "priv-endpoints"
+                                    prefix "10.40.255.0/24"
+                                    allow_private_endpoints Enabled
+                                }
+                            ]
+                    }
+
+                let existingPrivateLinkId =
+                    { PrivateLink.privateLinkServices.resourceId "pls" with
+                        ResourceGroup = Some "farmer-pls"
+                    }
+
+                let pe1 =
+                    privateEndpoint {
+                        name "pe1"
+                        custom_nic_name "pe1-nic"
+                        link_to_subnet (subnets.resourceId (ResourceName "my-net", ResourceName "priv-endpoints"))
+                        resource (Unmanaged existingPrivateLinkId)
+                    }
+
+                let myDnsZone =
+                    dnsZone {
+                        name "farmer.com"
+                        zone_type Dns.Public
+
+                        add_records
+                            [
+                                Farmer.Builders.Dns.aRecord {
+                                    name "pe1"
+                                    ttl 600
+
+                                    add_ipv4_addresses
+                                        [
+                                            pe1.CustomNicFirstEndpointIP
+                                            |> Option.map ArmExpression.Eval
+                                            |> Option.toObj
+                                        ]
+                                }
+                            ]
+                    }
+
+                let deployment =
+                    arm {
+                        add_resources
+                            [
+                                myNet
+                                pe1
+                                resourceGroup {
+                                    name "[resourceGroup().name]"
+                                    depends_on pe1
+                                    add_resource myDnsZone
+                                }
+                            ]
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+                let peProps = jobj.SelectToken "resources[?(@.name=='pe1')].properties"
+                Expect.equal (string peProps.["customNetworkInterfaceName"]) "pe1-nic" "Incorrect custom nic name"
+
+                Expect.equal
+                    (string peProps.["subnet"].["id"])
+                    "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'my-net', 'priv-endpoints')]"
+                    "Incorrect subnet id"
+
+                Expect.equal
+                    (string peProps.["privateLinkServiceConnections"].[0].["properties"].["privateLinkServiceId"])
+                    "[resourceId('farmer-pls', 'Microsoft.Network/privateLinkServices', 'pls')]"
+                    "Incorrect private link service ID"
             }
         ]


### PR DESCRIPTION
This PR closes #956

The changes in this PR are as follows:

* Private Endpoints: Adds `privateEndpoint` builder and option to set custom network interface name.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders

let myPrivateEndpoint = privateEndpoint {
    name "private-endpoint"
    custom_nic_name "private-endpoint-nic"
    link_to_subnet (subnets.resourceId (ResourceName "my-net", ResourceName "priv-endpoints" ))
    resource (Unmanaged existingPrivateLinkId)
}
```
