### PR TITLE
Possibility of modifying NSG SecurityRule priorities, fix for #990

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.7.12
+* NSG: Added option to modify generated SecurityRule priority step increment
 
 ## 1.7.11
 * Dedicated Hosts: Support for Host Groups and Hosts

--- a/docs/content/api-overview/resources/nsg.md
+++ b/docs/content/api-overview/resources/nsg.md
@@ -17,6 +17,7 @@ The Network Security Group builder creates network security groups with rules fo
 |-|-|-|
 | nsg | name | Specifies the name of the network security group |
 | nsg | add_rules | Adds security rules to the network security group |
+| nsg | priority_incr | First rule is priority 100. After that, this sets how much priority is increased per each rule. Default 100. |
 | securityRule | name | The name of the security rule |
 | securityRule | description | The description  of the security rule |
 | securityRule | services | The services port(s) and protocol(s) protected by this security rule |

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -213,9 +213,12 @@ type NsgBuilder() =
             SecurityRules = state.SecurityRules @ rules
         }
 
-    /// First rule is priority 100. After that, this sets how much priority is increased per each rule. Default 100. 
+    /// First rule is priority 100. After that, this sets how much priority is increased per each rule. Default 100.
     [<CustomOperation "priority_incr">]
-    member _.PriorityIncrementor(state: NsgConfig, priority_incr) = { state with PriorityIncrementor = priority_incr }
+    member _.PriorityIncrementor(state: NsgConfig, priority_incr) =
+        { state with
+            PriorityIncrementor = priority_incr
+        }
 
     interface ITaggable<NsgConfig> with
         member _.Add state tags =

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -171,6 +171,7 @@ type NsgConfig =
         Name: ResourceName
         SecurityRules: SecurityRuleConfig list
         Tags: Map<string, string>
+        PriorityIncrementor: int
     }
 
     interface IBuilder with
@@ -185,7 +186,7 @@ type NsgConfig =
                         seq {
                             // Policy Rules
                             for priority, rule in List.indexed this.SecurityRules do
-                                buildNsgRule this.Name rule ((priority + 1) * 100)
+                                buildNsgRule this.Name rule (priority * this.PriorityIncrementor + 100)
                         }
                         |> List.ofSeq
                     Tags = this.Tags
@@ -198,6 +199,7 @@ type NsgBuilder() =
             Name = ResourceName.Empty
             SecurityRules = []
             Tags = Map.empty
+            PriorityIncrementor = 100
         }
 
     /// Sets the name of the network security group
@@ -210,6 +212,10 @@ type NsgBuilder() =
         { state with
             SecurityRules = state.SecurityRules @ rules
         }
+
+    /// First rule is priority 100. After that, this sets how much priority is increased per each rule. Default 100. 
+    [<CustomOperation "priority_incr">]
+    member _.PriorityIncrementor(state: NsgConfig, priority_incr) = { state with PriorityIncrementor = priority_incr }
 
     interface ITaggable<NsgConfig> with
         member _.Add state tags =

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -165,6 +165,7 @@ let tests =
                     nsg {
                         name "my-nsg"
                         add_rules [ webPolicy; appPolicy; dbPolicy; blockOutbound ]
+                        priority_incr 50
                     }
 
                 let nsg =
@@ -197,7 +198,7 @@ let tests =
                     Expect.equal rule2.DestinationPortRanges.[0] "8080" ""
                     Expect.equal rule2.Direction "Inbound" ""
                     Expect.equal rule2.Protocol "Tcp" ""
-                    Expect.equal rule2.Priority (Nullable 200) ""
+                    Expect.equal rule2.Priority (Nullable 150) ""
                     Expect.equal rule2.SourceAddressPrefixes.[0] "10.100.30.0/24" ""
                     Expect.equal rule2.SourcePortRanges.Count 0 ""
                     // DB server access
@@ -208,7 +209,7 @@ let tests =
                     Expect.equal rule3.DestinationPortRanges.[0] "5432" ""
                     Expect.equal rule3.Direction "Inbound" ""
                     Expect.equal rule3.Protocol "Tcp" ""
-                    Expect.equal rule3.Priority (Nullable 300) ""
+                    Expect.equal rule3.Priority (Nullable 200) ""
                     Expect.equal rule3.SourceAddressPrefixes.[0] "10.100.31.0/24" ""
                     Expect.equal rule3.SourcePortRanges.Count 0 ""
                     // Block Internet access
@@ -219,7 +220,7 @@ let tests =
                     Expect.equal rule4.DestinationPortRange "*" ""
                     Expect.equal rule4.Direction "Outbound" ""
                     Expect.equal rule4.Protocol "*" ""
-                    Expect.equal rule4.Priority (Nullable 400) ""
+                    Expect.equal rule4.Priority (Nullable 250) ""
                     Expect.containsAll rule4.SourceAddressPrefixes [ "10.100.31.0/24"; "10.100.32.0/24" ] ""
                 | _ -> raiseFarmer "Unexpected number of resources in template."
             }


### PR DESCRIPTION
This PR closes #990

The changes in this PR are as follows:

* Changed to NSG Builder only, a new keyword `priority_incr` can be used to replace previously hard-coded value.
* For max backward combability, the default value is the old hard-coded builder value, 100.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription. See below...
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
**I did test that the values are correct, but this was a builder-side hard-coded value parametrization only, so there is nothing to be added to the data-models or ARM templates, so no changes to deploy to Azure.**
