### PR TITLE
ACR Managed Identity Support for Container Groups and Container Apps

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.7.9
+* Container Group: Support for Managed Identity
+* Container App: Support for Managed Identity
 
 ## 1.7.8
 * Route Tables: Initial support for Route Tables and Routes

--- a/docs/content/api-overview/resources/container-apps.md
+++ b/docs/content/api-overview/resources/container-apps.md
@@ -45,6 +45,7 @@ The Container Apps builder (`containerApp`) is used to define one or more contai
 | active_revision_mode | Indicates whether multiple version of a container app can be active at once.|
 | add_registry_credentials | Adds container image registry credentials for images in this container app, which are a list of server and usernames. Passwords are supplied as secure parameters. |
 | reference_registry_credentials | Adds container image registry credentials for images in this container app in the form of a list of Azure resource ids. |
+| add_managed_identity_registry_credentials | Adds container app registry managed identity credentials for images in this container app, which are a list of server and identities. |
 | add_containers | Adds a list of containers to this container app. All containers in the app share resources and scaling. |
 | add_simple_container | Adds a single container that references a public docker image and version. |
 | add_secret_parameter | Adds an application secret to the entire container app. This is passed as a secure parameter to the template, and an environment variable is automatically created which references the secret. |

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -30,6 +30,7 @@ The Container Group builder (`containerGroup`) defines a Container Group.
 | system_identity | Activates the system identity of the container group. |
 | add_registry_credentials | Adds a container image registry credential with a secure parameter for the password. |
 | reference_registry_credentials | References credentials from a container image registry by resource ID. |
+| add_managed_identity_registry_credentials | Adds container image registry managed identity credentials for images in this container group. |
 | add_tcp_port | Adds a TCP port to be externally accessible. |
 | add_udp_port | Adds a UDP port to be externally accessible. |
 | add_volumes | Adds volumes to a container group so they are accessible to containers. |
@@ -151,6 +152,7 @@ let containerGroupUser = userAssignedIdentity {
 }
 
 let containerGroupLoggingWorkspace = logAnalytics { name "webapplogs" }
+let managedIdentity = ManagedIdentity.Empty
 
 let group = containerGroup {
     name "webApp"
@@ -162,7 +164,7 @@ let group = containerGroup {
     add_instances [ nginx ]
     // Add registry credentials as a secure password
     add_registry_credentials [
-        registry "mygregistry.azurecr.io" "registryuser"
+        registry "mygregistry.azurecr.io" "registryuser" managedIdentity
     ]
     // or reference an Azure container registry to pull the credentials directly.
     reference_registry_credentials [

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -189,6 +189,7 @@ type ContainerApp =
                                                     server = cred.Server
                                                     username = cred.Username
                                                     passwordSecretRef = cred.Username
+                                                    identity = null
                                                 |}
                                             | ImageRegistryAuthentication.ListCredentials resourceId ->
                                                 {|
@@ -200,12 +201,14 @@ type ContainerApp =
                                                             )
                                                             .Eval()
                                                     passwordSecretRef = usernameSecretName resourceId
+                                                    identity = null
                                                 |}
                                             | ImageRegistryAuthentication.ManagedIdentityCredential cred ->
                                                 {|
                                                     server = cred.Server
-                                                    username = null
-                                                    passwordSecretRef = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
+                                                    username = String.Empty
+                                                    passwordSecretRef = null
+                                                    identity = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
                                                 |}
                                     |]
                                 ingress =

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -167,7 +167,12 @@ type ContainerApp =
                                             | ImageRegistryAuthentication.ManagedIdentityCredential cred ->
                                                 {|
                                                     name = cred.Server
-                                                    value = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
+                                                    value =
+                                                        if cred.Identity.Dependencies.Length > 0 then
+                                                            cred.Identity.Dependencies.Head.ArmExpression.Eval()
+                                                        else
+                                                            String.Empty
+
 
                                                 |}
                                         for setting in this.Secrets do
