### PR TITLE
Add service bus security config and zone redundancy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+## vNext
+* ServiceBus: Add support for disabling public network access
+* ServiceBus: Add support for enabling zone redundancy
+* ServiceBus: Add support for setting the mininum TLS version
+
 ## 1.7.12
 * CDN: Added Wildcard support for `ComparisonOperator`
 * Network Security Groups: Added option to modify generated SecurityRule priority step increment

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -50,7 +50,9 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Namespace | sku | The ServiceBusNamespaceSku e.g. Standard |
 | Namespace | namespace_name | The name of the namespace that holds the queue. |
 | Namespace | depends_on | [Sets dependencies on the service bus namespace.](../../dependencies/) |
-| Namespace | add_authorization_rule | Adds an authorization rule to the namespace. |
+| Namespace | enable_zone_redundancy | Enables zone redundancy. |
+| Namespace | disable_public_network_access | Disables public network access to the namespace. |
+| Namespace | min_tls_version | Set the minimum TLS version for clients connecting to the namespace. |
 
 #### Configuration Members
 

--- a/samples/scripts/service-bus.fsx
+++ b/samples/scripts/service-bus.fsx
@@ -7,6 +7,9 @@ open Farmer.ServiceBus
 let myServiceBus = serviceBus {
     name "allMyQueues"
     sku Standard
+    min_tls_version TlsVersion.Tls12
+    enable_zone_redundancy
+    disable_public_network_access
     add_queues [
         queue { name "queuenumberone" }
         queue { name "queuenumbertwo" }

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -9,21 +9,21 @@ let private tryGetIso (v: IsoDateTime option) =
     v |> Option.map (fun v -> v.Value) |> Option.toObj
 
 let subscriptions =
-    ResourceType("Microsoft.ServiceBus/namespaces/topics/subscriptions", "2017-04-01")
+    ResourceType("Microsoft.ServiceBus/namespaces/topics/subscriptions", "2022-01-01-preview")
 
-let queues = ResourceType("Microsoft.ServiceBus/namespaces/queues", "2017-04-01")
-let topics = ResourceType("Microsoft.ServiceBus/namespaces/topics", "2017-04-01")
-let namespaces = ResourceType("Microsoft.ServiceBus/namespaces", "2017-04-01")
+let queues = ResourceType("Microsoft.ServiceBus/namespaces/queues", "2022-01-01-preview")
+let topics = ResourceType("Microsoft.ServiceBus/namespaces/topics", "2022-01-01-preview")
+let namespaces = ResourceType("Microsoft.ServiceBus/namespaces", "2022-01-01-preview")
 
 let queueAuthorizationRules =
-    ResourceType("Microsoft.ServiceBus/namespaces/queues/authorizationRules", "2017-04-01")
+    ResourceType("Microsoft.ServiceBus/namespaces/queues/authorizationRules", "2022-01-01-preview")
 
 let namespaceAuthorizationRules =
-    ResourceType("Microsoft.ServiceBus/namespaces/AuthorizationRules", "2017-04-01")
+    ResourceType("Microsoft.ServiceBus/namespaces/AuthorizationRules", "2022-01-01-preview")
 
 module Namespaces =
     module Topics =
-        let rules = ResourceType("Rules", "2017-04-01")
+        let rules = ResourceType("Rules", "2022-01-01-preview")
 
         type Subscription =
             {
@@ -213,6 +213,9 @@ type Namespace =
         Location: Location
         Sku: Sku
         Dependencies: ResourceId Set
+        ZoneRedundant: FeatureFlag option
+        DisablePublicNetworkAccess: FeatureFlag option
+        MinTlsVersion: TlsVersion option
         Tags: Map<string, string>
     }
 
@@ -234,5 +237,24 @@ type Namespace =
                         name = this.Sku.NameArmValue
                         tier = this.Sku.TierArmValue
                         capacity = this.Capacity |> Option.toNullable
+                    |}
+                properties =
+                    {|
+                        minimumTlsVersion =
+                            match this.MinTlsVersion with
+                            | Some Tls10 -> "1.0"
+                            | Some Tls11 -> "1.1"
+                            | Some Tls12 -> "1.2"
+                            | None -> null
+                        publicNetworkAccess = 
+                          match this.DisablePublicNetworkAccess with
+                          | Some FeatureFlag.Enabled -> "Disabled"
+                          | Some FeatureFlag.Disabled -> "Enabled"
+                          | None -> null
+                        zoneRedundant = 
+                          match this.ZoneRedundant with
+                          | Some FeatureFlag.Enabled -> "true"
+                          | Some FeatureFlag.Disabled -> "false"
+                          | None -> null
                     |}
             |}

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -11,9 +11,14 @@ let private tryGetIso (v: IsoDateTime option) =
 let subscriptions =
     ResourceType("Microsoft.ServiceBus/namespaces/topics/subscriptions", "2022-01-01-preview")
 
