### PR TITLE
Bugfix to remove apiVersion from  embedded routes in Route Table

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.15
+* Route Tables: Fix bug where embedded routes should only serialize properties.
+
 ## 1.7.14
 * Identity: Update the list of all RBAC roles to latest.
 * Container Groups: Automatically round container instance memory to the first decimal place.

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -137,7 +137,13 @@ type RouteTable =
     member internal this.JsonModelProperties =
         {|
             disableBgpRoutePropagation = this.DisableBGPRoutePropagation.AsBoolean
-            routes = this.Routes |> Seq.map (fun x -> (x :> IArmResource).JsonModel)
+            routes =
+                this.Routes
+                |> Seq.map (fun x ->
+                    {|
+                        name = x.Name.Value
+                        properties = x.JsonModelProperties
+                    |})
         |}
 
     interface IArmResource with

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -721,6 +721,7 @@ let tests =
                 Expect.isNotNull routes "Routes should have been generated for the route table"
                 Expect.equal (string routes.[0].["name"]) "myroute" "route 1 should be named 'myroute'"
                 Expect.equal (string routes.[1].["name"]) "myroute2" "route 2 should be named 'myroute2'"
+                Expect.isNull routes.[0].["apiVersion"] "Embedded routes should not have 'apiVersion'."
                 let routeProps = routes.[0].["properties"]
                 let route2Props = routes.[1].["properties"]
                 let route3Props = routes.[2].["properties"]


### PR DESCRIPTION
The changes in this PR are as follows:

* Route Tables: Fix bug where embedded routes should only serialize properties.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
No documentation update since this is an internal bug fix.

```fsharp
routeTable {
    name "test-rt"
    add_routes [
        route {
            name "virtual-net1"
            addressPrefix "100.72.16.0/24"
            nextHopIpAddress "100.72.2.53"
        }
        route {
            name "virtual-net2"
            addressPrefix "192.168.100.0/24"
            nextHopIpAddress "100.72.2.53"
        }
    ]
}
```