@@ -208,7 +213,11 @@ type ContainerApp =
                                                     server = cred.Server
                                                     username = String.Empty
                                                     passwordSecretRef = null
-                                                    identity = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
+                                                    identity =
+                                                        if cred.Identity.Dependencies.Length > 0 then
+                                                            cred.Identity.Dependencies.Head.ArmExpression.Eval()
+                                                        else
+                                                            String.Empty
                                                 |}
                                     |]
                                 ingress =

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -1,6 +1,7 @@
 [<AutoOpen>]
 module Farmer.Arm.App
 
+open System
 open Farmer.ContainerApp
 open Farmer.Identity
 open Farmer
@@ -122,6 +123,8 @@ type ContainerApp =
                     match credential with
                     | ImageRegistryAuthentication.Credential credential -> credential.Password
                     | ImageRegistryAuthentication.ListCredentials _ -> ()
+                    | ImageRegistryAuthentication.ManagedIdentityCredential _ -> ()
+
             ]
 
     interface IArmResource with
@@ -161,6 +164,12 @@ type ContainerApp =
                                                             )
                                                             .Eval()
                                                 |}
+                                            | ImageRegistryAuthentication.ManagedIdentityCredential cred ->
+                                                {|
+                                                    name = cred.Server
+                                                    value = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
+
+                                                |}
                                         for setting in this.Secrets do
                                             {|
                                                 name = setting.Key.Value
@@ -191,6 +200,12 @@ type ContainerApp =
                                                             )
                                                             .Eval()
                                                     passwordSecretRef = usernameSecretName resourceId
+                                                |}
+                                            | ImageRegistryAuthentication.ManagedIdentityCredential cred ->
+                                                {|
+                                                    server = cred.Server
+                                                    username = null
+                                                    passwordSecretRef = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
                                                 |}
                                     |]
                                 ingress =

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -395,7 +395,11 @@ type ContainerGroup =
                                         server = cred.Server
                                         username = String.Empty
                                         password = null
-                                        identity = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
+                                        identity =
+                                            if cred.Identity.Dependencies.Length > 0 then
+                                                cred.Identity.Dependencies.Head.ArmExpression.Eval()
+                                            else
+                                                String.Empty
                                     |})
                         ipAddress =
                             match this.IpAddress with

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -393,7 +393,7 @@ type ContainerGroup =
                                 | ImageRegistryAuthentication.ManagedIdentityCredential cred ->
                                     {|
                                         server = cred.Server
-                                        username = String.Empty
+                                        username = null
                                         password = null
                                         identity = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
                                     |})

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -207,6 +207,7 @@ type ContainerGroup =
                     match credential with
                     | ImageRegistryAuthentication.Credential credential -> credential.Password
                     | ImageRegistryAuthentication.ListCredentials _ -> ()
+                    | ImageRegistryAuthentication.ManagedIdentityCredential _ -> ()
                 for container in this.ContainerInstances do
                     for envVar in container.EnvironmentVariables do
                         match envVar.Value with
@@ -365,6 +366,7 @@ type ContainerGroup =
                                         server = cred.Server
                                         username = cred.Username
                                         password = cred.Password.ArmExpression.Eval()
+                                        identity = null
                                     |}
                                 | ImageRegistryAuthentication.ListCredentials resourceId ->
                                     {|
@@ -386,6 +388,14 @@ type ContainerGroup =
                                                     $"listCredentials({resourceId.ArmExpression.Value}, '2019-05-01').passwords[0].value"
                                                 )
                                                 .Eval()
