### PR TITLE
Adding support for route tables and their child resource, routes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.7.8
+* Route Tables: Initial support for Route Tables and Routes
 
 ## 1.7.7
 * NAT Gateways: Initial support for NAT Gateways.

--- a/docs/content/api-overview/resources/route-tables.md
+++ b/docs/content/api-overview/resources/route-tables.md
@@ -1,0 +1,58 @@
+---
+title: "Route Tables"
+date: 2022-09-08T22:26:00-04:00
+chapter: false
+weight: 5
+---
+
+#### Overview
+The `routeTable` builder creates a route table to efficiently change default routing traffic between Azure subnets, virtual networks, and on-premises networks. To learn more about routeTables, reference the [Azure Docs](https://docs.microsoft.com/en-us/azure/virtual-network/manage-route-table)
+
+* RouteTable (`Microsoft.Network/routeTables`)
+* Route (`Microsoft.Network/routeTables/routes`)
+
+#### Builder Keywords
+
+| Applies To | Keyword | Purpose |
+|-|-|-|
+| routeTable | name | Name of the NAT Gateway resource |
+| routeTable | disableBgpRoutePropagation | Whether to disable the routes learned by BGP on that route table |
+| routeTable | add_routes | The routes to be added to this route table |
+| route | name | Name of the route resource |
+| route | addressPrefix | The destination CIDR to which the route applies |
+| route | nextHopType | The type of Azure hop the packet should be sent to |
+| route | nextHopIpAddress | The IP address packets should be forwarded to. Only allowed in routes where the next hop type is VirtualAppliance |
+| route | hasBgpOverride | Whether the route overrides overalpping BGP routes regardless of LPM |
+
+#### Example
+
+```fsharp
+#r "nuget:Farmer"
+
+open Farmer
+open Farmer.Builders
+
+arm {
+    location Location.EastUS
+    add_resources
+        [
+            routeTable {
+                name "myroutetable"
+                add_routes [
+                    route {
+                        name "myroute"
+                        addressPrefix "10.10.90.0/24"
+                        nextHopType Route.HopType.VirtualAppliance
+                        nextHopIpAddress "10.10.67.5"
+                    }
+                    route {
+                        name "myroute2"
+                        addressPrefix "10.10.80.0/24"
+                        nextHopType Route.HopType.VirtualAppliance
+                        nextHopIpAddress "10.10.67.5"
+                    }
+                ]
+            }
+        ]
+}
+```

--- a/src/Farmer/Arm/AVS.fs
+++ b/src/Farmer/Arm/AVS.fs
@@ -2,4 +2,4 @@
 module Farmer.Arm.AVS
 
 open Farmer
-let privateClouds = ResourceType ("Microsoft.AVS/privateClouds", "2021-12-01")
+let privateClouds = ResourceType("Microsoft.AVS/privateClouds", "2021-12-01")

--- a/src/Farmer/Arm/AVS.fs
+++ b/src/Farmer/Arm/AVS.fs
@@ -1,0 +1,5 @@
+﻿[<AutoOpen>]
+module Farmer.Arm.AVS
+
+open Farmer
+let privateClouds = ResourceType ("Microsoft.AVS/privateClouds", "2021-12-01")

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -50,6 +50,11 @@ let privateEndpoints =
 let virtualNetworkPeering =
     ResourceType("Microsoft.Network/virtualNetworks/virtualNetworkPeerings", "2020-05-01")
 
+let routeTables =
+    ResourceType("Microsoft.Network/routeTables", "2021-01-01")
+let routes = 
+    ResourceType("Microsoft.Network/routeTables/routes", "2021-01-01")
+    
 type SubnetReference =
     | ViaManagedVNet of (ResourceId * ResourceName)
     | Direct of LinkedResource
@@ -89,6 +94,55 @@ type SubnetReference =
             raiseFarmer $"given resource was not of type '{subnets.Type}'."
 
         Direct subnetRef
+
+type HopType =
+    | VirtualAppliance
+with
+    member x.ArmValue =
+        match x with
+        | VirtualAppliance -> "VirtualAppliance"
+    
+type Route =
+    {
+        Name: ResourceName
+        AddressPrefix: IPAddressCidr
+        NextHopType: HopType
+        NextHopIpAddress: IPAddressCidr
+        HasBgpOverride: bool
+    }
+    member internal this.JsonModelProperties =
+        {|
+            addressPrefix = this.AddressPrefix
+            nextHopType = this.NextHopType.ArmValue
+            nextHopIpAddress = this.NextHopIpAddress
+            hasBgpOverride = this.HasBgpOverride
+        |}
+    interface IArmResource with
+        member this.ResourceId = routes.resourceId this.Name
+        member this.JsonModel =
+            {| routes.Create(this.Name) with
+                properties = this.JsonModelProperties
+            |}
+
+type RouteTable =
+    {
+        Name: ResourceName
+        Location: Location
+        Tags: Map<string, string>
+        DisableBGPRoutePropagation: bool
+        Routes: seq<Route>
+    }
+    member internal this.JsonModelProperties =
+        {|
+            disableBgpRoutePropagation = this.DisableBGPRoutePropagation
+            routes = this.Routes |> Seq.map (fun x -> x.JsonModelProperties)
+        |}
+    interface IArmResource with
+        member this.ResourceId = routeTables.resourceId this.Name
+        member this.JsonModel =
+            {| routeTables.Create(this.Name, this.Location, tags = this.Tags) with
+                properties = this.JsonModelProperties
+            |}
 
 type PublicIpAddress =
     {

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -101,14 +101,17 @@ type Route =
         Name: ResourceName
         AddressPrefix: IPAddressCidr
         NextHopType: Route.HopType
-        NextHopIpAddress: System.Net.IPAddress
+        NextHopIpAddress: System.Net.IPAddress option
         HasBgpOverride: FeatureFlag
     }
     member internal this.JsonModelProperties =
         {|
             addressPrefix = IPAddressCidr.format this.AddressPrefix
             nextHopType = this.NextHopType.ArmValue
-            nextHopIpAddress = this.NextHopIpAddress.ToString()
+            nextHopIpAddress =
+                this.NextHopIpAddress
+                    |> Option.map (fun x -> x.ToString())
+                    |> Option.defaultValue Unchecked.defaultof<_>
             hasBgpOverride = this.HasBgpOverride.AsBoolean
         |}
     interface IArmResource with

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -50,12 +50,10 @@ let privateEndpoints =
 let virtualNetworkPeering =
     ResourceType("Microsoft.Network/virtualNetworks/virtualNetworkPeerings", "2020-05-01")
 
-let routeTables =
-    ResourceType("Microsoft.Network/routeTables", "2021-01-01")
-let routes = 
-    ResourceType("Microsoft.Network/routeTables/routes", "2021-01-01")
-    
-    
+let routeTables = ResourceType("Microsoft.Network/routeTables", "2021-01-01")
+let routes = ResourceType("Microsoft.Network/routeTables/routes", "2021-01-01")
+
+
 type SubnetReference =
     | ViaManagedVNet of (ResourceId * ResourceName)
     | Direct of LinkedResource
@@ -95,7 +93,7 @@ type SubnetReference =
             raiseFarmer $"given resource was not of type '{subnets.Type}'."
 
         Direct subnetRef
-    
+
 type Route =
     {
         Name: ResourceName
@@ -104,18 +102,21 @@ type Route =
         NextHopIpAddress: System.Net.IPAddress option
         HasBgpOverride: FeatureFlag
     }
+
     member internal this.JsonModelProperties =
         {|
             addressPrefix = IPAddressCidr.format this.AddressPrefix
             nextHopType = this.NextHopType.ArmValue
             nextHopIpAddress =
                 this.NextHopIpAddress
-                    |> Option.map (fun x -> x.ToString())
-                    |> Option.defaultValue Unchecked.defaultof<_>
+                |> Option.map (fun x -> x.ToString())
+                |> Option.defaultValue Unchecked.defaultof<_>
             hasBgpOverride = this.HasBgpOverride.AsBoolean
         |}
+
     interface IArmResource with
         member this.ResourceId = routes.resourceId this.Name
+
         member this.JsonModel =
             {| routes.Create(this.Name) with
                 properties = this.JsonModelProperties
@@ -129,13 +130,16 @@ type RouteTable =
         DisableBGPRoutePropagation: FeatureFlag
         Routes: Route list
     }
+
     member internal this.JsonModelProperties =
         {|
             disableBgpRoutePropagation = this.DisableBGPRoutePropagation.AsBoolean
-            routes = this.Routes |> Seq.map (fun x -> (x:> IArmResource).JsonModel)
+            routes = this.Routes |> Seq.map (fun x -> (x :> IArmResource).JsonModel)
         |}
+
     interface IArmResource with
         member this.ResourceId = routeTables.resourceId this.Name
+
         member this.JsonModel =
             {| routeTables.Create(this.Name, this.Location, tags = this.Tags) with
                 properties = this.JsonModelProperties
@@ -606,6 +610,7 @@ type NetworkInterface =
                                                         .Eval()
                                             |}
                                     |}
