### PR TITLE
Dedicated support for Startup Command.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* Web App: Ability to set Startup Command directly (useful for Linux deployments).
 
 ## 1.7.13
 * KeyVault: Added support for disabling public network access.

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -63,6 +63,7 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | link_to_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. Use this operator when the given VNET is in the same deployment |
 | Web App | link_to_unmanaged_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. Use this operator when the given VNET is *not* in the same deployment |
 | Web App | add_virtual_applications | Adds list of `virtualApplication` definitions to the webapp |
+| Web App | startup_command | Adds a startup command to be run post-deployment. This is useful on Linux-based web app deployments, where your application is "implicitly" converted into a docker image and may need to be told what to do on startup. 
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -375,7 +375,8 @@ type WebAppConfig =
         SourceControlSettings: {| Repository: Uri
                                   Branch: string
                                   ContinuousIntegration: FeatureFlag |} option
-        DockerImage: (string * string) option
+        DockerRegistryPath: string option
+        StartupCommand: string option
         DockerCi: bool
         DockerAcrCredentials: {| RegistryName: string
                                  Password: SecureParameter |} option
@@ -564,9 +565,8 @@ type WebAppConfig =
                                 match this.CommonWebConfig.OperatingSystem with
                                 | Linux -> "linux"
                                 | Windows -> ()
-                                match this.DockerImage with
-                                | Some _ -> "container"
-                                | _ -> ()
+                                if this.DockerRegistryPath.IsSome then
+                                    "container"
                             ]
                             |> String.concat ","
                         Dependencies =
@@ -597,8 +597,8 @@ type WebAppConfig =
                             match this.CommonWebConfig.OperatingSystem with
                             | Windows -> None
                             | Linux ->
-                                match this.DockerImage with
-                                | Some (image, _) -> Some("DOCKER|" + image)
+                                match this.DockerRegistryPath with
+                                | Some image -> Some("DOCKER|" + image)
                                 | None ->
                                     match this.Runtime with
                                     | DotNetCore version -> Some $"DOTNETCORE|{version}"
@@ -649,7 +649,7 @@ type WebAppConfig =
                             | _ -> None
                             |> Option.map (fun stack -> "CURRENT_STACK", stack)
                             |> Option.toList
-                        AppCommandLine = this.DockerImage |> Option.map snd
+                        AppCommandLine = this.StartupCommand
                         AutoSwapSlotName = None
                         ZipDeployPath =
                             this.CommonWebConfig.ZipDeployPath
@@ -872,7 +872,8 @@ type WebAppBuilder() =
             Tags = Map.empty
             Dependencies = Set.empty
             Runtime = Runtime.DotNetCoreLts
-            DockerImage = None
+            DockerRegistryPath = None
+            StartupCommand = None
             DockerCi = false
             SourceControlSettings = None
             DockerAcrCredentials = None
@@ -894,21 +895,21 @@ type WebAppBuilder() =
         { state with
             SiteExtensions =
                 match state with
-                // its important to only add this extension if we're not using Web App for Containers - if we are
+                // it is important to only add this extension if we're not using Web App for Containers - if we are
                 // then this will generate an error during deployment:
                 // No route registered for '/api/siteextensions/Microsoft.AspNetCore.AzureAppServices.SiteExtension'
                 | {
                       Runtime = DotNetCore _
                       AutomaticLoggingExtension = true
-                      DockerImage = None
+                      DockerRegistryPath = None
                       CommonWebConfig = { OperatingSystem = Windows }
                   } -> state.SiteExtensions.Add Extensions.Logging
                 | _ -> state.SiteExtensions
-            DockerImage =
-                match state.DockerImage, state.DockerAcrCredentials with
-                | Some (image, tag), Some credentials when not (image.Contains "azurecr.io") ->
-                    Some($"{credentials.RegistryName}.azurecr.io/{image}", tag)
-                | Some x, _ -> Some x
+            DockerRegistryPath =
+                match state.DockerRegistryPath, state.DockerAcrCredentials with
+                | Some image, Some credentials when not (image.Contains "azurecr.io") ->
+                    Some $"{credentials.RegistryName}.azurecr.io/{image}"
+                | Some registryPath, _ -> Some registryPath
                 | None, _ -> None
         }
 
@@ -961,23 +962,31 @@ type WebAppBuilder() =
     [<CustomOperation "runtime_stack">]
     member _.RuntimeStack(state: WebAppConfig, runtime) = { state with Runtime = runtime }
 
-    [<CustomOperation "docker_image">]
     /// Specifies a docker image to use from the registry (linux only), and the startup command to execute.
+    [<CustomOperation "docker_image">]
     member _.DockerImage(state: WebAppConfig, registryPath, startupFile) =
         { state with
             CommonWebConfig =
                 { state.CommonWebConfig with
                     OperatingSystem = Linux
                 }
-            DockerImage = Some(registryPath, startupFile)
+            DockerRegistryPath = Some registryPath
+            StartupCommand = Some startupFile
         }
 
-    [<CustomOperation "docker_ci">]
     /// Have your custom Docker image automatically re-deployed when a new version is pushed to e.g. Docker hub.
+    [<CustomOperation "docker_ci">]
     member _.DockerCI(state: WebAppConfig) = { state with DockerCi = true }
 
-    [<CustomOperation "docker_use_azure_registry">]
+    /// Supply a specific startup command - typically used when using "raw" app deployments to App Service Linux.
+    [<CustomOperation "startup_command">]
+    member _.StartupCommand(state: WebAppConfig, startupCommand) =
+        { state with
+            StartupCommand = Some startupCommand
+        }
+
     /// Have your custom Docker image automatically re-deployed when a new version is pushed to e.g. Docker hub.
+    [<CustomOperation "docker_use_azure_registry">]
     member _.DockerAcrCredentials(state: WebAppConfig, registryName) =
         { state with
             DockerAcrCredentials =

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -1602,6 +1602,17 @@ let tests =
                     "Should add virtual application definition for root"
             }
 
+            test "Can add startup command without docker" {
+                let wa: Site =
+                    webApp {
+                        name "test"
+                        startup_command "foo"
+                    }
+                    |> getResourceAtIndex 3
+
+                Expect.equal wa.SiteConfig.AppCommandLine "foo" "Command line not set correctly"
+            }
+
             test "Supports defining additional virtual applications without changing root" {
                 let wa =
                     webApp {


### PR DESCRIPTION
This PR closes #999 

The changes in this PR are as follows:

* Adds a `startup_command` keyword to the Web App builder.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
webApp {
    startup_command "foo.exe"
}
```

I'll test it end-to-end shortly. I'm sure I've done Linux deployments in the past so I'm surprised I can't find a clear way of doing this - @ninjarobot do you know any way to already do this in Farmer?