### PR TITLE
Adds missing network and security configuration for storage accounts 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+## vNext
+* Storage Accounts: Support for disabling public network access
+* Storage Accounts: Support for restricting access to azure services without also specifying a vnet/subnet (useful when access is already controlled by a private endpoint but you still need to add a bypass for Azure services).
+* Storage Accounts: Support for disabling blob public access
+* Storage Accounts: Support for disabling shared key access
+* Storage Accounts: Support for defaulting to AAD auth in the portal instead of shared key access
+* Storage Accounts: Support for changing the DNS endpoint type which allows you to create more than 250 storage accounts in a given subscription.
+
 ## 1.7.11
 * Dedicated Hosts: Support for Host Groups and Hosts
 * WebApps: Added support for Node 14, 16 and 18

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -36,12 +36,18 @@ The Storage Account builder creates storage accounts and their associated contai
 | enable_versioning | Enabled versioning for different storage services |
 | restrict_to_ip | Restrict access to a given ip address |
 | restrict_to_subnet | Restrict access to a given virtual network subnet |
+| restrict_to_azure_services | Restrict access to a given set of Azure Services. (Used when access to the storage account already controlled by private endpoint) |
+| disable_public_network_access | Disables public network access to the storage account |
 | use_static_website | Activates static website host, and uploads the provided local content as a post-deployment task to the storage with the specified index page |
 | static_website_error_page | Specifies the 404 page to display for static website hosting |
 | enable_data_lake | Enables Azure Data Lake Gen2 support on the storage account |
 | add_lifecycle_policy | Given a rule name, a list of PolicyActions and a list of string filters, creates a lifecycle policy for the storage account |
 | grant_access | Given a managed identity (can be either user- or system- assigned), and a specific RoleId from the Roles module, grants access to the identity for the provided role. |
 | min_tls_version | Sets the minimum TLS version for the storage account |
+| disable_blob_public_access | Disables public (anonymous) access to blobs for the entire storage account |
+| disable_shared_key_access | Disables shared key access for the storage account |
+| default_to_oauth_authentication | Defaults to OAuth (AAD) authentication for requests to blobs, queues and containers in the Azure portal |
+| use_azure_dns_zone | Change the DNS Endpoint type from `Standard` to `AzureDnsZone` |
 
 
 #### Configuration Members

--- a/samples/scripts/storage.fsx
+++ b/samples/scripts/storage.fsx
@@ -12,6 +12,11 @@ let myStorage = storageAccount {
     add_tables [ "table2"; "table3" ]
     add_lifecycle_rule "cleanup" [ Storage.DeleteAfter 7<Days> ] Storage.NoRuleFilters
     add_lifecycle_rule "test" [ Storage.DeleteAfter 1<Days>; Storage.DeleteAfter 2<Days>; Storage.ArchiveAfter 1<Days>; ] [ "foo/bar" ]
+    disable_public_network_access
+    disable_blob_public_access
+    disable_shared_key_access
+    default_to_oauth_authentication
+    restrict_to_azure_services [ Farmer.Arm.Storage.NetworkRuleSetBypass.AzureServices ]
 }
 let template = arm {
     add_resource myStorage

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.Storage
 
 let storageAccounts =
-    ResourceType("Microsoft.Storage/storageAccounts", "2019-06-01")
+    ResourceType("Microsoft.Storage/storageAccounts", "2022-05-01")
 
 let blobServices =
     ResourceType("Microsoft.Storage/storageAccounts/blobServices", "2019-06-01")
@@ -106,6 +106,11 @@ type StorageAccount =
                           ErrorPage: string option
                           ContentPath: string |} option
         MinTlsVersion: TlsVersion option
+        DnsZoneType: string
+        DisablePublicNetworkAccess: FeatureFlag
+        DisableBlobPublicAccess: FeatureFlag
+        DisableSharedKeyAccess: FeatureFlag
+        DefaultToOAuthAuthentication: FeatureFlag
         Tags: Map<string, string>
     }
 
@@ -186,6 +191,23 @@ type StorageAccount =
                             | Some Tls11 -> "TLS1_1"
                             | Some Tls12 -> "TLS1_2"
                             | None -> null