+
 
 
 

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -106,14 +106,14 @@ type Route =
     {
         Name: ResourceName
         AddressPrefix: IPAddressCidr
-        NextHopType: HopType
+        NextHopType: string
         NextHopIpAddress: IPAddressCidr
         HasBgpOverride: bool
     }
     member internal this.JsonModelProperties =
         {|
             addressPrefix = this.AddressPrefix
-            nextHopType = this.NextHopType.ArmValue
+            nextHopType = this.NextHopType
             nextHopIpAddress = this.NextHopIpAddress
             hasBgpOverride = this.HasBgpOverride
         |}
@@ -130,7 +130,7 @@ type RouteTable =
         Location: Location
         Tags: Map<string, string>
         DisableBGPRoutePropagation: bool
-        Routes: seq<Route>
+        Routes: Route list
     }
     member internal this.JsonModelProperties =
         {|

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -98,7 +98,7 @@ type SubnetReference =
 type HopType =
     | VirtualAppliance
     | Internet
-    | None
+    | Nothing
     | VirtualNetworkGateway
     | VnetLocal
 with
@@ -106,7 +106,7 @@ with
         match x with
         | VirtualAppliance -> "VirtualAppliance"
         | Internet -> "Internet"
-        | None -> "None"
+        | Nothing -> "None"
         | VirtualNetworkGateway -> "VirtualNetworkGateway"
         | VnetLocal -> "VnetLocal"
     

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -5,6 +5,7 @@ open System.Net.Mail
 open Farmer
 open Farmer.Arm
 open Farmer.ExpressRoute
+open Farmer.Route
 open Farmer.VirtualNetworkGateway
 
 let connections = ResourceType("Microsoft.Network/connections", "2020-04-01")
@@ -99,7 +100,6 @@ type Route =
         Name: ResourceName
         AddressPrefix: IPAddressCidr
         NextHopType: Route.HopType
-        NextHopIpAddress: System.Net.IPAddress option
         HasBgpOverride: FeatureFlag
     }
 
