### PR TITLE
Automatically round container instance memory to the first decimal place

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 ## vNext
 * Identity: Update the list of all RBAC roles to latest.
+* Container Groups: Automatically round container instance memory to the first decimal place.
 
 ## 1.7.13
 * KeyVault: Added support for disabling public network access.

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -707,7 +707,10 @@ type ContainerInstanceBuilder() =
 
     /// Sets the maximum gigabytes of memory the container instance may use
     [<CustomOperationAttribute "memory">]
-    member _.Memory(state: ContainerInstanceConfig, memory) = { state with Memory = memory }
+    member _.Memory(state: ContainerInstanceConfig, memory: float<Gb>) =
+        { state with
+            Memory = System.Math.Round(memory / 1.<Gb>, 1) * 1.<Gb>
+        }
 
     /// Enables container instances with gpus
     [<CustomOperationAttribute "gpu">]

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -100,6 +100,15 @@ let tests =
 
                 Expect.equal 8.0<Gb> container8Gb.Memory "Memory rounded incorrectly for 8 GB"
 
+                let container8_2Gb =
+                    containerInstance {
+                        name "myapp"
+                        image "myapp:latest"
+                        memory 8.2<Gb>
+                    }
+
+                Expect.equal 8.2<Gb> container8_2Gb.Memory "Memory rounded incorrectly for 8.2 GB"
+
                 let container0_2Gb =
                     containerInstance {
                         name "myapp"

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -81,6 +81,35 @@ let tests =
                 Expect.equal ports [ 80; 443; 9090 ] "Incorrect ports on container"
             }
 
+            test "Container group memory increment truncation" {
+                let container4_5Gb =
+                    containerInstance {
+                        name "myapp"
+                        image "myapp:latest"
+                        memory 4.5678<Gb>
+                    }
+
+                Expect.equal 4.6<Gb> container4_5Gb.Memory "Memory rounded incorrectly for 4.5 GB"
+
+                let container8Gb =
+                    containerInstance {
+                        name "myapp"
+                        image "myapp:latest"
+                        memory 8.<Gb>
+                    }
+
+                Expect.equal 8.0<Gb> container8Gb.Memory "Memory rounded incorrectly for 8 GB"
+
+                let container0_2Gb =
+                    containerInstance {
+                        name "myapp"
+                        image "myapp:latest"
+                        memory 0.22<Gb>
+                    }
+
+                Expect.equal 0.2<Gb> container0_2Gb.Memory "Memory rounded incorrectly for 0.2 GB"
+            }
+
             test "Container group with init containers" {
                 let group =
                     let emptyDir1 = "emptyDir1"


### PR DESCRIPTION
The container instances in container groups must have memory defined in increments of 0.1 GB, otherwise it will give an error of:`The memory requirement should be in increments of 0.1 GB`

The changes in this PR are as follows:

* Container Groups: Automatically round container instance memory to the first decimal place.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Validation change only, so no doc update.