+                        dnsEndpointType = this.DnsZoneType
+                        publicNetworkAccess =
+                            match this.DisablePublicNetworkAccess with
+                            | FeatureFlag.Disabled -> "Enabled"
+                            | FeatureFlag.Enabled -> "Disabled"
+                        allowBlobPublicAccess =
+                            match this.DisableBlobPublicAccess with
+                            | FeatureFlag.Disabled -> "true"
+                            | FeatureFlag.Enabled -> "false"
+                        allowSharedKeyAccess =
+                            match this.DisableSharedKeyAccess with
+                            | FeatureFlag.Disabled -> "true"
+                            | FeatureFlag.Enabled -> "false"
+                        defaultToOAuthAuthentication =
+                            match this.DefaultToOAuthAuthentication with
+                            | FeatureFlag.Disabled -> "false"
+                            | FeatureFlag.Enabled -> "true"
                     |}
             |}
 

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -106,11 +106,11 @@ type StorageAccount =
                           ErrorPage: string option
                           ContentPath: string |} option
         MinTlsVersion: TlsVersion option
-        DnsZoneType: string
-        DisablePublicNetworkAccess: FeatureFlag
-        DisableBlobPublicAccess: FeatureFlag
-        DisableSharedKeyAccess: FeatureFlag
-        DefaultToOAuthAuthentication: FeatureFlag
+        DnsZoneType: string option
+        DisablePublicNetworkAccess: FeatureFlag option
+        DisableBlobPublicAccess: FeatureFlag option
+        DisableSharedKeyAccess: FeatureFlag option
+        DefaultToOAuthAuthentication: FeatureFlag option
         Tags: Map<string, string>
     }
 
@@ -191,23 +191,30 @@ type StorageAccount =
                             | Some Tls11 -> "TLS1_1"
                             | Some Tls12 -> "TLS1_2"
                             | None -> null
-                        dnsEndpointType = this.DnsZoneType
+                        dnsEndpointType = 
+                            match this.DnsZoneType with
+                            | Some s -> s
+                            | None -> null
                         publicNetworkAccess =
                             match this.DisablePublicNetworkAccess with
-                            | FeatureFlag.Disabled -> "Enabled"
-                            | FeatureFlag.Enabled -> "Disabled"
+                            | Some FeatureFlag.Disabled -> "Enabled"
+                            | Some FeatureFlag.Enabled -> "Disabled"
+                            | None -> null
                         allowBlobPublicAccess =
                             match this.DisableBlobPublicAccess with
-                            | FeatureFlag.Disabled -> "true"
-                            | FeatureFlag.Enabled -> "false"
+                            | Some FeatureFlag.Disabled -> "true"
+                            | Some FeatureFlag.Enabled -> "false"
+                            | None -> null
                         allowSharedKeyAccess =
                             match this.DisableSharedKeyAccess with
-                            | FeatureFlag.Disabled -> "true"
-                            | FeatureFlag.Enabled -> "false"
+                            | Some FeatureFlag.Disabled -> "true"
+                            | Some FeatureFlag.Enabled -> "false"
+                            | None -> null
                         defaultToOAuthAuthentication =
                             match this.DefaultToOAuthAuthentication with
-                            | FeatureFlag.Disabled -> "false"
-                            | FeatureFlag.Enabled -> "true"
+                            | Some FeatureFlag.Disabled -> "false"
+                            | Some FeatureFlag.Enabled -> "true"
+                            | None -> null
                     |}
             |}
 

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -191,7 +191,7 @@ type StorageAccount =
                             | Some Tls11 -> "TLS1_1"
                             | Some Tls12 -> "TLS1_2"
                             | None -> null
-                        dnsEndpointType = 
+                        dnsEndpointType =
                             match this.DnsZoneType with
                             | Some s -> s
                             | None -> null

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -378,6 +378,11 @@ type FunctionsConfig =
                         EnableHierarchicalNamespace = None
                         MinTlsVersion = None
                         Tags = this.Tags