@@ -108,9 +108,12 @@ type Route =
             addressPrefix = IPAddressCidr.format this.AddressPrefix
             nextHopType = this.NextHopType.ArmValue
             nextHopIpAddress =
-                this.NextHopIpAddress
-                |> Option.map (fun x -> x.ToString())
-                |> Option.defaultValue Unchecked.defaultof<_>
+                match this.NextHopType with
+                | VirtualAppliance ip ->
+                    ip
+                    |> Option.map (fun x -> x.ToString())
+                    |> Option.defaultValue Unchecked.defaultof<_>
+                | _ -> Unchecked.defaultof<_>
             hasBgpOverride = this.HasBgpOverride.AsBoolean
         |}
 
@@ -610,6 +613,7 @@ type NetworkInterface =
                                                         .Eval()
                                             |}
                                     |}
+
 
 
 

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -101,14 +101,14 @@ type Route =
         Name: ResourceName
         AddressPrefix: IPAddressCidr
         NextHopType: Route.HopType
-        NextHopIpAddress: IPAddressCidr
+        NextHopIpAddress: System.Net.IPAddress
         HasBgpOverride: FeatureFlag
     }
     member internal this.JsonModelProperties =
         {|
             addressPrefix = IPAddressCidr.format this.AddressPrefix
             nextHopType = this.NextHopType.ArmValue
-            nextHopIpAddress = IPAddressCidr.format this.NextHopIpAddress
+            nextHopIpAddress = this.NextHopIpAddress.ToString()
             hasBgpOverride = this.HasBgpOverride.AsBoolean
         |}
     interface IArmResource with

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -97,10 +97,18 @@ type SubnetReference =
 
 type HopType =
     | VirtualAppliance
+    | Internet
+    | None
+    | VirtualNetworkGateway
+    | VnetLocal
 with
     member x.ArmValue =
         match x with
         | VirtualAppliance -> "VirtualAppliance"
