### PR TITLE
Key Vault: disable_public_network_access

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+## vNext
+
+* KeyVault: Added support for disabling public network access.
+* KeyVault: Added missing key permissions (GetRotationPolicy, SetRotationPolicy, Rotate)
+
 ## 1.7.12
 * CDN: Added Wildcard support for `ComparisonOperator`
 * Network Security Groups: Added option to modify generated SecurityRule priority step increment

--- a/docs/content/api-overview/resources/keyvault.md
+++ b/docs/content/api-overview/resources/keyvault.md
@@ -88,6 +88,7 @@ The `keyVault` builder contains access policies, secrets, and configuration info
 | add_vnet_rule | Adds a virtual network rule. This is the full resource id of a vnet subnet, such as '/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'. |
 | add_secret | Adds a secret to the vault. This can either be a "full" secret config created using the Secret Builder, a string literal value which represents the parameter name, or a string literal with a resource and an expression based on that resource e.g. a storage account and the Key member. |
 | add_secrets | Adds multiple secrets to the vault. This can either be "full" secret configs created using the Secret Builder, string literal values which represents the parameter name. |
+| disable_public_network_access | Disables public network access to the vault. |
 | add_tag | Adds a tag to the key vault. |
 | add_tags | Adds multiple tags to the key vault. |
 

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -216,11 +216,11 @@ type Vault =
                                 ipRules = this.IpRules
                                 virtualNetworkRules = this.VnetRules |> List.map (fun rule -> {| id = rule |})
                             |}
-                        publicNetworkAccess = 
-                          match this.DisablePublicNetworkAccess with
-                          | Some FeatureFlag.Enabled -> "Disabled"
-                          | Some FeatureFlag.Disabled -> "Enabled"
-                          | None -> null
+                        publicNetworkAccess =
+                            match this.DisablePublicNetworkAccess with
+                            | Some FeatureFlag.Enabled -> "Disabled"
+                            | Some FeatureFlag.Disabled -> "Enabled"
+                            | None -> null
                     |}
             |}
 

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -5,13 +5,13 @@ open Farmer
 open Farmer.KeyVault
 open System
 
-let secrets = ResourceType("Microsoft.KeyVault/vaults/secrets", "2019-09-01")
+let secrets = ResourceType("Microsoft.KeyVault/vaults/secrets", "2022-07-01")
 
 let accessPolicies =
-    ResourceType("Microsoft.KeyVault/vaults/accessPolicies", "2019-09-01")
+    ResourceType("Microsoft.KeyVault/vaults/accessPolicies", "2022-07-01")
 
-let vaults = ResourceType("Microsoft.KeyVault/vaults", "2019-09-01")
-let keys = ResourceType("Microsoft.keyVault/vaults/keys", "2019-09-01")
+let vaults = ResourceType("Microsoft.KeyVault/vaults", "2022-07-01")
+let keys = ResourceType("Microsoft.keyVault/vaults/keys", "2022-07-01")
 
 module Vaults =
     type Secret =
@@ -147,6 +147,7 @@ type Vault =
         Bypass: Bypass option
         IpRules: string list
         VnetRules: string list
+        DisablePublicNetworkAccess: FeatureFlag option
         Tags: Map<string, string>
     }
 
@@ -215,6 +216,11 @@ type Vault =
                                 ipRules = this.IpRules
                                 virtualNetworkRules = this.VnetRules |> List.map (fun rule -> {| id = rule |})
                             |}
+                        publicNetworkAccess = 
+                          match this.DisablePublicNetworkAccess with
+                          | Some FeatureFlag.Enabled -> "Disabled"
+                          | Some FeatureFlag.Disabled -> "Enabled"
+                          | None -> null
                     |}
             |}
 

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -191,6 +191,7 @@ type KeyVaultConfig =
         Uri: Uri option
         Keys: KeyConfig list
         Secrets: SecretConfig list
+        DisablePublicNetworkAccess: FeatureFlag option
         Tags: Map<string, string>
     }
 
@@ -248,6 +249,7 @@ type KeyVaultConfig =
                         Bypass = this.NetworkAcl.Bypass
                         IpRules = this.NetworkAcl.IpRules
                         VnetRules = this.NetworkAcl.VnetRules
+                        DisablePublicNetworkAccess = this.DisablePublicNetworkAccess
                         Tags = this.Tags
                     }
 
@@ -414,6 +416,7 @@ type KeyVaultBuilderState =
         Uri: Uri option
         Secrets: SecretConfig list
         Keys: KeyConfig list
