### PR TITLE
Provide a colourized and focused diff around ARM template JSON regressions

### DIFF
--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -68,7 +68,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="expecto" Version="9.0.0" />
+    <PackageReference Include="expecto" Version="9.0.4" />
+    <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="Microsoft.Azure.Management.Cdn" Version="6.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.Management.CognitiveServices" Version="7.0.0" />
@@ -94,7 +95,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.9.1" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.13.3" />
     <PackageReference Update="FSharp.Core" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The changes in this PR are as follows:

* Adds a colorized diff for JSON regressions based off Expecto.Diff. Intending to push some fixes to Expecto.Diff to improve it for large comparisons.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

This is an update to the JSON regression tests to improve the development workflow for contributors and does not make changes to the Farmer library itself.