+        | Internet -> "Internet"
+        | None -> "None"
+        | VirtualNetworkGateway -> "VirtualNetworkGateway"
+        | VnetLocal -> "VnetLocal"
     
 type Route =
     {
@@ -112,9 +120,9 @@ type Route =
     }
     member internal this.JsonModelProperties =
         {|
-            addressPrefix = this.AddressPrefix
+            addressPrefix = IPAddressCidr.format this.AddressPrefix
             nextHopType = this.NextHopType
-            nextHopIpAddress = this.NextHopIpAddress
+            nextHopIpAddress = IPAddressCidr.format this.NextHopIpAddress
             hasBgpOverride = this.HasBgpOverride
         |}
     interface IArmResource with

--- a/src/Farmer/Builders/Builders.RouteTable.fs
+++ b/src/Farmer/Builders/Builders.RouteTable.fs
@@ -29,8 +29,8 @@ type RouteTableConfig =
             let routes: Network.Route list =
                 this.Routes |> List.map
                     (fun r ->
-                        if Option.isNone r.AddressPrefix then raiseFarmer("need address prefix")
-                        if Option.isNone r.NextHopIpAddress then raiseFarmer("need address prefix")
+                        if Option.isNone r.AddressPrefix then raiseFarmer("address prefix is required")
+                        if Option.isNone r.NextHopIpAddress then raiseFarmer("next hop ip address is required")
                         {
                             Name = r.Name
                             AddressPrefix = r.AddressPrefix.Value
@@ -66,6 +66,7 @@ type RouteTableBuilder() =
         { state with
             Routes =  routeConfigs @ state.Routes
         }
+let routeTable = RouteTableBuilder()
 
 type RouteBuilder() =
     member _.Yield _ =
@@ -89,3 +90,5 @@ type RouteBuilder() =
     member _.NextHopIpAddress(state: RouteConfig, ip: string) = { state with NextHopIpAddress = Some (IPAddressCidr.parse ip) }
     [<CustomOperation "hasBgpOverride">]
     member _.HasBgpOverride(state: RouteConfig, flag: bool) = { state with HasBgpOverride = Some( FeatureFlag.ofBool flag) }
+
+let route = RouteBuilder()

--- a/src/Farmer/Builders/Builders.RouteTable.fs
+++ b/src/Farmer/Builders/Builders.RouteTable.fs
@@ -10,7 +10,6 @@ type RouteConfig =
         Name: ResourceName
         AddressPrefix: IPAddressCidr option
         NextHopType: Route.HopType
-        NextHopIpAddress: System.Net.IPAddress option
         HasBgpOverride: FeatureFlag option
     }
 
@@ -36,7 +35,6 @@ type RouteTableConfig =
                             Name = r.Name
                             AddressPrefix = addressPrefix
                             NextHopType = r.NextHopType
-                            NextHopIpAddress = r.NextHopIpAddress
                             HasBgpOverride = r.HasBgpOverride |> Option.defaultValue FeatureFlag.Disabled
                         })
 
@@ -84,7 +82,6 @@ type RouteBuilder() =
             Name = ResourceName.Empty
             AddressPrefix = None
             NextHopType = Route.HopType.Nothing
-            NextHopIpAddress = None
             HasBgpOverride = None
         }
 
@@ -105,12 +102,12 @@ type RouteBuilder() =
     [<CustomOperation "nextHopIpAddress">]
     member _.NextHopIpAddress(state: RouteConfig, ip: System.Net.IPAddress) =
         { state with
-            NextHopIpAddress = Some ip
+            NextHopType = VirtualAppliance(Some ip)
         }
 
     member _.NextHopIpAddress(state: RouteConfig, ip: string) =
         { state with
-            NextHopIpAddress = Some(System.Net.IPAddress.Parse ip)
+            NextHopType = VirtualAppliance(Some(System.Net.IPAddress.Parse ip))
         }
 
     [<CustomOperation "hasBgpOverride">]

--- a/src/Farmer/Builders/Builders.RouteTable.fs
+++ b/src/Farmer/Builders/Builders.RouteTable.fs
@@ -29,16 +29,14 @@ type RouteTableConfig =
             let routes: Network.Route list =
                 this.Routes |> List.map
                     (fun r ->
-                        match r.AddressPrefix, r.NextHopIpAddress with
-                        | None, None -> raiseFarmer ("address prefix and next hop ip address are required")
-                        | None, _ -> raiseFarmer("address prefix is required")
-                        | _, None -> raiseFarmer ("next hop ip address is required")
-                        | Some addressPrefix, Some nextHopIp ->
+                        match r.AddressPrefix with
+                        | None -> raiseFarmer("address prefix is required")
+                        | Some addressPrefix ->
                             {
                                 Name = r.Name
                                 AddressPrefix = addressPrefix
                                 NextHopType = r.NextHopType
-                                NextHopIpAddress = nextHopIp
+                                NextHopIpAddress = r.NextHopIpAddress
                                 HasBgpOverride = r.HasBgpOverride |> Option.defaultValue FeatureFlag.Disabled
                     })
             let routeTable: Network.RouteTable =