+                                        identity = null
+                                    |}
+                                | ImageRegistryAuthentication.ManagedIdentityCredential cred ->
+                                    {|
+                                        server = cred.Server
+                                        username = String.Empty
+                                        password = null
+                                        identity = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
                                     |})
                         ipAddress =
                             match this.IpAddress with

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -393,7 +393,7 @@ type ContainerGroup =
                                 | ImageRegistryAuthentication.ManagedIdentityCredential cred ->
                                     {|
                                         server = cred.Server
-                                        username = null
+                                        username = String.Empty
                                         password = null
                                         identity = if cred.Identity.Dependencies.Length > 0 then cred.Identity.Dependencies.Head.ArmExpression.Eval() else String.Empty
                                     |})

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -409,6 +409,15 @@ type ContainerAppBuilder() =
                 @ (resourceIds |> List.map ImageRegistryAuthentication.ListCredentials)
         }
 
+    /// Adds container app registry managed identity credentials for images in this container app.
+    [<CustomOperation "add_managed_identity_registry_credentials">]
+    member _.ManagedIdentityRegistryCredentials(state: ContainerAppConfig, credentials) =
+        { state with
+            ImageRegistryCredentials =
+                state.ImageRegistryCredentials
+                @ (credentials |> List.map ImageRegistryAuthentication.ManagedIdentityCredential)
+        }
+
     /// Adds one or more containers to the container app.
     [<CustomOperation "add_containers">]
     member _.AddContainers(state: ContainerAppConfig, containers: ContainerConfig list) =

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -453,14 +453,14 @@ type ContainerGroupBuilder() =
                 state.ImageRegistryCredentials
                 @ (resourceIds |> List.map ImageRegistryAuthentication.ListCredentials)
         }
-        
+
     /// Adds container image registry managed identity credentials for images in this container group.
     [<CustomOperation "add_managed_identity_registry_credentials">]
-    member _.ManagedIdentityRegistryCredentials(state: ContainerGroupConfig, resourceIds) =
+    member _.ManagedIdentityRegistryCredentials(state: ContainerGroupConfig, credentials) =
         { state with
             ImageRegistryCredentials =
                 state.ImageRegistryCredentials
-                @ (resourceIds |> List.map ImageRegistryAuthentication.ManagedIdentityCredential)
+                @ (credentials |> List.map ImageRegistryAuthentication.ManagedIdentityCredential)
         }
 
     /// Adds a collection of init containers to this group that run once on startup before other containers in the group.

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -2,6 +2,7 @@
 module Farmer.Builders.ContainerGroups
 
 open Farmer
+open Farmer.Arm
 open Farmer.Builders
 open Farmer.ContainerGroup
 open Farmer.Identity
@@ -452,7 +453,15 @@ type ContainerGroupBuilder() =
                 state.ImageRegistryCredentials
                 @ (resourceIds |> List.map ImageRegistryAuthentication.ListCredentials)
         }
-
+        
+    /// Adds container image registry managed identity credentials for images in this container group.
+    [<CustomOperation "add_managed_identity_registry_credentials">]
+    member _.ManagedIdentityRegistryCredentials(state: ContainerGroupConfig, resourceIds) =
+        { state with
+            ImageRegistryCredentials =
+                state.ImageRegistryCredentials
+                @ (resourceIds |> List.map ImageRegistryAuthentication.ManagedIdentityCredential)
+        }
     /// Adds a collection of init containers to this group that run once on startup before other containers in the group.
     [<CustomOperation "add_init_containers">]
     member _.AddInitContainers(state: ContainerGroupConfig, initContainers) =
@@ -610,11 +619,12 @@ type ContainerGroupBuilder() =
             }
 
 /// Creates an image registry credential with a generated SecureParameter for the password.
-let registry (server: string) (username: string) =
+let registry (server: string) (username: string) (managedIdentity: ManagedIdentity) =
     {
         Server = server
         Username = username
         Password = SecureParameter $"{server}-password"
+        Identity = managedIdentity
     }
 
 type ContainerInstanceBuilder() =

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -462,6 +462,7 @@ type ContainerGroupBuilder() =
                 state.ImageRegistryCredentials
                 @ (resourceIds |> List.map ImageRegistryAuthentication.ManagedIdentityCredential)
         }
