### PR TITLE
Add ability to associate metadata with Storage Account Queues. Metada…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ Release Notes
 * Network Security Groups: Fix bug where a SecurityRule without a source throws a meaningful exception
 * Network Security Groups: Add rule to existing security group
 * SQL Azure: Adds support for AD admin
+* Storage Account Queues: Support for adding metadata
 
 ## 1.7.24
 * Network Interface: Adds support for network interface creation.
@@ -82,9 +83,6 @@ Release Notes
 ## 1.7.11
 * Dedicated Hosts: Support for Host Groups and Hosts
 * WebApps: Added support for Node 14, 16 and 18
-
-## 1.7.11
-* Storage Account Queues: Support for adding metadata
 
 ## 1.7.10
 * Container Groups and Container Apps: Support for link_to_identity for ACR managed identities.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -83,6 +83,9 @@ Release Notes
 * Dedicated Hosts: Support for Host Groups and Hosts
 * WebApps: Added support for Node 14, 16 and 18
 
+## 1.7.11
+* Storage Account Queues: Support for adding metadata
+
 ## 1.7.10
 * Container Groups and Container Apps: Support for link_to_identity for ACR managed identities.
 

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -28,10 +28,7 @@ The Storage Account builder creates storage accounts and their associated contai
 | add_file_share | Adds a file share to storage account |
 | add_file_share_with_quota | Adds a file share to storage account with a share quota in Gb |
 | add_queue | Adds a queue to the storage account |
-| add_queue_with_metadata | Adds a queue to the storage account with metadata associated with it |
 | add_queues | Adds a list of queues to the storage account |
-| add_queues_with_unique_metadata | Adds a list of queues to the storage account, each with unique metadata associated with them |
-| add_queues_with_same_metadata | Addsa list of queues to the storage account, all with the same set of metadata associated with them |
 | add_table | Adds a table to the storage account |
 | add_tables | Adds a list of tables to the storage account |
 | add_cors_rules | Adds a list of CORS rules to the different storage services |
@@ -51,7 +48,6 @@ The Storage Account builder creates storage accounts and their associated contai
 | disable_shared_key_access | Disables shared key access for the storage account |
 | default_to_oauth_authentication | Defaults to OAuth (AAD) authentication for requests to blobs, queues and containers in the Azure portal |
 | use_azure_dns_zone | Change the DNS Endpoint type from `Standard` to `AzureDnsZone` |
-
 
 #### Configuration Members
 