--- a/src/Farmer/Builders/Builders.RouteTable.fs
+++ b/src/Farmer/Builders/Builders.RouteTable.fs
@@ -96,31 +96,3 @@ type RouteBuilder() =
     
 let route =
     RouteBuilder()
-    
-let myRoute =
-    route {
-        name "myroute"
-        addressPrefix "10.0.0.0/26"
-        nextHopType HopType.Internet
-        nextHopIpAddress "10.0.0.0/26"
-    }
-       
-let myRouteTable =
-    routeTable {
-        name "myroutetable"
-        add_routes [
-            route {
-                name "myroute"
-                addressPrefix "10.0.0.0/26"
-                nextHopType HopType.Internet
-                nextHopIpAddress "10.0.0.0/26"
-            }
-            route {
-                name "myroute2"
-                addressPrefix "10.0.0.0/26"
-                nextHopType HopType.Internet
-                nextHopIpAddress "10.0.0.0/26"
-            }
-        ]
-    }
-   

--- a/src/Farmer/Builders/Builders.RouteTable.fs
+++ b/src/Farmer/Builders/Builders.RouteTable.fs
@@ -5,7 +5,6 @@ open Farmer
 open Farmer.Arm
 open Farmer.Route
 
-// todo: can we default next hop type?
 type RouteConfig =
     {
         Name: ResourceName
@@ -67,9 +66,6 @@ type RouteTableBuilder() =
         { state with
             Routes =  routeConfigs @ state.Routes
         }
-    
-
-let routeTable = RouteTableBuilder()
 
 type RouteBuilder() =
     member _.Yield _ =
@@ -93,6 +89,3 @@ type RouteBuilder() =
     member _.NextHopIpAddress(state: RouteConfig, ip: string) = { state with NextHopIpAddress = Some (IPAddressCidr.parse ip) }
     [<CustomOperation "hasBgpOverride">]
     member _.HasBgpOverride(state: RouteConfig, flag: bool) = { state with HasBgpOverride = Some( FeatureFlag.ofBool flag) }
-    
-let route =
-    RouteBuilder()

--- a/src/Farmer/Builders/Builders.RouteTable.fs
+++ b/src/Farmer/Builders/Builders.RouteTable.fs
@@ -1,0 +1,81 @@
+﻿[<AutoOpen>]
+module Farmer.Builders.RouteTable
+
+open Farmer
+open Farmer.Arm
+
+type RouteConfig =
+    {
+        Name: ResourceName
+        AddressPrefix: IPAddressCidr
+        NextHopType: HopType
+        NextHopIpAddress: IPAddressCidr
+        HasBgpOverride: FeatureFlag
+    }
+
+type RouteTableConfig =
+    {
+        Name: ResourceName
+        DisableBGPRoutePropagation: FeatureFlag 
+        Routes: Network.Route list
+        Tags: Map<string, string>
+    }
+
+    interface IBuilder with
+        member this.ResourceId = routeTables.resourceId this.Name
+
+        member this.BuildResources location =
+            [
+                {
+                    RouteTable.Name = this.Name
+                    Location = location
+                    DisableBGPRoutePropagation = this.DisableBGPRoutePropagation.AsBoolean
+                    Routes = this.Routes
+                    Tags = this.Tags
+                }
+            ]
+
+type RouteTableBuilder() =
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            Tags = Map.empty
+        }
+
+    [<CustomOperation "name">]
+    member _.Name(state: RouteTableConfig, name: string) = { state with Name = ResourceName name }
+    [<CustomOperation "disableBgpRoutePropagation">]
+    member _.DisableBGPRoutePropagation(state: RouteTableConfig, flag: bool) = { state with DisableBGPRoutePropagation = FeatureFlag.ofBool flag }
+    [<CustomOperation "add_route">]
+    member _.AddRoute(state: RouteTableConfig, routeConfig: RouteConfig) =
+        let route: Network.Route = {
+            Name = routeConfig.Name
+            AddressPrefix = routeConfig.AddressPrefix
+            NextHopType = routeConfig.NextHopType
+            NextHopIpAddress = routeConfig.NextHopIpAddress
+            HasBgpOverride = routeConfig.HasBgpOverride.AsBoolean
+        }
+        { state with
+            Routes =  [route] @ state.Routes
+        }
+    
+
+let routeTable = RouteTableBuilder()
+
+type RouteBuilder() =
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            Tags = Map.empty
+        }
+
+    [<CustomOperation "name">]
+    member _.Name(state: RouteConfig, name: string) = { state with Name = ResourceName name }
+    [<CustomOperation "addressPrefix">]
+    member _.AddressPrefix(state: RouteConfig, ip: IPAddressCidr) = { state with AddressPrefix = ip }
+    [<CustomOperation "nextHopType">]
+    member _.NextHopType(state: RouteConfig, ht: HopType) = { state with NextHopType = ht }
+    [<CustomOperation "nextHopIpAddress">]
+    member _.NextHopIpAddress(state: RouteConfig, ip: IPAddressCidr) = { state with NextHopIpAddress = ip }
+    [<CustomOperation "hasBgpOverride">]
+    member _.HasBgpOverride(state: RouteConfig, flag: FeatureFlag) = { state with HasBgpOverride = flag }

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -153,7 +153,7 @@ module Mb =
 
 module Route =
     type HopType =