+        DisablePublicNetworkAccess: FeatureFlag option
         Tags: Map<string, string>
     }
 
@@ -443,6 +446,7 @@ type KeyVaultBuilder() =
             Uri = None
             Secrets = []
             Keys = []
+            DisablePublicNetworkAccess = None
             Tags = Map.empty
         }
 
@@ -464,6 +468,7 @@ type KeyVaultBuilder() =
             Keys = state.Keys
             Secrets = state.Secrets
             Uri = state.Uri
+            DisablePublicNetworkAccess = state.DisablePublicNetworkAccess
             Tags = state.Tags
         }
 
@@ -711,6 +716,12 @@ type KeyVaultBuilder() =
 
     member this.AddSecrets(state: KeyVaultBuilderState, items) =
         this.AddSecrets(state, items |> Seq.map (fun (key, value) -> SecretConfig.create (key, value)))
+
+    /// Disable public network access
+    [<CustomOperation "disable_public_network_access">]
+    member _.DisablePublicNetworkAccess(state: KeyVaultBuilderState, ?flag:FeatureFlag) = 
+        let flag = defaultArg flag FeatureFlag.Enabled
+        { state with DisablePublicNetworkAccess = Some flag }
 
     interface ITaggable<KeyVaultBuilderState> with
         member _.Add state tags =

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -719,9 +719,12 @@ type KeyVaultBuilder() =
 
     /// Disable public network access
     [<CustomOperation "disable_public_network_access">]
-    member _.DisablePublicNetworkAccess(state: KeyVaultBuilderState, ?flag:FeatureFlag) = 
+    member _.DisablePublicNetworkAccess(state: KeyVaultBuilderState, ?flag: FeatureFlag) =
         let flag = defaultArg flag FeatureFlag.Enabled
-        { state with DisablePublicNetworkAccess = Some flag }
+
+        { state with
+            DisablePublicNetworkAccess = Some flag
+        }
 
     interface ITaggable<KeyVaultBuilderState> with
         member _.Add state tags =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -2101,6 +2101,9 @@ module KeyVault =
         | Restore
         | Recover
         | Purge
+        | GetRotationPolicy
+        | SetRotationPolicy
+        | Rotate
 
         static member All = makeAll<Key>
 

--- a/src/Tests/KeyVault.fs
+++ b/src/Tests/KeyVault.fs
@@ -349,7 +349,10 @@ let tests =
                 let deployment = arm { add_resource vault }
                 let jobj = JObject.Parse(deployment.Template |> Writer.toJson)
 
-                Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Enabled" "public network access should be enabled"
+                Expect.equal
+                    (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString())
+                    "Enabled"
+                    "public network access should be enabled"
             }
             test "Public network access can be disabled" {
                 let vault =
@@ -361,6 +364,9 @@ let tests =
                 let deployment = arm { add_resource vault }
                 let jobj = JObject.Parse(deployment.Template |> Writer.toJson)
 
-                Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Disabled" "public network access should be disabled"
+                Expect.equal
+                    (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString())
+                    "Disabled"
+                    "public network access should be disabled"
             }
         ]

--- a/src/Tests/KeyVault.fs
+++ b/src/Tests/KeyVault.fs
@@ -338,4 +338,29 @@ let tests =
                 let ruleId = string rules.[0].["id"]
                 Expect.equal vnetId ruleId "The setup network rule should match the used vnetId"
             }
+            test "Public network access can be toggled" {
+                let vault =
+                    keyVault {
+                        name "TestFarmVault"
+                        disable_public_network_access
+                        disable_public_network_access FeatureFlag.Disabled
+                    }
+
+                let deployment = arm { add_resource vault }
+                let jobj = JObject.Parse(deployment.Template |> Writer.toJson)
+
+                Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Enabled" "public network access should be enabled"
+            }
+            test "Public network access can be disabled" {
+                let vault =
+                    keyVault {
+                        name "TestFarmVault"
+                        disable_public_network_access
+                    }
+
+                let deployment = arm { add_resource vault }
+                let jobj = JObject.Parse(deployment.Template |> Writer.toJson)
+
+                Expect.equal (jobj.SelectToken("resources[0].properties.publicNetworkAccess").ToString()) "Disabled" "public network access should be disabled"
+            }
         ]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Adds support for disabling public network access against key vault.
* Adds missing key permissions.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let vault =
    keyVault {
        name "my-vault"
        // ...

        // new:
        disable_public_network_access
    }

```