@@ -83,23 +79,43 @@ let storage = storageAccount {
     add_file_share "share1"
     add_file_share_with_quota "share2" 1024<Gb>
     add_queue "myqueue"
-    add_queue_with_metadata "myqueue2" (Map [
-        ("source", "imageStore")
-    ])
-    add_queues ["myqueue3"; "myqueue4"]
-    add_queues_with_unique_metadata [
-        ("myqueue5", Map [
-            ("source", "imageStore")
-        ])
-        ("myqueue6", Map [
-            ("source", "customerPurchaseStage")
-        ])
+    add_queue (storageQueue {
+      name "queue1"
+      metadata [
+        "environment", "dev"
+        "project", "farmer"
+      ]
+    })
+    add_queues [
+      storageQueue {
+        name "queue1"
+        metadata [
+          "environment", "dev"
+          "project", "farmer"
+        ]
+      }
+      storageQueue {
+        name "queue2"
+        metadata [
+          "environment", "test"
+          "project", "barnyard"
+        ]
+      }
     ]
-    add_queues_with_same_metadata 
-        ["myqueue7", "myqueue8"]
-        (Map [
-            ("source", "imageStore")
-        ])
+    add_queues 
+      [
+        storageQueue {
+          name "queue1"
+        }
+        storageQueue {
+          name "queue"
+        }
+      ]
+      [
+        "environment", "dev"
+        "project", "farmer"
+      ]      
+
     add_table "mytable"
     use_static_website "local/path/to/folder/content" "index.html"
     static_website_error_page "error.html"

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -28,7 +28,10 @@ The Storage Account builder creates storage accounts and their associated contai
 | add_file_share | Adds a file share to storage account |
 | add_file_share_with_quota | Adds a file share to storage account with a share quota in Gb |
 | add_queue | Adds a queue to the storage account |
+| add_queue_with_metadata | Adds a queue to the storage account with metadata associated with it |
 | add_queues | Adds a list of queues to the storage account |
+| add_queues_with_unique_metadata | Adds a list of queues to the storage account, each with unique metadata associated with them |
+| add_queues_with_same_metadata | Addsa list of queues to the storage account, all with the same set of metadata associated with them |
 | add_table | Adds a table to the storage account |
 | add_tables | Adds a list of tables to the storage account |
 | add_cors_rules | Adds a list of CORS rules to the different storage services |
@@ -80,6 +83,23 @@ let storage = storageAccount {
     add_file_share "share1"
     add_file_share_with_quota "share2" 1024<Gb>
     add_queue "myqueue"
+    add_queue_with_metadata "myqueue2" (Map [
+        ("source", "imageStore")
+    ])
+    add_queues ["myqueue3"; "myqueue4"]
+    add_queues_with_unique_metadata [
+        ("myqueue5", Map [
+            ("source", "imageStore")
+        ])
+        ("myqueue6", Map [
+            ("source", "customerPurchaseStage")
+        ])
+    ]
+    add_queues_with_same_metadata 
+        ["myqueue7", "myqueue8"]
+        (Map [
+            ("source", "imageStore")
+        ])
     add_table "mytable"
     use_static_website "local/path/to/folder/content" "index.html"
     static_website_error_page "error.html"

--- a/samples/scripts/storage.fsx
+++ b/samples/scripts/storage.fsx
@@ -7,6 +7,12 @@ let myStorage = storageAccount {
     name "myfarmerstorage"
     sku Storage.Sku.Standard_LRS
     add_queues [ "queue1"; "queue2" ]
+    add_queues_with_same_metadata 
+        ["queue3"; "queue4"]
+        (Map [
+            ("environment", "dev")
+            ("source", "image")
+        ])
     add_private_container "container1"
     add_table "table1"
     add_tables [ "table2"; "table3" ]

--- a/samples/scripts/storage.fsx
+++ b/samples/scripts/storage.fsx
@@ -6,13 +6,22 @@ open Farmer.Builders
 let myStorage = storageAccount {
     name "myfarmerstorage"
     sku Storage.Sku.Standard_LRS
-    add_queues [ "queue1"; "queue2" ]
-    add_queues_with_same_metadata 
-        ["queue3"; "queue4"]
-        (Map [
-            ("environment", "dev")
-            ("source", "image")
-        ])
+    add_queues [
+        storageQueue {
+            name "queue1"
+            metadata [
+                "environment", "dev"
+                "project", "farmer"
+            ]
+        }
+        storageQueue {
+            name "queue2"
+            metadata [
+                "environment", "test"
+                "project", "barnyard"
+            ]
+        }
+    ]
     add_private_container "container1"
     add_table "table1"
     add_tables [ "table2"; "table3" ]

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -431,16 +431,18 @@ module Queues =
                 queues.resourceId (this.StorageAccount / "default" / this.Name.ResourceName)
 
             member this.JsonModel =
-                let queue = queues.Create(
-                                this.StorageAccount / "default" / this.Name.ResourceName,
-                                dependsOn = [ storageAccounts.resourceId this.StorageAccount ]
-                            )
+                let queue =
+                    queues.Create(
+                        this.StorageAccount / "default" / this.Name.ResourceName,
+                        dependsOn = [ storageAccounts.resourceId this.StorageAccount ]
+                    )
+
                 match this.Metadata with
-                    | Some m ->
-                        {| queue with
-                            properties = box {| metadata = m |}
-                        |}
-                    | None -> queue
+                | Some m ->
+                    {| queue with
+                        properties = box {| metadata = m |}
+                    |}
+                | None -> queue
 
 module ManagementPolicies =
     type ManagementPolicy =

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -33,6 +33,12 @@ type StoragePolicy =
         Filters: string list
     }
 
+type StorageQueueConfig = 
+    {
+        Name: StorageResourceName
+        Metadata: Metadata option
+    }
+
 type StorageAccountConfig =
     {
         /// The name of the storage account.
@@ -46,7 +52,7 @@ type StorageAccountConfig =
         /// File shares
         FileShares: (StorageResourceName * int<Gb> option) list
         /// Queues
-        Queues: (StorageResourceName * Metadata option) Set
+        Queues: StorageQueueConfig list
         /// Network Access Control Lists
         NetworkAcls: NetworkRuleSet option
         /// Tables
@@ -142,8 +148,8 @@ type StorageAccountConfig =
                     }
                 for queue in this.Queues do
                     {
-                        Queues.Queue.Name = fst queue
-                        Queues.Queue.Metadata = snd queue
+                        Queues.Queue.Name = queue.Name
+                        Queues.Queue.Metadata = queue.Metadata
                         Queues.Queue.StorageAccount = this.Name.ResourceName
                     }
                 for table in this.Tables do
@@ -227,7 +233,7 @@ type StorageAccountBuilder() =
             Containers = []
             FileShares = []
             Rules = Map.empty
-            Queues = Set.empty
+            Queues = List.empty
             NetworkAcls = None
             Tables = Set.empty
             RoleAssignments = Set.empty
@@ -300,34 +306,27 @@ type StorageAccountBuilder() =
 
     /// Adds a single queue to the storage account.
     [<CustomOperation "add_queue">]
-    member _.AddQueue(state: StorageAccountConfig, name: string) =
+    member _.AddQueue(state: StorageAccountConfig, queue: StorageQueueConfig) =
         { state with
-            Queues = state.Queues.Add(StorageResourceName.Create(name).OkValue, None)
+            Queues = state.Queues @ [ queue ]
         }
 
-    /// Adds a single queue with metadata to the storage account.
-    [<CustomOperation "add_queue_with_metadata">]
-    member _.AddQueue(state: StorageAccountConfig, name: string, metadata: Metadata) =
+    [<CustomOperation "add_queue">]
+    member _.AddQueue(state: StorageAccountConfig, name: string) =
         { state with
-            Queues = state.Queues.Add(StorageResourceName.Create(name).OkValue, Some(metadata))
+            Queues = state.Queues @ [ {Name = StorageResourceName.Create(name).OkValue; Metadata = None } ]
         }
 
     /// Adds a set of queues to the storage account.
     [<CustomOperation "add_queues">]
-    member this.AddQueues(state: StorageAccountConfig, names) =
-        (state, names) ||> Seq.fold (fun state name -> this.AddQueue(state, name))
+    member this.AddQueues(state: StorageAccountConfig, queues: StorageQueueConfig seq) =
+        (state, queues) ||> Seq.fold (fun state queue -> this.AddQueue(state, queue))
 
-    /// Adds a set of queues with unique metadata to the storage account.
-    [<CustomOperation "add_queues_with_unique_metadata">]
-    member this.AddQueues(state: StorageAccountConfig, queues: (string * Metadata) seq) =
-        (state, queues) ||> Seq.fold (fun state queue -> 
-            this.AddQueue(state, fst queue, snd queue))
-
-    /// Adds a set of queues with same metadata to the storage account.
-    [<CustomOperation "add_queues_with_same_metadata">]
-    member this.AddQueues(state: StorageAccountConfig, names, metadata: Metadata) =
-        (state, names) ||> Seq.fold (fun state name -> 
-            this.AddQueue(state, name, metadata))
+    /// Adds a set of queues to the storage account with the same metadata.
+    [<CustomOperation "add_queues">]
+    member this.AddQueues(state: StorageAccountConfig, queues: StorageQueueConfig seq, metadata: (string * string) list) =
+        let qs = queues |> Seq.map (fun queue -> { queue with Metadata = Some(metadata |> Map.ofSeq)})
+        (state, qs) ||> Seq.fold (fun state queue -> this.AddQueue(state, queue))
 
     /// Adds a single table to the storage account.
     [<CustomOperation "add_table">]
@@ -668,4 +667,30 @@ type EndpointBuilder with
         let state = this.Origin(state, storage.Endpoint)
         this.DependsOn(state, storage.ResourceId)
 
+type StorageQueueBuilder() =
+    member _.Yield _ =
+        {
+            Name = StorageResourceName.Empty
+            Metadata = Some(Map.empty)
+        }
+
+    member _.Run state =
+        state
+
+    /// Sets the name of the storage queue.
+    [<CustomOperation "name">]
+    member _.Name(state: StorageQueueConfig, name: string) =
+        { state with
+            Name = StorageResourceName.Create(ResourceName name).OkValue
+        }
+
+    /// Sets the name of the storage account.
+    [<CustomOperation "metadata">]
+    member _.Name(state: StorageQueueConfig, metadata: (string * string) list) =
+        let m = metadata |> Map.ofList
+        { state with
+            Metadata = Some(m)
+        }
+
 let storageAccount = StorageAccountBuilder()
+let storageQueue = StorageQueueBuilder()

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -33,7 +33,7 @@ type StoragePolicy =
         Filters: string list
     }
 
-type StorageQueueConfig = 
+type StorageQueueConfig =
     {
         Name: StorageResourceName
         Metadata: Metadata option
@@ -314,7 +314,14 @@ type StorageAccountBuilder() =
     [<CustomOperation "add_queue">]
     member _.AddQueue(state: StorageAccountConfig, name: string) =
         { state with
-            Queues = state.Queues @ [ {Name = StorageResourceName.Create(name).OkValue; Metadata = None } ]
+            Queues =
+                state.Queues
+                @ [
+                    {
+                        Name = StorageResourceName.Create(name).OkValue
+                        Metadata = None
+                    }
+                ]
         }
 
     /// Adds a set of queues to the storage account.
@@ -324,8 +331,19 @@ type StorageAccountBuilder() =
 
     /// Adds a set of queues to the storage account with the same metadata.
     [<CustomOperation "add_queues">]
-    member this.AddQueues(state: StorageAccountConfig, queues: StorageQueueConfig seq, metadata: (string * string) list) =
-        let qs = queues |> Seq.map (fun queue -> { queue with Metadata = Some(metadata |> Map.ofSeq)})
+    member this.AddQueues
+        (
+            state: StorageAccountConfig,
+            queues: StorageQueueConfig seq,
+            metadata: (string * string) list
+        ) =
+        let qs =
+            queues
+            |> Seq.map (fun queue ->
+                { queue with
+                    Metadata = Some(metadata |> Map.ofSeq)
+                })
+
         (state, qs) ||> Seq.fold (fun state queue -> this.AddQueue(state, queue))
 
     /// Adds a single table to the storage account.
@@ -674,8 +692,7 @@ type StorageQueueBuilder() =
             Metadata = Some(Map.empty)
         }
 
-    member _.Run state =
-        state
+    member _.Run state = state
 
     /// Sets the name of the storage queue.
     [<CustomOperation "name">]
@@ -688,9 +705,7 @@ type StorageQueueBuilder() =
     [<CustomOperation "metadata">]
     member _.Name(state: StorageQueueConfig, metadata: (string * string) list) =
         let m = metadata |> Map.ofList
-        { state with
-            Metadata = Some(m)
-        }
+        { state with Metadata = Some(m) }
 
 let storageAccount = StorageAccountBuilder()
 let storageQueue = StorageQueueBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1170,6 +1170,7 @@ module Storage =
         private
         | StorageResourceName of ResourceName
 
+        static member internal Empty = StorageResourceName ResourceName.Empty
         static member Create name =
             [
                 nonEmptyLengthBetween 3 63

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -151,26 +151,17 @@ let tests =
                 [
                     test "Creates queues correctly" {
                         let resources: StorageQueue list =
-                            let queue = storageQueue {
-                                name "queue4"
-                                metadata [
-                                    "environment", "dev"
-                                    "source", "image"
-                                ]
-                            }
-                            
+                            let queue =
+                                storageQueue {
+                                    name "queue4"
+                                    metadata [ "environment", "dev"; "source", "image" ]
+                                }
+
                             let account =
                                 storageAccount {
                                     name "storage"
                                     add_queue "queue1"
-                                    add_queues [
-                                        storageQueue {
-                                            name "queue2"
-                                        }
-                                        storageQueue {
-                                            name "queue3"
-                                        }
-                                    ]
+                                    add_queues [ storageQueue { name "queue2" }; storageQueue { name "queue3" } ]
                                     add_queue queue
                                 }
 
@@ -185,28 +176,25 @@ let tests =
                     }
                     test "Metadata is added correctly to single queue" {
                         let resource: StorageQueue =
-                            let account = storageAccount {
-                                name "storage"
-                                add_queue (
-                                    storageQueue {
-                                        name "queue1"
-                                        metadata [
-                                            "environment", "dev"
-                                            "project", "farmer"
-                                        ]
-                                    }
-                                )
-                            }
+                            let account =
+                                storageAccount {
+                                    name "storage"
+
+                                    add_queue (
+                                        storageQueue {
+                                            name "queue1"
+                                            metadata [ "environment", "dev"; "project", "farmer" ]
+                                        }
+                                    )
+                                }
+
                             account |> getResourceAtIndex client.SerializationSettings 1
 
                         Expect.equal resource.Name "storage/default/queue1" "queue name for 'queue1' is wrong"
-                        
+
                         Expect.equal
-                            resource.Metadata 
-                            (seq [
-                                ("environment", "dev")
-                                ("project", "farmer")
-                            ] |> dict)
+                            resource.Metadata
+                            (seq [ ("environment", "dev"); ("project", "farmer") ] |> dict)
                             "Metadata not set correctly"
                     }
                     test "Metadata is added correctly to multiple queues" {
@@ -214,35 +202,22 @@ let tests =
                             let account =
                                 storageAccount {
                                     name "storage"
-                                    add_queues [
-                                        storageQueue {
-                                            name "queue1"
-                                            metadata [
-                                                "environment", "dev"
-                                                "project", "farmer"
-                                            ]
-                                        }
-                                        storageQueue {
-                                            name "queue2"
-                                            metadata [
-                                                "environment", "test"
-                                                "project", "barnyard"
-                                            ]
-                                        }
-                                    ]
-                                    add_queues 
+
+                                    add_queues
                                         [
                                             storageQueue {
-                                                name "queue3"
+                                                name "queue1"
+                                                metadata [ "environment", "dev"; "project", "farmer" ]
                                             }
                                             storageQueue {
-                                                name "queue4"
+                                                name "queue2"
+                                                metadata [ "environment", "test"; "project", "barnyard" ]
                                             }
                                         ]
-                                        [
-                                            "environment", "test"
-                                            "project", "barnyard"
-                                        ]
+
+                                    add_queues
+                                        [ storageQueue { name "queue3" }; storageQueue { name "queue4" } ]
+                                        [ "environment", "test"; "project", "barnyard" ]
                                 }
 
                             [
@@ -252,31 +227,23 @@ let tests =
 
                         Expect.equal resources.[0].Name "storage/default/queue1" "queue name for 'queue1' is wrong"
                         Expect.equal resources.[1].Name "storage/default/queue2" "queue name for 'queue2' is wrong"
-                        
-                        let queue1Metadata = seq [
-                            ("environment", "dev")
-                            ("project", "farmer")
-                        ] 
-                        let queue2Metadata = seq [
-                            ("environment", "test")
-                            ("project", "barnyard")
-                        ]
+
+                        let queue1Metadata = seq [ ("environment", "dev"); ("project", "farmer") ]
+                        let queue2Metadata = seq [ ("environment", "test"); ("project", "barnyard") ]
 
                         Expect.equal
-                            resources.[0].Metadata 
+                            resources.[0].Metadata
                             (queue1Metadata |> dict)
                             "Metadata not set correctly for queue1"
+
                         Expect.equal
-                            resources.[1].Metadata 
+                            resources.[1].Metadata
                             (queue1Metadata |> dict)
                             "Metadata not set correctly for queue2"
                     }
                     test "Metadata is added correctly to multiple queues when same for all" {
                         let resources: StorageQueue list =
-                            let account =
-                                storageAccount {
-                                    name "storage"
-                                }
+                            let account = storageAccount { name "storage" }
 
                             [
                                 for i in 1..2 do
@@ -285,18 +252,16 @@ let tests =
 
                         Expect.equal resources.[0].Name "storage/default/queue1" "queue name for 'queue1' is wrong"
                         Expect.equal resources.[1].Name "storage/default/queue2" "queue name for 'queue2' is wrong"
-                        
-                        let queueMetadata = seq [
-                            ("environment", "dev")
-                            ("project", "farmer")
-                        ]
+
+                        let queueMetadata = seq [ ("environment", "dev"); ("project", "farmer") ]
 
                         Expect.equal
-                            resources.[0].Metadata 
+                            resources.[0].Metadata
                             (queueMetadata |> dict)
                             "Metadata not set correctly for queue1"
+
                         Expect.equal
-                            resources.[1].Metadata 
+                            resources.[1].Metadata
                             (queueMetadata |> dict)
                             "Metadata not set correctly for queue2"
                     }

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -151,11 +151,27 @@ let tests =
                 [
                     test "Creates queues correctly" {
                         let resources: StorageQueue list =
+                            let queue = storageQueue {
+                                name "queue4"
+                                metadata [
+                                    "environment", "dev"
+                                    "source", "image"
+                                ]
+                            }
+                            
                             let account =
                                 storageAccount {
                                     name "storage"
                                     add_queue "queue1"
-                                    add_queues [ "queue2"; "queue3" ]
+                                    add_queues [
+                                        storageQueue {
+                                            name "queue2"
+                                        }
+                                        storageQueue {
+                                            name "queue3"
+                                        }
+                                    ]
+                                    add_queue queue
                                 }
 
                             [
@@ -171,10 +187,15 @@ let tests =
                         let resource: StorageQueue =
                             let account = storageAccount {
                                 name "storage"
-                                add_queue_with_metadata "queue1" (Map [
-                                    ("environment", "dev")
-                                    ("project", "farmer")
-                                ])    
+                                add_queue (
+                                    storageQueue {
+                                        name "queue1"
+                                        metadata [
+                                            "environment", "dev"
+                                            "project", "farmer"
+                                        ]
+                                    }
+                                )
                             }
                             account |> getResourceAtIndex client.SerializationSettings 1
 
@@ -188,21 +209,40 @@ let tests =
                             ] |> dict)
                             "Metadata not set correctly"
                     }
-                    test "Metadata is added correctly to multiple queues when unique" {
+                    test "Metadata is added correctly to multiple queues" {
                         let resources: StorageQueue list =
                             let account =
                                 storageAccount {
                                     name "storage"
-                                    add_queues_with_unique_metadata [ 
-                                        ("queue1", Map [
-                                            ("environment", "dev")
-                                            ("project", "farmer")
-                                        ])
-                                        ("queue2", Map [
-                                            ("environment", "test")
-                                            ("project", "barnyard")
-                                        ]) 
+                                    add_queues [
+                                        storageQueue {
+                                            name "queue1"
+                                            metadata [
+                                                "environment", "dev"
+                                                "project", "farmer"
+                                            ]
+                                        }
+                                        storageQueue {
+                                            name "queue2"
+                                            metadata [
+                                                "environment", "test"
+                                                "project", "barnyard"
+                                            ]
+                                        }
                                     ]
+                                    add_queues 
+                                        [
+                                            storageQueue {
+                                                name "queue3"
+                                            }
+                                            storageQueue {
+                                                name "queue4"
+                                            }
+                                        ]
+                                        [
+                                            "environment", "test"
+                                            "project", "barnyard"
+                                        ]
                                 }
 
                             [
@@ -236,12 +276,6 @@ let tests =
                             let account =
                                 storageAccount {
                                     name "storage"
-                                    add_queues_with_same_metadata 
-                                        ["queue1"; "queue2"]
-                                        (Map [
-                                            ("environment", "dev")
-                                            ("project", "farmer")
-                                        ]) 
                                 }
 
                             [

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -192,7 +192,7 @@ let tests =
 
                         Expect.equal resource.Name "storage/default/queue1" "queue name for 'queue1' is wrong"
 
-                        Expect.equal
+                        Expect.containsAll
                             resource.Metadata
                             (seq [ ("environment", "dev"); ("project", "farmer") ] |> dict)
                             "Metadata not set correctly"
@@ -231,12 +231,12 @@ let tests =
                         let queue1Metadata = seq [ ("environment", "dev"); ("project", "farmer") ]
                         let queue2Metadata = seq [ ("environment", "test"); ("project", "barnyard") ]
 
-                        Expect.equal
+                        Expect.containsAll
                             resources.[0].Metadata
                             (queue1Metadata |> dict)
                             "Metadata not set correctly for queue1"
 
-                        Expect.equal
+                        Expect.containsAll
                             resources.[1].Metadata
                             (queue1Metadata |> dict)
                             "Metadata not set correctly for queue2"
@@ -255,12 +255,12 @@ let tests =
 
                         let queueMetadata = seq [ ("environment", "dev"); ("project", "farmer") ]
 
-                        Expect.equal
+                        Expect.containsAll
                             resources.[0].Metadata
                             (queueMetadata |> dict)
                             "Metadata not set correctly for queue1"
 
-                        Expect.equal
+                        Expect.containsAll
                             resources.[1].Metadata
                             (queueMetadata |> dict)
                             "Metadata not set correctly for queue2"

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -238,12 +238,25 @@ let tests =
 
                         Expect.containsAll
                             resources.[1].Metadata
-                            (queue1Metadata |> dict)
+                            (queue2Metadata |> dict)
                             "Metadata not set correctly for queue2"
                     }
                     test "Metadata is added correctly to multiple queues when same for all" {
                         let resources: StorageQueue list =
-                            let account = storageAccount { name "storage" }
+                            let account = storageAccount {
+                                name "storage"
+                                add_queues
+                                    [
+                                        storageQueue {
+                                            name "queue1"
+                                            metadata [ "environment", "dev"; "project", "farmer" ]
+                                        }
+                                        storageQueue {
+                                            name "queue2"
+                                            metadata [ "environment", "dev"; "project", "farmer" ]
+                                        }
+                                    ]
+                            }
 
                             [
                                 for i in 1..2 do


### PR DESCRIPTION
…ta can be added for a single queue, multiple queues with unique metadata or multiple queues with the same metadata

This PR closes #916 

The changes in this PR are as follows:

* Adds ability to add metadata to Storage Account Queues

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
The unit tests don't pass but I could not work out why. I cannot see a difference in the actual and expected values. 

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let storageAccount = storageAccount {
    name = "testaccount"
    add_queue_with_metadata "myqueue" (Map [
        "source", "imageStore"
    ])
}
```