-        | VirtualAppliance
+        | VirtualAppliance of System.Net.IPAddress option
         | Internet
         | Nothing
         | VirtualNetworkGateway
@@ -161,7 +161,7 @@ module Route =
 
         member x.ArmValue =
             match x with
-            | VirtualAppliance -> "VirtualAppliance"
+            | VirtualAppliance _ -> "VirtualAppliance"
             | Internet -> "Internet"
             | Nothing -> "None"
             | VirtualNetworkGateway -> "VirtualNetworkGateway"

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -153,12 +153,12 @@ module Mb =
 
 module Route =
     type HopType =
-    | VirtualAppliance
-    | Internet
-    | Nothing
-    | VirtualNetworkGateway
-    | VnetLocal
-    with
+        | VirtualAppliance
+        | Internet
+        | Nothing
+        | VirtualNetworkGateway
+        | VnetLocal
+
         member x.ArmValue =
             match x with
             | VirtualAppliance -> "VirtualAppliance"

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -151,6 +151,22 @@ type EnvVar =
 module Mb =
     let toBytes (mb: int<Mb>) = int64 mb * 1024L * 1024L
 
+module Route =
+    type HopType =
+    | VirtualAppliance
+    | Internet
+    | Nothing
+    | VirtualNetworkGateway
+    | VnetLocal
+    with
+        member x.ArmValue =
+            match x with
+            | VirtualAppliance -> "VirtualAppliance"
+            | Internet -> "Internet"
+            | Nothing -> "None"
+            | VirtualNetworkGateway -> "VirtualNetworkGateway"
+            | VnetLocal -> "VnetLocal"
+
 module Vm =
     type VMSize =
         | Basic_A0

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -170,6 +170,7 @@
     <Compile Include="Builders/Builders.OperationsManagement.fs" />
     <Compile Include="Builders\Builders.PrivateLink.fs" />
     <Compile Include="Builders\Builders.PrivateEndpoint.fs" />
+    <Compile Include="Builders\Builders.RouteTable.fs" />
     <Compile Include="Aliases.fs" />
   </ItemGroup>
 </Project>

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -77,6 +77,7 @@
     <Compile Include="Arm/CommunicationServices.fs" />
     <Compile Include="Arm/BingSearch.fs" />
     <Compile Include="Arm/Dns.fs" />
+    <Compile Include="Arm\AVS.fs" />
     <Compile Include="Arm/Network.fs" />
     <Compile Include="Arm/Bastion.fs" />
     <Compile Include="Arm/Compute.fs" />

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -675,22 +675,21 @@ let tests =
                                     add_routes [
                                         route {
                                             name "myroute"
-                                            addressPrefix "10.0.0.0/26"
+                                            addressPrefix "10.10.90.0/24"
                                             nextHopType Route.HopType.VirtualAppliance
-                                            nextHopIpAddress "10.0.0.0/26"
+                                            nextHopIpAddress "10.10.67.5"
                                         }
                                         route {
                                             name "myroute2"
-                                            addressPrefix "10.0.0.0/26"
-                                            nextHopType Route.HopType.Internet
-                                            nextHopIpAddress "10.0.0.1/26"
+                                            addressPrefix "10.10.80.0/24"
+                                            nextHopType Route.HopType.VirtualAppliance
+                                            nextHopIpAddress "10.10.67.5"
                                         }
                                     ]
                                 }
                             ]
                     }
                 let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