+                        DnsZoneType = "Standard"
+                        DisablePublicNetworkAccess = FeatureFlag.Disabled
+                        DisableBlobPublicAccess = FeatureFlag.Disabled
+                        DisableSharedKeyAccess = FeatureFlag.Disabled
+                        DefaultToOAuthAuthentication = FeatureFlag.Disabled
                     }
                 | _ -> ()
 

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -378,11 +378,11 @@ type FunctionsConfig =
                         EnableHierarchicalNamespace = None
                         MinTlsVersion = None
                         Tags = this.Tags
-                        DnsZoneType = "Standard"
-                        DisablePublicNetworkAccess = FeatureFlag.Disabled
-                        DisableBlobPublicAccess = FeatureFlag.Disabled
-                        DisableSharedKeyAccess = FeatureFlag.Disabled
-                        DefaultToOAuthAuthentication = FeatureFlag.Disabled
+                        DnsZoneType = None
+                        DisablePublicNetworkAccess = None
+                        DisableBlobPublicAccess = None
+                        DisableSharedKeyAccess = None
+                        DefaultToOAuthAuthentication = None
                     }
                 | _ -> ()
 

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -69,15 +69,15 @@ type StorageAccountConfig =
         /// Tags to apply to the storage account
         Tags: Map<string, string>
         /// DNS endpoint type
-        DnsZoneType: string
+        DnsZoneType: string option
         /// Disable Public Network Acccess
-        DisablePublicNetworkAccess: FeatureFlag
+        DisablePublicNetworkAccess: FeatureFlag option
         /// Disable blob public access
-        DisableBlobPublicAccess: FeatureFlag
+        DisableBlobPublicAccess: FeatureFlag option
         /// Disable Shared Key Access
-        DisableSharedKeyAccess: FeatureFlag
+        DisableSharedKeyAccess: FeatureFlag option
         /// Default to Azure Active Directory authorization in the Azure portal
-        DefaultToOAuthAuthentication: FeatureFlag
+        DefaultToOAuthAuthentication: FeatureFlag option
     }
 
     /// Gets the ARM expression path to the key of this storage account.
@@ -236,11 +236,11 @@ type StorageAccountBuilder() =
             IsVersioningEnabled = []
             MinTlsVersion = None
             Tags = Map.empty
-            DnsZoneType = "Standard"
-            DisablePublicNetworkAccess = FeatureFlag.Disabled
-            DisableBlobPublicAccess = FeatureFlag.Disabled
-            DisableSharedKeyAccess = FeatureFlag.Disabled
-            DefaultToOAuthAuthentication = FeatureFlag.Disabled
+            DnsZoneType = None
+            DisablePublicNetworkAccess = None
+            DisableBlobPublicAccess = None
+            DisableSharedKeyAccess = None
+            DefaultToOAuthAuthentication = None
         }
 
     member _.Run state =