+
     /// Adds a collection of init containers to this group that run once on startup before other containers in the group.
     [<CustomOperation "add_init_containers">]
     member _.AddInitContainers(state: ContainerGroupConfig, initContainers) =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1892,6 +1892,8 @@ module Identity =
                 UserAssigned = userAssignedIdentity :: managedIdentity.UserAssigned
             }
 
+open Identity
+
 module Containers =
     type DockerImage =
         | PrivateImage of RegistryDomain: string * ContainerName: string * Version: string option
@@ -1927,6 +1929,7 @@ type ImageRegistryCredential =
         Server: string
         Username: string
         Password: SecureParameter
+        Identity: ManagedIdentity
     }
 
 [<RequireQualifiedAccess>]
@@ -1935,6 +1938,8 @@ type ImageRegistryAuthentication =
     | Credential of ImageRegistryCredential
     /// Credentials for the container registry will be listed by ARM expression.
     | ListCredentials of ResourceId
+    /// Credentials for the container registry are included with the identity as a template parameter.    
+    | ManagedIdentityCredential of ImageRegistryCredential      
 
 [<RequireQualifiedAccess>]
 type LogAnalyticsWorkspace =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1938,8 +1938,8 @@ type ImageRegistryAuthentication =
     | Credential of ImageRegistryCredential
     /// Credentials for the container registry will be listed by ARM expression.
     | ListCredentials of ResourceId
-    /// Credentials for the container registry are included with the identity as a template parameter.    
-    | ManagedIdentityCredential of ImageRegistryCredential      
+    /// Credentials for the container registry are included with the identity as a template parameter.
+    | ManagedIdentityCredential of ImageRegistryCredential
 
 [<RequireQualifiedAccess>]
 type LogAnalyticsWorkspace =

--- a/src/Tests/ContainerApps.fs
+++ b/src/Tests/ContainerApps.fs
@@ -24,6 +24,7 @@ let fullContainerAppDeployment =
 
     let version = "1.0.0"
     let managedIdentity = ManagedIdentity.Empty