-                printfn $"{(deployment.Template |> Writer.toJson |> string)}"
 
                 let routeTable =
                     jobj.SelectToken "resources[?(@.type=='Microsoft.Network/routeTables')]"
@@ -705,8 +704,8 @@ let tests =
                 let routeProps = routes.[0].["properties"]
                 let route2Props = routes.[1].["properties"] 
                 Expect.equal (string routeProps.["nextHopType"]) "VirtualAppliance" "route 1 should have a hop type of 'VirtualAppliance'"
-                Expect.equal (string routeProps.["addressPrefix"]) "10.0.0.0/26" "route 1 should have an address prefix of '10.0.0.0/26'"
-                Expect.equal (string route2Props.["nextHopIpAddress"]) "10.0.0.1/26" "route 2 should have a next hop ip address of '10.0.0.1/26"
+                Expect.equal (string routeProps.["addressPrefix"]) "10.10.90.0/24" "route 1 should have an address prefix of '10.10.90.0/24'"
+                Expect.equal (string route2Props.["nextHopIpAddress"]) "10.10.67.5" "route 2 should have a next hop ip address of '10.10.67.5'"
             }
             test "Create private endpoint" {
                 let myNet =

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -682,14 +682,13 @@ let tests =
                                         route {
                                             name "myroute2"
                                             addressPrefix "10.10.80.0/24"
-                                            nextHopType Route.HopType.VirtualAppliance
-                                            nextHopIpAddress "10.10.67.5"
                                         }
                                     ]
                                 }
                             ]
                     }
                 let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+                let a = jobj.ToString()
 
                 let routeTable =
                     jobj.SelectToken "resources[?(@.type=='Microsoft.Network/routeTables')]"
@@ -705,7 +704,8 @@ let tests =
                 let route2Props = routes.[1].["properties"] 
                 Expect.equal (string routeProps.["nextHopType"]) "VirtualAppliance" "route 1 should have a hop type of 'VirtualAppliance'"
                 Expect.equal (string routeProps.["addressPrefix"]) "10.10.90.0/24" "route 1 should have an address prefix of '10.10.90.0/24'"
-                Expect.equal (string route2Props.["nextHopIpAddress"]) "10.10.67.5" "route 2 should have a next hop ip address of '10.10.67.5'"
+                Expect.isNull route2Props.["nextHopIpAddress"] "route 2 should not have a next hop ip address"
+                Expect.equal (string route2Props.["nextHopType"]) "None" "route 2 should have the default set to None for nextHopType"
             }
             test "Create private endpoint" {
                 let myNet =

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -679,12 +679,26 @@ let tests =
                                             route {
                                                 name "myroute"
                                                 addressPrefix "10.10.90.0/24"
-                                                nextHopType Route.HopType.VirtualAppliance
                                                 nextHopIpAddress "10.10.67.5"
                                             }
                                             route {
                                                 name "myroute2"
                                                 addressPrefix "10.10.80.0/24"
+                                            }
+                                            route {
+                                                name "myroute3"
+                                                addressPrefix "10.2.31.0/24"
+                                                nextHopType (Route.HopType.VirtualAppliance None)
+                                            }
+                                            route {
+                                                name "myroute4"
+                                                addressPrefix "10.2.31.0/24"
+
+                                                nextHopType (
+                                                    Route.HopType.VirtualAppliance(
+                                                        Some(System.Net.IPAddress.Parse "10.2.31.2")
+                                                    )
+                                                )
                                             }
                                         ]
                                 }
@@ -709,6 +723,8 @@ let tests =
                 Expect.equal (string routes.[1].["name"]) "myroute2" "route 2 should be named 'myroute2'"
                 let routeProps = routes.[0].["properties"]
                 let route2Props = routes.[1].["properties"]
+                let route3Props = routes.[2].["properties"]
+                let route4Props = routes.[3].["properties"]
 
                 Expect.equal
                     (string routeProps.["nextHopType"])
@@ -721,11 +737,17 @@ let tests =
                     "route 1 should have an address prefix of '10.10.90.0/24'"
 
                 Expect.isNull route2Props.["nextHopIpAddress"] "route 2 should not have a next hop ip address"