-let queues = ResourceType("Microsoft.ServiceBus/namespaces/queues", "2022-01-01-preview")
-let topics = ResourceType("Microsoft.ServiceBus/namespaces/topics", "2022-01-01-preview")
-let namespaces = ResourceType("Microsoft.ServiceBus/namespaces", "2022-01-01-preview")
+let queues =
+    ResourceType("Microsoft.ServiceBus/namespaces/queues", "2022-01-01-preview")
+
+let topics =
+    ResourceType("Microsoft.ServiceBus/namespaces/topics", "2022-01-01-preview")
+
+let namespaces =
+    ResourceType("Microsoft.ServiceBus/namespaces", "2022-01-01-preview")
 
 let queueAuthorizationRules =
     ResourceType("Microsoft.ServiceBus/namespaces/queues/authorizationRules", "2022-01-01-preview")
@@ -246,15 +251,15 @@ type Namespace =
                             | Some Tls11 -> "1.1"
                             | Some Tls12 -> "1.2"
                             | None -> null
-                        publicNetworkAccess = 
-                          match this.DisablePublicNetworkAccess with
-                          | Some FeatureFlag.Enabled -> "Disabled"
-                          | Some FeatureFlag.Disabled -> "Enabled"
-                          | None -> null
-                        zoneRedundant = 
-                          match this.ZoneRedundant with
-                          | Some FeatureFlag.Enabled -> "true"
-                          | Some FeatureFlag.Disabled -> "false"
-                          | None -> null
+                        publicNetworkAccess =
+                            match this.DisablePublicNetworkAccess with
+                            | Some FeatureFlag.Enabled -> "Disabled"
+                            | Some FeatureFlag.Disabled -> "Enabled"
+                            | None -> null
+                        zoneRedundant =
+                            match this.ZoneRedundant with
+                            | Some FeatureFlag.Enabled -> "true"
+                            | Some FeatureFlag.Disabled -> "false"
+                            | None -> null
                     |}
             |}

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -577,19 +577,22 @@ type ServiceBusBuilder() =
 
     /// Enable zone redundancy
     [<CustomOperation "enable_zone_redundancy">]
-    member _.EnableZoneRedundancy(state: ServiceBusConfig, ?flag:FeatureFlag) = 
+    member _.EnableZoneRedundancy(state: ServiceBusConfig, ?flag: FeatureFlag) =
         let flag = defaultArg flag FeatureFlag.Enabled
         { state with ZoneRedundant = Some flag }
 
     /// Disable public network access
     [<CustomOperation "disable_public_network_access">]
-    member _.DisablePublicNetworkAccess(state: ServiceBusConfig, ?flag:FeatureFlag) = 
+    member _.DisablePublicNetworkAccess(state: ServiceBusConfig, ?flag: FeatureFlag) =
         let flag = defaultArg flag FeatureFlag.Enabled
-        { state with DisablePublicNetworkAccess = Some flag }
+
+        { state with
+            DisablePublicNetworkAccess = Some flag
+        }
 
     /// Set minimum TLS version
     [<CustomOperation "min_tls_version">]
