### PR TITLE
Keep RG and Subs components from VNet when generating a subnet resourceId

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.7.8
+* VMs: Add support for VNets in other resource groups
 
 ## 1.7.7
 * NAT Gateways: Initial support for NAT Gateways.

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -549,10 +549,9 @@ type NetworkInterface =
                                             |> Option.defaultValue Unchecked.defaultof<_>
                                         subnet =
                                             {|
-                                                id =
-                                                    subnets
-                                                        .resourceId(this.VirtualNetwork.Name, ipConfig.SubnetName)
-                                                        .Eval()
+                                                id = { this.VirtualNetwork.ResourceId with 
+                                                        Type = subnets
+                                                        Segments = [ipConfig.SubnetName] }.Eval()
                                             |}
                                     |}
 

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -549,11 +549,15 @@ type NetworkInterface =
                                             |> Option.defaultValue Unchecked.defaultof<_>
                                         subnet =
                                             {|
-                                                id = { this.VirtualNetwork.ResourceId with 
+                                                id =
+                                                    { this.VirtualNetwork.ResourceId with
                                                         Type = subnets
-                                                        Segments = [ipConfig.SubnetName] }.Eval()
+                                                        Segments = [ ipConfig.SubnetName ]
+                                                    }
+                                                        .Eval()
                                             |}
                                     |}
+
 
 
 

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -442,6 +442,11 @@ type VirtualMachineBuilder() =
     member this.LinkToVNet(state: VmConfig, vnet: VirtualNetworkConfig) = this.LinkToVNet(state, vnet.Name)
 
     [<CustomOperation "link_to_unmanaged_vnet">]
+    member _.LinkToUnmanagedVNet(state: VmConfig, id: ResourceId) =
+        { state with
+            VNet = LinkedResource(Unmanaged(id))
+        }
+
     member _.LinkToUnmanagedVNet(state: VmConfig, name: ResourceName) =
         { state with
             VNet = LinkedResource(Unmanaged(virtualNetworks.resourceId name))

--- a/src/Tests/VirtualMachine.fs
+++ b/src/Tests/VirtualMachine.fs
@@ -527,6 +527,45 @@ let tests =
                     $"NIC should only depend on its public IP, not also the vnet: {nicDependsOn}"
             }
 
+            test "Link new VM to existing vnet in different resource group" {
+                let myVnet = Arm.Network.virtualNetworks.resourceId("myvnet", groupName="other-group")
+                let template =
+                    let myVm =
+                        vm {
+                            name "myvm"
+                            username "azureuser"
+                            link_to_unmanaged_vnet myVnet
+                            subnet_name "default"
+                        }
+
+                    arm { add_resource myVm }
+
+                let jobj = Newtonsoft.Json.Linq.JObject.Parse(template.Template |> Writer.toJson)
+                let vmResource = jobj.SelectToken("resources[?(@.name=='myvm')]")
+                let vmDependsOn = (vmResource.["dependsOn"] :?> Newtonsoft.Json.Linq.JArray)
+                Expect.hasLength vmDependsOn 1 "Incorrect number of VM dependencies"
+
+                Expect.sequenceEqual
+                    vmDependsOn
+                    (Newtonsoft.Json.Linq.JArray [ "[resourceId('Microsoft.Network/networkInterfaces', 'myvm-nic')]" ])
+                    $"VM should only depend on its NIC, not also the vnet: {vmDependsOn}"
+
+                let nicResource = jobj.SelectToken("resources[?(@.name=='myvm-nic')]")
+                let nicDependsOn = (nicResource.["dependsOn"] :?> Newtonsoft.Json.Linq.JArray)
+                Expect.hasLength nicDependsOn 1 "NIC should only have 1 dependency - the public IP"
+
+                let nicSubnetId = nicResource.SelectToken("properties.ipConfigurations[0].properties.subnet.id").ToString();
+                Expect.equal 
+                    nicSubnetId 
+                    "[resourceId('other-group', 'Microsoft.Network/virtualNetworks/subnets', 'myvnet', 'default')]"
+                    "NIC subnet should repect resource group specified in VM VNet"
+
+                Expect.sequenceEqual
+                    nicDependsOn
+                    (Newtonsoft.Json.Linq.JArray [ "[resourceId('Microsoft.Network/publicIPAddresses', 'myvm-ip')]" ])
+                    $"NIC should only depend on its public IP, not also the vnet: {nicDependsOn}"
+            }
+
             test "Enables Azure AD SSH access on Linux virtual machine" {
                 let template =
                     let myVm =

--- a/src/Tests/VirtualMachine.fs
+++ b/src/Tests/VirtualMachine.fs
@@ -528,7 +528,9 @@ let tests =
             }
 
             test "Link new VM to existing vnet in different resource group" {
-                let myVnet = Arm.Network.virtualNetworks.resourceId("myvnet", groupName="other-group")
+                let myVnet =
+                    Arm.Network.virtualNetworks.resourceId ("myvnet", groupName = "other-group")
+
                 let template =
                     let myVm =
                         vm {
@@ -554,9 +556,13 @@ let tests =
                 let nicDependsOn = (nicResource.["dependsOn"] :?> Newtonsoft.Json.Linq.JArray)
                 Expect.hasLength nicDependsOn 1 "NIC should only have 1 dependency - the public IP"
 
-                let nicSubnetId = nicResource.SelectToken("properties.ipConfigurations[0].properties.subnet.id").ToString();
-                Expect.equal 
-                    nicSubnetId 
+                let nicSubnetId =
+                    nicResource
+                        .SelectToken("properties.ipConfigurations[0].properties.subnet.id")
+                        .ToString()
+
+                Expect.equal
+                    nicSubnetId
                     "[resourceId('other-group', 'Microsoft.Network/virtualNetworks/subnets', 'myvnet', 'default')]"
                     "NIC subnet should repect resource group specified in VM VNet"
 


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Support creating VMs connected to Subnets in different resource groups

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
 - Bug fix, no change to documented functionality.
 - 
Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let myVnet = Arm.Network.virtualNetworks.resourceId("myvnet", groupName="other-group")
vm {
    name "myvm"
    username "azureuser"
    link_to_unmanaged_vnet myVnet
    subnet_name "default"
}
```