@@ -588,14 +588,14 @@ type StorageAccountBuilder() =
     [<CustomOperation "use_azure_dns_zone">]
     member _.SetDnsEndpointType(state: StorageAccountConfig) =
         { state with
-            DnsZoneType = "AzureDnsZone"
+            DnsZoneType = Some "AzureDnsZone"
         }
 
     /// Disable public network access, all access must be through a private endpoint.
     [<CustomOperation "disable_public_network_access">]
     member _.DisablePublicNetworkAccess(state: StorageAccountConfig) =
         { state with
-            DisablePublicNetworkAccess = FeatureFlag.Enabled
+            DisablePublicNetworkAccess = Some FeatureFlag.Enabled
             NetworkAcls =
                 {
                     Bypass = set [ NetworkRuleSetBypass.None ]
@@ -612,7 +612,7 @@ type StorageAccountBuilder() =
         let flag = defaultArg flag FeatureFlag.Enabled
 
         { state with
-            DisableBlobPublicAccess = flag
+            DisableBlobPublicAccess = Some flag
         }
 
     /// Disable shared key access
@@ -621,7 +621,7 @@ type StorageAccountBuilder() =
         let flag = defaultArg flag FeatureFlag.Enabled
 
         { state with
-            DisableSharedKeyAccess = flag
+            DisableSharedKeyAccess = Some flag
         }
 
     /// Default to Azure Active Directory authorization in the Azure portal
@@ -630,7 +630,7 @@ type StorageAccountBuilder() =
         let flag = defaultArg flag FeatureFlag.Enabled
 
         { state with
-            DefaultToOAuthAuthentication = flag
+            DefaultToOAuthAuthentication = Some flag
         }
 
     interface ITaggable<StorageAccountConfig> with

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -534,7 +534,7 @@ type StorageAccountBuilder() =
 
     /// Restrict access to this storage account to the private endpoints and azure services.
     [<CustomOperation "restrict_to_azure_services">]
-    member _.RestrictToAzureServices(state: StorageAccountConfig, bypass: NetworkRuleSetBypass list) =        
+    member _.RestrictToAzureServices(state: StorageAccountConfig, bypass: NetworkRuleSetBypass list) =
         match state.NetworkAcls with
         | None ->
             { state with

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -534,10 +534,11 @@ type StorageAccountBuilder() =
 
     /// Restrict access to this storage account to the private endpoints and azure services.
     [<CustomOperation "restrict_to_azure_services">]
-    member _.RestrictToAzureServices(state: StorageAccountConfig, bypass: NetworkRuleSetBypass list) =
+    member _.RestrictToAzureServices(state: StorageAccountConfig, bypass: NetworkRuleSetBypass list) =        
         match state.NetworkAcls with
         | None ->
             { state with
+                DisablePublicNetworkAccess = Some FeatureFlag.Disabled
                 NetworkAcls =
                     {
                         Bypass = set bypass
@@ -549,6 +550,7 @@ type StorageAccountBuilder() =
             }
         | Some existingAcl ->
             { state with
+                DisablePublicNetworkAccess = Some FeatureFlag.Disabled
                 NetworkAcls =
                     { existingAcl with
                         Bypass = Set.union (set bypass) existingAcl.Bypass

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -191,6 +191,11 @@ type VmConfig =
                         EnableHierarchicalNamespace = None
                         MinTlsVersion = None
                         Tags = this.Tags
+                        DnsZoneType = "Standard"
+                        DisablePublicNetworkAccess = FeatureFlag.Disabled
+                        DisableBlobPublicAccess = FeatureFlag.Disabled
+                        DisableSharedKeyAccess = FeatureFlag.Disabled
+                        DefaultToOAuthAuthentication = FeatureFlag.Disabled
                     }
                 | Some _
                 | None -> ()

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -191,11 +191,11 @@ type VmConfig =
                         EnableHierarchicalNamespace = None
                         MinTlsVersion = None
                         Tags = this.Tags
-                        DnsZoneType = "Standard"
-                        DisablePublicNetworkAccess = FeatureFlag.Disabled
-                        DisableBlobPublicAccess = FeatureFlag.Disabled
-                        DisableSharedKeyAccess = FeatureFlag.Disabled
-                        DefaultToOAuthAuthentication = FeatureFlag.Disabled
+                        DnsZoneType = None
+                        DisablePublicNetworkAccess = None
+                        DisableBlobPublicAccess = None
+                        DisableSharedKeyAccess = None
+                        DefaultToOAuthAuthentication = None
                     }
                 | Some _
                 | None -> ()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Farmer</AssemblyName>
-    <Version>1.7.10</Version>
+    <Version>1.7.11</Version>
     <Description>Farmer makes authoring ARM templates easy!</Description>
     <Copyright>Copyright 2019-2022 Compositional IT Ltd.</Copyright>
     <Company>Compositional IT</Company>

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -598,20 +598,6 @@ let tests =
                 Expect.equal resource.MinimumTlsVersion "TLS1_2" "Min TLS version is wrong"
             }
 
-            test "dnsEndpointType is standard by default" {
-                let resource =
-                    let account = storageAccount { name "mystorage123" }
-                    arm { add_resource account }
-
-                let jsn = resource.Template |> Writer.toJson
-                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
-
-                Expect.equal
-                    (jobj.SelectToken("resources[0].properties.dnsEndpointType").ToString())
-                    "Standard"
-                    "dnsEndpointType should be standard by default"
-            }
-
             test "dnsEndpointType can be set to AzureDnsZone" {
                 let resource =
                     let account =
@@ -635,20 +621,6 @@ let tests =
                 Expect.throws
                     (fun () -> storageAccount { sku Sku.Standard_ZRS } |> ignore)
                     "Must set a name on a storage account"
-            }
-
-            test "Public network access is enabled by default" {
-                let resource =
-                    let account = storageAccount { name "mystorage123" }
-                    arm { add_resource account }
-
-                let jsn = resource.Template |> Writer.toJson
-                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
-
-                Expect.equal
-                    (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString())
-                    "Enabled"
-                    "public network access should be enabled by default"
             }
 
             test "Public network access can be disabled" {
@@ -715,20 +687,6 @@ let tests =
                     "network acl should not define vnet restrictions"
             }
 
-            test "Blob public access is enabled by default" {
-                let resource =
-                    let account = storageAccount { name "mystorage123" }
-                    arm { add_resource account }
-
-                let jsn = resource.Template |> Writer.toJson
-                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
-
-                Expect.equal
-                    (jobj.SelectToken("resources[0].properties.allowBlobPublicAccess").ToString())
-                    "true"
-                    "blob public access should be enabled by default"
-            }
-
             test "Blob public access can be disabled" {
                 let resource =
                     let account =
@@ -768,20 +726,6 @@ let tests =
                     "blob public access should be enabled"
             }
 
-            test "Shared key access is enabled by default" {
-                let resource =
-                    let account = storageAccount { name "mystorage123" }
-                    arm { add_resource account }
-
-                let jsn = resource.Template |> Writer.toJson
-                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
-
-                Expect.equal
-                    (jobj.SelectToken("resources[0].properties.allowSharedKeyAccess").ToString())
-                    "true"
-                    "shared key access should be enabled by default"
-            }
-
             test "Shared key access can be disabled" {
                 let resource =
                     let account =
@@ -819,22 +763,6 @@ let tests =
                     (jobj.SelectToken("resources[0].properties.allowSharedKeyAccess").ToString())
                     "true"
                     "shared key access should be enabled"
-            }
-
-            test "Default to OAuth is enabled by default" {
-                let resource =
-                    let account = storageAccount { name "mystorage123" }
-                    arm { add_resource account }
-
-                let jsn = resource.Template |> Writer.toJson
-                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
-
-                Expect.equal
-                    (jobj
-                        .SelectToken("resources[0].properties.defaultToOAuthAuthentication")
-                        .ToString())
-                    "false"
-                    "default to OAuth should be disabled by default"
             }
 
             test "Default to OAuth can be disabled" {

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -685,6 +685,11 @@ let tests =
                         .SelectToken("resources[0].properties.networkAcls.virtualNetworkRules")
                         .Values<string>())
                     "network acl should not define vnet restrictions"
+
+                Expect.equal
+                    (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString())
+                    "Enabled"
+                    "public network access should be disabled"
             }
 
             test "Blob public access can be disabled" {

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -10,13 +10,7 @@
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacsuperdata",
-      "properties": {
-        "allowBlobPublicAccess": "true",
-        "allowSharedKeyAccess": "true",
-        "defaultToOAuthAuthentication": "false",
-        "dnsEndpointType": "Standard",
-        "publicNetworkAccess": "Enabled"
-      },
+      "properties": {},
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -5,12 +5,18 @@
   "parameters": {},
   "resources": [
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacsuperdata",
-      "properties": {},
+      "properties": {
+        "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
+      },
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -5,12 +5,18 @@
   "parameters": {},
   "resources": [
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacgriddevprac",
-      "properties": {},
+      "properties": {
+        "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
+      },
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -10,13 +10,7 @@
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacgriddevprac",
-      "properties": {
-        "allowBlobPublicAccess": "true",
-        "allowSharedKeyAccess": "true",
-        "defaultToOAuthAuthentication": "false",
-        "dnsEndpointType": "Standard",
-        "publicNetworkAccess": "Enabled"
-      },
+      "properties": {},
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -83,12 +83,18 @@
       "type": "Microsoft.Sql/servers/elasticPools"
     },
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "farmerstorage1979",
-      "properties": {},
+      "properties": {
+        "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
+      },
       "sku": {
         "name": "Standard_LRS"
       },
@@ -223,12 +229,18 @@
       "type": "Microsoft.Web/serverfarms"
     },
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "farmerfuncs1979storage",
-      "properties": {},
+      "properties": {
+        "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
+      },
       "sku": {
         "name": "Standard_LRS"
       },
@@ -409,12 +421,12 @@
         "isHttpAllowed": true,
         "isHttpsAllowed": true,
         "optimizationType": "GeneralWebDelivery",
-        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2019-06-01').primaryEndpoints.web, 'https://', ''), '/', '')]",
+        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2022-05-01').primaryEndpoints.web, 'https://', ''), '/', '')]",
         "origins": [
           {
             "name": "origin",
             "properties": {
-              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2019-06-01').primaryEndpoints.web, 'https://', ''), '/', '')]"
+              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2022-05-01').primaryEndpoints.web, 'https://', ''), '/', '')]"
             }
           }
         ],
@@ -779,12 +791,18 @@
       "type": "Microsoft.Web/serverfarms"
     },
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "dockerfuncstorage",
-      "properties": {},
+      "properties": {
+        "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
+      },
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -88,13 +88,7 @@
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "farmerstorage1979",
-      "properties": {
-        "allowBlobPublicAccess": "true",
-        "allowSharedKeyAccess": "true",
-        "defaultToOAuthAuthentication": "false",
-        "dnsEndpointType": "Standard",
-        "publicNetworkAccess": "Enabled"
-      },
+      "properties": {},
       "sku": {
         "name": "Standard_LRS"
       },
@@ -234,13 +228,7 @@
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "farmerfuncs1979storage",
-      "properties": {
-        "allowBlobPublicAccess": "true",
-        "allowSharedKeyAccess": "true",
-        "defaultToOAuthAuthentication": "false",
-        "dnsEndpointType": "Standard",
-        "publicNetworkAccess": "Enabled"
-      },
+      "properties": {},
       "sku": {
         "name": "Standard_LRS"
       },
@@ -796,13 +784,7 @@
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "dockerfuncstorage",
-      "properties": {
-        "allowBlobPublicAccess": "true",
-        "allowSharedKeyAccess": "true",
-        "defaultToOAuthAuthentication": "false",
-        "dnsEndpointType": "Standard",
-        "publicNetworkAccess": "Enabled"
-      },
+      "properties": {},
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -148,13 +148,7 @@
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacsvmstorage",
-      "properties": {
-        "allowBlobPublicAccess": "true",
-        "allowSharedKeyAccess": "true",
-        "defaultToOAuthAuthentication": "false",
-        "dnsEndpointType": "Standard",
-        "publicNetworkAccess": "Enabled"
-      },
+      "properties": {},
       "sku": {
         "name": "Standard_LRS"
       },

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -20,7 +20,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2019-06-01').primaryEndpoints.blob]"
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2022-05-01').primaryEndpoints.blob]"
           }
         },
         "hardwareProfile": {
@@ -143,12 +143,18 @@
       "type": "Microsoft.Network/publicIPAddresses"
     },
     {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2022-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
       "name": "isaacsvmstorage",
-      "properties": {},
+      "properties": {
+        "allowBlobPublicAccess": "true",
+        "allowSharedKeyAccess": "true",
+        "defaultToOAuthAuthentication": "false",
+        "dnsEndpointType": "Standard",
+        "publicNetworkAccess": "Enabled"
+      },
       "sku": {
         "name": "Standard_LRS"
       },


### PR DESCRIPTION
Adds the following options for configuring storage account network/security settings.

This PR closes #

The changes in this PR are as follows:

- Disabling public network access
- Restricting access to azure services without also specifying a subnet to restrict too.
- Disabling blob public access
- Disabling shared key access
- Defaulting to AAD auth in the portal instead of shared key access
- Changing the DNS endpoint type which allows you to create more than 250 storage accounts in a given subscription.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
N/A

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let storageAcc = storageAccount {
    name "myaccount"

    // Creates the storage account using the azure dns endpoint, this cannot be used with private endpoints.
    //use_azure_dns_zone
    
    // completely disable public access
    disable_public_network_access

    disable_blob_public_access
    disable_shared_key_access
    default_to_oauth_authentication

    // restrict to private link + azure services - do not call disable_public_network_access
    //restrict_to_azure_services [NetworkRuleSetBypass.AzureServices]
}

```