-    member _.SetMinTlsVersion(state: ServiceBusConfig, minTlsVersion:TlsVersion) =
+    member _.SetMinTlsVersion(state: ServiceBusConfig, minTlsVersion: TlsVersion) =
         { state with
             MinTlsVersion = Some minTlsVersion
         }

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -582,14 +582,13 @@ type ServiceBusBuilder() =
     [<CustomOperation "enable_zone_redundancy">]
     member _.EnableZoneRedundancy(state: ServiceBusConfig, ?flag: FeatureFlag) =
         let flag = defaultArg flag FeatureFlag.Enabled
-        { state with
-            ZoneRedundant = Some flag
-        }
+        { state with ZoneRedundant = Some flag }
 
     /// Disable public network access
     [<CustomOperation "disable_public_network_access">]
     member _.DisablePublicNetworkAccess(state: ServiceBusConfig, ?flag: FeatureFlag) =
         let flag = defaultArg flag FeatureFlag.Enabled
+
         { state with
             DisablePublicNetworkAccess = Some flag
         }

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -546,7 +546,11 @@ type ServiceBusBuilder() =
         }
 
     member _.Run(state: ServiceBusConfig) =
-        let isBetween min max v = v >= min && v <= max
+
+        match state.ZoneRedundant, state.Sku with
+        | Some FeatureFlag.Enabled, Standard ->
+            raiseFarmer "Zone redundancy can only be enabled against premium service bus namespaces"
+        | _ -> ()
 
         for queue in state.Queues do
             let queue = queue.Value

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -464,6 +464,9 @@ type ServiceBusConfig =
         Queues: Map<ResourceName, ServiceBusQueueConfig>
         Topics: Map<ResourceName, ServiceBusTopicConfig>
         AuthorizationRules: Map<ResourceName, AuthorizationRuleRight Set>
+        ZoneRedundant: FeatureFlag option
+        DisablePublicNetworkAccess: FeatureFlag option
+        MinTlsVersion: TlsVersion option
         Tags: Map<string, string>
     }
 
@@ -488,6 +491,9 @@ type ServiceBusConfig =
                     Location = location
                     Sku = this.Sku
                     Dependencies = this.Dependencies
+                    DisablePublicNetworkAccess = this.DisablePublicNetworkAccess
+                    ZoneRedundant = this.ZoneRedundant
+                    MinTlsVersion = this.MinTlsVersion
                     Tags = this.Tags
                 }
 
@@ -533,6 +539,9 @@ type ServiceBusBuilder() =
             Topics = Map.empty
             Dependencies = Set.empty
             AuthorizationRules = Map.empty
+            DisablePublicNetworkAccess = None
+            ZoneRedundant = None
+            MinTlsVersion = None
             Tags = Map.empty
         }
 
@@ -565,6 +574,25 @@ type ServiceBusBuilder() =
     /// The SKU of the namespace.
     [<CustomOperation "sku">]
     member _.Sku(state: ServiceBusConfig, sku) = { state with Sku = sku }
+
+    /// Enable zone redundancy
+    [<CustomOperation "enable_zone_redundancy">]
+    member _.EnableZoneRedundancy(state: ServiceBusConfig, ?flag:FeatureFlag) = 
+        let flag = defaultArg flag FeatureFlag.Enabled
+        { state with ZoneRedundant = Some flag }
+
+    /// Disable public network access
+    [<CustomOperation "disable_public_network_access">]
+    member _.DisablePublicNetworkAccess(state: ServiceBusConfig, ?flag:FeatureFlag) = 
+        let flag = defaultArg flag FeatureFlag.Enabled
+        { state with DisablePublicNetworkAccess = Some flag }
+
+    /// Set minimum TLS version
+    [<CustomOperation "min_tls_version">]
+    member _.SetMinTlsVersion(state: ServiceBusConfig, minTlsVersion:TlsVersion) =
+        { state with
+            MinTlsVersion = Some minTlsVersion
+        }
 
     [<CustomOperation "add_queues">]
     member _.AddQueues(state: ServiceBusConfig, queues) =

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -546,7 +546,6 @@ type ServiceBusBuilder() =
         }
 
     member _.Run(state: ServiceBusConfig) =
