### PR TITLE
Network securty groups option to set initial rule priority

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 1.7.13
+* Network Security Groups: Added option to set priority for initial SecurityRule.
+
+
 ## 1.7.12
 * CDN: Added Wildcard support for `ComparisonOperator`
 * Network Security Groups: Added option to modify generated SecurityRule priority step increment

--- a/docs/content/api-overview/resources/nsg.md
+++ b/docs/content/api-overview/resources/nsg.md
@@ -17,7 +17,8 @@ The Network Security Group builder creates network security groups with rules fo
 |-|-|-|
 | nsg | name | Specifies the name of the network security group |
 | nsg | add_rules | Adds security rules to the network security group |
-| nsg | priority_incr | First rule is priority 100. After that, this sets how much priority is increased per each rule. Default 100. |
+| nsg | initial_rule_priority | The priority of the first rule, after which each rule gets an incrementally higher value. Default 100. |
+| nsg | priority_incr | This sets how much priority is increased per each rule. Default 100. |
 | securityRule | name | The name of the security rule |
 | securityRule | description | The description  of the security rule |
 | securityRule | services | The services port(s) and protocol(s) protected by this security rule |

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -171,6 +171,7 @@ type NsgConfig =
         Name: ResourceName
         SecurityRules: SecurityRuleConfig list
         Tags: Map<string, string>
+        InitialRulePriority: int
         PriorityIncrementor: int
     }
 
@@ -186,7 +187,10 @@ type NsgConfig =
                         seq {
                             // Policy Rules
                             for priority, rule in List.indexed this.SecurityRules do
-                                buildNsgRule this.Name rule (priority * this.PriorityIncrementor + 100)
+                                buildNsgRule
+                                    this.Name
+                                    rule
+                                    (priority * this.PriorityIncrementor + this.InitialRulePriority)
                         }
                         |> List.ofSeq
                     Tags = this.Tags
@@ -199,6 +203,7 @@ type NsgBuilder() =
             Name = ResourceName.Empty
             SecurityRules = []
             Tags = Map.empty
+            InitialRulePriority = 100
             PriorityIncrementor = 100
         }
 
@@ -211,6 +216,13 @@ type NsgBuilder() =
     member _.AddSecurityRules(state: NsgConfig, rules) =
         { state with
             SecurityRules = state.SecurityRules @ rules
+        }
+
+    /// Initial rule priority sets the priority of the first rule.
+    [<CustomOperation "initial_rule_priority">]
+    member _.InitialRulePriority(state: NsgConfig, initialPriority) =
+        { state with
+            InitialRulePriority = initialPriority
         }
 
     /// First rule is priority 100. After that, this sets how much priority is increased per each rule. Default 100.

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -165,6 +165,7 @@ let tests =
                     nsg {
                         name "my-nsg"
                         add_rules [ webPolicy; appPolicy; dbPolicy; blockOutbound ]
+                        initial_rule_priority 1000
                         priority_incr 50
                     }
 
@@ -185,7 +186,7 @@ let tests =
                     Expect.equal rule1.DestinationPortRanges.[1] "443" ""
                     Expect.equal rule1.Direction "Inbound" ""
                     Expect.equal rule1.Protocol "Tcp" ""
-                    Expect.equal rule1.Priority (Nullable 100) ""
+                    Expect.equal rule1.Priority (Nullable 1000) ""
                     Expect.equal rule1.SourceAddressPrefix "Internet" ""
                     Expect.equal rule1.SourceAddressPrefixes.Count 0 ""
                     Expect.equal rule1.SourcePortRange "*" ""
@@ -198,7 +199,7 @@ let tests =
                     Expect.equal rule2.DestinationPortRanges.[0] "8080" ""
                     Expect.equal rule2.Direction "Inbound" ""
                     Expect.equal rule2.Protocol "Tcp" ""
-                    Expect.equal rule2.Priority (Nullable 150) ""
+                    Expect.equal rule2.Priority (Nullable 1050) ""
                     Expect.equal rule2.SourceAddressPrefixes.[0] "10.100.30.0/24" ""
                     Expect.equal rule2.SourcePortRanges.Count 0 ""
                     // DB server access
@@ -209,7 +210,7 @@ let tests =
                     Expect.equal rule3.DestinationPortRanges.[0] "5432" ""
                     Expect.equal rule3.Direction "Inbound" ""
                     Expect.equal rule3.Protocol "Tcp" ""
-                    Expect.equal rule3.Priority (Nullable 200) ""
+                    Expect.equal rule3.Priority (Nullable 1100) ""
                     Expect.equal rule3.SourceAddressPrefixes.[0] "10.100.31.0/24" ""
                     Expect.equal rule3.SourcePortRanges.Count 0 ""
                     // Block Internet access
@@ -220,7 +221,7 @@ let tests =
                     Expect.equal rule4.DestinationPortRange "*" ""
                     Expect.equal rule4.Direction "Outbound" ""
                     Expect.equal rule4.Protocol "*" ""
-                    Expect.equal rule4.Priority (Nullable 250) ""
+                    Expect.equal rule4.Priority (Nullable 1150) ""
                     Expect.containsAll rule4.SourceAddressPrefixes [ "10.100.31.0/24"; "10.100.32.0/24" ] ""
                 | _ -> raiseFarmer "Unexpected number of resources in template."
             }

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -173,8 +173,6 @@ let tests =
                     arm { add_resource myNsg }
                     |> findAzureResources<NetworkSecurityGroup> client.SerializationSettings
 
-                printfn "%A" nsg
-
                 match nsg.Head.SecurityRules |> List.ofSeq with
                 | [ rule1; rule2; rule3; rule4 ] ->
                     // Web server access


### PR DESCRIPTION
The changes in this PR are as follows:

* Network Security Groups: Added option to set priority for initial SecurityRule.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
    nsg {
        name "my-nsg"
        initial_rule_priority 1000
        priority_incr 50
    }
```