+                Expect.isNull route3Props.["nextHopIpAddress"] "route 3 should not have a next hop ip address"
 
                 Expect.equal
                     (string route2Props.["nextHopType"])
                     "None"
                     "route 2 should have the default set to None for nextHopType"
+
+                Expect.equal
+                    (string route4Props.["nextHopIpAddress"])
+                    "10.2.31.2"
+                    "route 4 should have the next hop ip address set to 10.2.31.2"
             }
             test "Create private endpoint" {
                 let myNet =

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -668,25 +668,29 @@ let tests =
                 let deployment =
                     arm {
                         location Location.EastUS
+
                         add_resources
                             [
                                 routeTable {
                                     name "myroutetable"
-                                    add_routes [
-                                        route {
-                                            name "myroute"
-                                            addressPrefix "10.10.90.0/24"
-                                            nextHopType Route.HopType.VirtualAppliance
-                                            nextHopIpAddress "10.10.67.5"
-                                        }
-                                        route {
-                                            name "myroute2"
-                                            addressPrefix "10.10.80.0/24"
-                                        }
-                                    ]
+
+                                    add_routes
+                                        [
+                                            route {
+                                                name "myroute"
+                                                addressPrefix "10.10.90.0/24"
+                                                nextHopType Route.HopType.VirtualAppliance
+                                                nextHopIpAddress "10.10.67.5"
+                                            }
+                                            route {
+                                                name "myroute2"
+                                                addressPrefix "10.10.80.0/24"
+                                            }
+                                        ]
                                 }
                             ]
                     }
+
                 let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
                 let a = jobj.ToString()
 
@@ -694,18 +698,34 @@ let tests =
                     jobj.SelectToken "resources[?(@.type=='Microsoft.Network/routeTables')]"
 
                 let routeTableProps = routeTable.["properties"]
-                let disableBgp: bool = JToken.op_Explicit routeTableProps.["disableBgpRoutePropagation"]
+
+                let disableBgp: bool =
+                    JToken.op_Explicit routeTableProps.["disableBgpRoutePropagation"]
+
                 Expect.equal disableBgp false "Incorrect default value for disableBgpRoutePropagation"
                 let routes = routeTableProps.["routes"] :?> JArray
                 Expect.isNotNull routes "Routes should have been generated for the route table"
                 Expect.equal (string routes.[0].["name"]) "myroute" "route 1 should be named 'myroute'"
                 Expect.equal (string routes.[1].["name"]) "myroute2" "route 2 should be named 'myroute2'"
                 let routeProps = routes.[0].["properties"]
-                let route2Props = routes.[1].["properties"] 
-                Expect.equal (string routeProps.["nextHopType"]) "VirtualAppliance" "route 1 should have a hop type of 'VirtualAppliance'"
-                Expect.equal (string routeProps.["addressPrefix"]) "10.10.90.0/24" "route 1 should have an address prefix of '10.10.90.0/24'"
+                let route2Props = routes.[1].["properties"]
+
+                Expect.equal
+                    (string routeProps.["nextHopType"])
+                    "VirtualAppliance"
+                    "route 1 should have a hop type of 'VirtualAppliance'"
+
+                Expect.equal
+                    (string routeProps.["addressPrefix"])
+                    "10.10.90.0/24"
+                    "route 1 should have an address prefix of '10.10.90.0/24'"
+
                 Expect.isNull route2Props.["nextHopIpAddress"] "route 2 should not have a next hop ip address"
-                Expect.equal (string route2Props.["nextHopType"]) "None" "route 2 should have the default set to None for nextHopType"
+
+                Expect.equal
+                    (string route2Props.["nextHopType"])
+                    "None"
+                    "route 2 should have the default set to None for nextHopType"
             }
             test "Create private endpoint" {
                 let myNet =


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Adding support for route tables
* Adding support for routes

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x ] **Tested my code** end-to-end against a live Azure subscription.
* [x ] **Updated the documentation** in the docs folder for the affected changes.
* [ x] **Written unit tests** against the modified code that I have made.
* [ x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let deployment =
                    arm {
                        location Location.EastUS
                        add_resources
                            [
                                routeTable {
                                    name "myroutetable"
                                    add_routes [
                                        route {
                                            name "myroute"
                                            addressPrefix "10.10.90.0/24"
                                            nextHopType Route.HopType.VirtualAppliance
                                            nextHopIpAddress "10.10.67.5"
                                        }
                                        route {
                                            name "myroute2"
                                            addressPrefix "10.10.80.0/24"
                                        }
                                    ]
                                }
                            ]
                    }

```