-
         match state.ZoneRedundant, state.Sku with
         | Some FeatureFlag.Enabled, Standard ->
             raiseFarmer "Zone redundancy can only be enabled against premium service bus namespaces"
@@ -583,13 +582,14 @@ type ServiceBusBuilder() =
     [<CustomOperation "enable_zone_redundancy">]
     member _.EnableZoneRedundancy(state: ServiceBusConfig, ?flag: FeatureFlag) =
         let flag = defaultArg flag FeatureFlag.Enabled
-        { state with ZoneRedundant = Some flag }
+        { state with
+            ZoneRedundant = Some flag
+        }
 
     /// Disable public network access
     [<CustomOperation "disable_public_network_access">]
     member _.DisablePublicNetworkAccess(state: ServiceBusConfig, ?flag: FeatureFlag) =
         let flag = defaultArg flag FeatureFlag.Enabled
-
         { state with
             DisablePublicNetworkAccess = Some flag
         }

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -44,7 +44,7 @@ let dummyClient =
 let getResourceAtIndex o =
     o |> getResourceAtIndex dummyClient.SerializationSettings
 
-let parseTemplate (arm:ResourceGroupConfig) = 
+let parseTemplate (arm: ResourceGroupConfig) =
     let json = arm.Template |> Writer.toJson
     Newtonsoft.Json.Linq.JObject.Parse(json)
 
@@ -105,7 +105,11 @@ let tests =
                     }
 
                 let jobj = parseTemplate resourceGroup
-                Expect.equal (jobj.SelectToken($"resources[0].properties.publicNetworkAccess").ToString()) "Disabled" "Public network access should be disabled"
+
+                Expect.equal
+                    (jobj.SelectToken($"resources[0].properties.publicNetworkAccess").ToString())
+                    "Disabled"
+                    "Public network access should be disabled"
             }
 
             test "Public network access can be toggled" {
@@ -122,7 +126,11 @@ let tests =
                     }
 
                 let jobj = parseTemplate resourceGroup
-                Expect.equal (jobj.SelectToken($"resources[0].properties.publicNetworkAccess").ToString()) "Enabled" "Public network access should be enabled"
+
+                Expect.equal
+                    (jobj.SelectToken($"resources[0].properties.publicNetworkAccess").ToString())
+                    "Enabled"
+                    "Public network access should be enabled"
             }
 
             test "Zone redundancy can be enabled" {
@@ -138,7 +146,11 @@ let tests =
                     }
 
                 let jobj = parseTemplate resourceGroup
-                Expect.equal (jobj.SelectToken($"resources[0].properties.zoneRedundant").ToString()) "true" "Zone redundancy should be enabled"
+
+                Expect.equal
+                    (jobj.SelectToken($"resources[0].properties.zoneRedundant").ToString())
+                    "true"
+                    "Zone redundancy should be enabled"
             }
 
             test "Zone redundancy can be toggled" {
@@ -155,7 +167,11 @@ let tests =
                     }
 
                 let jobj = parseTemplate resourceGroup
-                Expect.equal (jobj.SelectToken($"resources[0].properties.zoneRedundant").ToString()) "false" "Zone redundancy should be disabled"
+
+                Expect.equal
+                    (jobj.SelectToken($"resources[0].properties.zoneRedundant").ToString())
+                    "false"
+                    "Zone redundancy should be disabled"
             }
 
             test "Min TLS version can be set" {
@@ -171,7 +187,11 @@ let tests =
                     }
 
                 let jobj = parseTemplate resourceGroup
-                Expect.equal (jobj.SelectToken($"resources[0].properties.minimumTlsVersion").ToString()) "1.2" "Min TLS should be 1.2"
+
+                Expect.equal
+                    (jobj.SelectToken($"resources[0].properties.minimumTlsVersion").ToString())
+                    "1.2"
+                    "Min TLS should be 1.2"
             }
 
             testList

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -139,7 +139,7 @@ let tests =
                         add_resource (
                             serviceBus {
                                 name "serviceBus"
-                                sku Standard
+                                sku (Premium MessagingUnits.OneUnit)
                                 enable_zone_redundancy
                             }
                         )