+
     let containerEnv =
         containerEnvironment {
             name "kubecontainerenv"
@@ -35,7 +36,9 @@ let fullContainerAppDeployment =
                         name "http"
                         add_identity msi
                         active_revision_mode Single
-                        add_registry_credentials [ registry containerRegistryDomain containerRegistryName managedIdentity ]
+
+                        add_registry_credentials
+                            [ registry containerRegistryDomain containerRegistryName managedIdentity ]
 
                         add_containers
                             [

--- a/src/Tests/ContainerApps.fs
+++ b/src/Tests/ContainerApps.fs
@@ -23,7 +23,7 @@ let fullContainerAppDeployment =
         }
 
     let version = "1.0.0"
-
+    let managedIdentity = ManagedIdentity.Empty
     let containerEnv =
         containerEnvironment {
             name "kubecontainerenv"
@@ -35,7 +35,7 @@ let fullContainerAppDeployment =
                         name "http"
                         add_identity msi
                         active_revision_mode Single
-                        add_registry_credentials [ registry containerRegistryDomain containerRegistryName ]
+                        add_registry_credentials [ registry containerRegistryDomain containerRegistryName managedIdentity ]
 
                         add_containers
                             [

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -314,7 +314,7 @@ let tests =
                 Expect.hasLength group.ImageRegistryCredentials 1 "Expected one image managed identity registry credential"
                 let credentials = group.ImageRegistryCredentials.[0]
                 Expect.equal credentials.Server "my-registry.azurecr.io" "Incorrect container image registry server"
-                Expect.equal credentials.Username null "Container image registry user should be null"
+                Expect.equal credentials.Username String.Empty "Container image registry user should be null"
                 Expect.equal credentials.Identity (managedIdentity.Dependencies.Head.ArmExpression.Eval()) "Incorrect container image registry identity"
                 Expect.equal credentials.Password null "Container image registry password should be null"
             }
@@ -919,16 +919,7 @@ async {
 
                 Expect.equal (string ipConfigName) "ipconfigProfile" "netprofile ipConfiguration has wrong name"
             }
-            // test "Can link a network profile directly to a container group" {
-            //     let profile = networkProfile { name "netprofile" }
-            //
-            //     let template =
-            //         containerGroup {
-            //             name "appWithHttpFrontend"
-            //             network_profile profile
-            //         }
-            //         |> asAzureResource
-            // }
+
             test "Support for additional dependencies" {
                 let storage = storageAccount { name "containerstorage" }
 

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -286,13 +286,27 @@ let tests =
             }
             
             test "Container group with managed identity to private registry" {
+                let userAssignedIdentity =  ResourceId.create (
+                                                Arm.ManagedIdentity.userAssignedIdentities,
+                                                ResourceName "user",
+                                                "resourceGroup"
+                                            )
+                                            |> UserAssignedIdentity
                 let managedIdentity =
                     { ManagedIdentity.Empty with
-                        UserAssigned = [ UserAssignedIdentity(userAssignedIdentities.resourceId "a") ]
+                        UserAssigned = [ userAssignedIdentity ]
                     }
                 let group =
                     containerGroup {
                         add_instances [ nginx ]
+                        add_identity (
+                            ResourceId.create (
+                                Arm.ManagedIdentity.userAssignedIdentities,
+                                ResourceName "user",
+                                "resourceGroup"
+                            )
+                            |> UserAssignedIdentity
+                        )
                         add_managed_identity_registry_credentials [ registry "my-registry.azurecr.io" "user" managedIdentity ]
                     }
                     |> asAzureResource
@@ -300,7 +314,7 @@ let tests =
                 Expect.hasLength group.ImageRegistryCredentials 1 "Expected one image managed identity registry credential"
                 let credentials = group.ImageRegistryCredentials.[0]
                 Expect.equal credentials.Server "my-registry.azurecr.io" "Incorrect container image registry server"
-                Expect.equal credentials.Username String.Empty "Container image registry user should be null"
+                Expect.equal credentials.Username null "Container image registry user should be null"
                 Expect.equal credentials.Identity (managedIdentity.Dependencies.Head.ArmExpression.Eval()) "Incorrect container image registry identity"
                 Expect.equal credentials.Password null "Container image registry password should be null"
             }

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -72,7 +72,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.Management.CognitiveServices" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.Compute" Version="35.2.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ContainerService" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.DeviceProvisioningServices" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="2.10.0-preview" />


### PR DESCRIPTION
This PR closes #976

The changes in this PR are as follows:

* Container Group: Adding Managed Identity Support for ACR image pull.
* Container APP: Adding Managed Identity Support for ACR image pull.
* Updating  Microsoft.Azure.Management.ContainerInstance version from 3.0.0 to 7.0.0 in testing to support new fields in managed identity fields in [ImageRegistryCredentials](https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.management.containerinstance.models.imageregistrycredential.-ctor?view=azure-dotnet#microsoft-azure-management-containerinstance-models-imageregistrycredential-ctor(system-string-system-string-system-string-system-string-system-string))

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let acrIdentity =  ResourceId.create (
                                 Arm.ManagedIdentity.userAssignedIdentities,
                                 ResourceName "msi",
                                 "<msi-resourcegroup>",
                                 "<msi-subscription>"
                             )
                             |> UserAssignedIdentity
let managedIdentity =
    {
        ManagedIdentity.Empty with
        UserAssigned = [ acrIdentity ]
    }
let farmerContainerGroup =
        containerGroup {
            name "farmercontainers"
            add_instances [
                containerInstance {
                    name "suave-script"
                    image "farmercontainers.azurecr.io/fsharpwebapp:1.0.0"
                }
            ]
            add_identity acrIdentity
            add_managed_identity_registry_credentials [ registry "farmercontainers.azurecr.io" "user" managedIdentity ]
            depends_on buildImage
            vnet myVnet
            subnet "msi-subnet"
        }

```
