### PR TITLE
Allow null priority to allow updating non-spot VM instances

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.7.8
+* VMs: Default to no priority
 
 ## 1.7.7
 * NAT Gateways: Initial support for NAT Gateways.

--- a/docs/content/api-overview/resources/virtual-machine.md
+++ b/docs/content/api-overview/resources/virtual-machine.md
@@ -25,7 +25,7 @@ In addition, every VM you create will add a SecureString parameter to the ARM te
 |diagnostics_support_managed|Turns on diagnostics support using an Azure-managed storage account.|
 |diagnostics_support_external|Turns on diagnostics support using an existing storage account.|
 |vm_size|Sets the size of the VM.|
-|priority|Sets the VM Priority. Only one `spot_instance` or `priority` setting is allowed per VM.|
+|priority|Sets the VM Priority. Only one `spot_instance` or `priority` setting is allowed per VM. No priority is set by default. |
 |spot_instance|Makes the VM a spot instance. Shorthand for `priority (Spot (<EvictionPolicy>, <maxPrice>)`. Only one `spot_instance` or `priority` setting is allowed per VM.|
 |username|Sets the admin username of the VM (note: the password is supplied as a securestring parameter to the generated ARM template).|
 |password_parameter|Sets the name of the parameter which contains the admin password for this VM. defaults to "password-for-<VM-name>"|

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -87,7 +87,7 @@ type VmConfig =
                     StorageAccount = this.DiagnosticsStorageAccount |> Option.map (fun r -> r.resourceId(this).Name)
                     NetworkInterfaceName = this.NicName.Name
                     Size = this.Size
-                    Priority = this.Priority |> Option.defaultValue Regular
+                    Priority = this.Priority
                     Credentials =
                         match this.Username with
                         | Some username ->

--- a/src/Tests/VirtualMachine.fs
+++ b/src/Tests/VirtualMachine.fs
@@ -57,6 +57,21 @@ let tests =
                     (resource.DiagnosticsProfile.BootDiagnostics.Enabled.GetValueOrDefault false)
                     "Boot Diagnostics should be enabled"
             }
+
+            test "By default, VM does not include Priority" {
+                let template =
+                    let myVm =
+                        vm {
+                            name "myvm"
+                            username "me"
+                        }
+
+                    arm { add_resource myVm }
+
+                let jobj = Newtonsoft.Json.Linq.JObject.Parse(template.Template |> Writer.toJson)
+                let vmProperties = jobj.SelectToken("resources[?(@.name=='myvm')].properties") :?> Newtonsoft.Json.Linq.JObject
+                Expect.isNull (vmProperties.Property "priority") "Priority should not be set by default"
+            }
             test "Can create a basic virtual machine with managed boot diagnostics" {
                 let resource =
                     let myVm =

--- a/src/Tests/VirtualMachine.fs
+++ b/src/Tests/VirtualMachine.fs
@@ -69,7 +69,10 @@ let tests =
                     arm { add_resource myVm }
 
                 let jobj = Newtonsoft.Json.Linq.JObject.Parse(template.Template |> Writer.toJson)
-                let vmProperties = jobj.SelectToken("resources[?(@.name=='myvm')].properties") :?> Newtonsoft.Json.Linq.JObject
+
+                let vmProperties =
+                    jobj.SelectToken("resources[?(@.name=='myvm')].properties") :?> Newtonsoft.Json.Linq.JObject
+
                 Expect.isNull (vmProperties.Property "priority") "Priority should not be set by default"
             }
             test "Can create a basic virtual machine with managed boot diagnostics" {

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -658,7 +658,6 @@
                   "adminUsername": "farmer-admin",
                   "computerName": "farmervm"
                 },
-                "priority": "Regular",
                 "storageProfile": {
                   "dataDisks": [
                     {

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -38,7 +38,6 @@
           "adminUsername": "isaac",
           "computerName": "isaacsVM"
         },
-        "priority": "Regular",
         "storageProfile": {
           "dataDisks": [
             {


### PR DESCRIPTION
This PR closes #894

The changes in this PR are as follows:

* Don't set VM priority unless explicitly opted in to so that non-spot instances still work

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
vm {
  name "myvm"
  username "me"
}
```