@@ -159,7 +159,7 @@ let tests =
                         add_resource (
                             serviceBus {
                                 name "serviceBus"
-                                sku Standard
+                                sku (Premium MessagingUnits.OneUnit)
                                 enable_zone_redundancy
                                 enable_zone_redundancy FeatureFlag.Disabled
                             }
@@ -172,6 +172,18 @@ let tests =
                     (jobj.SelectToken($"resources[0].properties.zoneRedundant").ToString())
                     "false"
                     "Zone redundancy should be disabled"
+            }
+
+            test "Zone redundancy cannot be set against standard SKU namespace" {
+                Expect.throws
+                    (fun () ->
+                        serviceBus {
+                            name "serviceBus"
+                            sku Standard
+                            enable_zone_redundancy
+                        }
+                        |> ignore)
+                    "Zone redundancy can only be enabled against premium service bus namespaces"
             }
 
             test "Min TLS version can be set" {

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -37,10 +37,11 @@
       "type": "Microsoft.Storage/storageAccounts/queueServices/queues"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [],
       "location": "northeurope",
       "name": "farmereventpubservicebusns",
+      "properties": {},
       "sku": {
         "name": "Basic",
         "tier": "Basic"
@@ -49,7 +50,7 @@
       "type": "Microsoft.ServiceBus/namespaces"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmereventpubservicebusns')]"
       ],

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -310,10 +310,11 @@
       "type": "Microsoft.Web/sites"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [],
       "location": "northeurope",
       "name": "farmerbus1979",
+      "properties": {},
       "sku": {
         "name": "Standard",
         "tier": "Standard"
@@ -322,7 +323,7 @@
       "type": "Microsoft.ServiceBus/namespaces"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmerbus1979')]"
       ],
@@ -331,7 +332,7 @@
       "type": "Microsoft.ServiceBus/namespaces/queues"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmerbus1979')]"
       ],
@@ -340,7 +341,7 @@
       "type": "Microsoft.ServiceBus/namespaces/topics"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmerbus1979', 'topic1')]"
       ],

--- a/src/Tests/test-data/service-bus.json
+++ b/src/Tests/test-data/service-bus.json
@@ -5,10 +5,11 @@
   "parameters": {},
   "resources": [
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [],
       "location": "northeurope",
       "name": "farmer-bus",
+      "properties": {},
       "sku": {
         "capacity": 1,
         "name": "Premium",
@@ -18,7 +19,7 @@
       "type": "Microsoft.ServiceBus/namespaces"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmer-bus')]"
       ],
@@ -27,7 +28,7 @@
       "type": "Microsoft.ServiceBus/namespaces/queues"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', 'farmer-bus')]"
       ],
@@ -36,7 +37,7 @@
       "type": "Microsoft.ServiceBus/namespaces/topics"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmer-bus', 'topic1')]"
       ],
@@ -44,7 +45,7 @@
       "properties": {},
       "resources": [
         {
-          "apiVersion": "2017-04-01",
+          "apiVersion": "2022-01-01-preview",
           "dependsOn": [
             "sub1"
           ],
@@ -63,14 +64,14 @@
       "type": "Microsoft.ServiceBus/namespaces/topics/subscriptions"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [],
       "name": "farmer-bus/unmanaged-topic",
       "properties": {},
       "type": "Microsoft.ServiceBus/namespaces/topics"
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2022-01-01-preview",
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces/topics', 'farmer-bus', 'unmanaged-topic')]"
       ],
@@ -78,7 +79,7 @@
       "properties": {},
       "resources": [
         {
-          "apiVersion": "2017-04-01",
+          "apiVersion": "2022-01-01-preview",
           "dependsOn": [
             "sub1"
           ],


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Adds `disable_public_network_access` to the service bus builder
* Adds `enable_zone_redundancy` to the service bus builder
* Adds `min_tls_version` to the service bus builder to allow you to set min TLS version.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let myServiceBus = serviceBus {
    name "allMyQueues"
    sku (Premium MessagingUnits.OneUnit)
    min_tls_version TlsVersion.Tls12
    enable_zone_redundancy
    disable_public_network_access
}

```
