### PR TITLE
Add support for creating and attaching VM disks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@ Release Notes
 
 ## vNext
 * Container Apps: Fix scaler spelling
+* Disks: Create managed disks
+* Virtual Machines: Attach existing managed disks.
 
 ## 1.7.16
 * Container Apps: Fix a bug whereby Dapr was not correctly turned on.

--- a/docs/content/api-overview/resources/disk.md
+++ b/docs/content/api-overview/resources/disk.md
@@ -1,0 +1,96 @@
+---
+title: "Disk"
+date: 2023-02-16T09:19:00+00:00
+chapter: false
+weight: 22
+---
+
+#### Overview
+The `disk` builder creates managed disks that may be attached to a virtual machine. With managed disks, the storage account backing the disk is handled by Azure. Disks can be created as empty disks or by importing a virtual hard disk from an existing storage account.
+
+* Disks (`Microsoft.Compute/disks`)
+
+#### Builder Keywords
+
+|Keyword|Purpose|
+|-|-|
+|name|Sets the name of the managed disk.|
+|sku|Sets the type of disk, such as `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, or `UltraSSD_LRS`.|
+|add_availability_zone|When a disk will be attached to a VM in an availability zone, the same availability zone should be set here.|
+|os_type|Sets the OS for the managed disk - `Windows` or `Linux`.|
+|create_empty|Creates an empty disk of the given size.|
+|import|Imports a disk from an existing virtual hard drive (.vhd) file.|
+
+#### Example
+
+```fsharp
+open Farmer
+open Farmer.Builders
+
+let emptyDisk =
+    disk {
+        name "empty-disk"
+        os_type Linux
+        create_empty 128<Gb>
+    }
+
+let importedDisk =
+    disk {
+        name "imported-disk-image"
+        sku Vm.DiskType.Premium_LRS
+        os_type Linux
+
+        // Provide the URI for the disk image and the ARM resource Id for the storage account.
+        import
+            (System.Uri
+                "https://mystorageaccount.blob.core.windows.net/vhds/MyVirtualHardDisk.vhd")
+            (Arm.Storage.storageAccounts.resourceId "mystorageaccount")
+    }
+```
+
+Multiple disks can be created and then attached to a virtual machine:
+
+```fsharp
+let disk0 =
+    disk {
+        name "disk-0"
+        sku Vm.DiskType.Premium_LRS
+        os_type Linux
+        create_empty 1024<Gb>
+        add_availability_zone "1"
+    }
+
+let disk1 =
+    disk {
+        name "disk-1"
+        sku Vm.DiskType.Standard_LRS
+        os_type Linux
+        import
+            (System.Uri
+                "https://mystorageaccount.blob.core.windows.net/vhds/MyVirtualHardDisk.vhd")
+            (Arm.Storage.storageAccounts.resourceId "mystorageaccount")
+        add_availability_zone "1"
+    }
+
+let vmWithAttachedDisks =
+    vm {
+        name "vm-with-attached-disks"
+        vm_size Standard_B1ms
+        operating_system UbuntuServer_2204LTS
+        username "azureuser"
+        add_availability_zone "1"
+        attach_data_disk disk0
+        attach_data_disk disk1
+    }
+
+let deployment =
+    arm {
+        add_resources
+            [
+                disk0
+                disk1
+                vmWithAttachedDisks
+            ]
+    }
+
+```

--- a/docs/content/api-overview/resources/virtual-machine.md
+++ b/docs/content/api-overview/resources/virtual-machine.md
@@ -34,6 +34,10 @@ In addition, every VM you create will add a SecureString parameter to the ARM te
 |add_disk|Adds a data disk to the VM with a specific size and type.|
 |add_ssd_disk|Adds a SSD data disk to the VM with a specific size.|
 |add_slow_disk|Adds a conventional (non-SSD) data disk to the VM with a specific size.|
+|attach_os_disk|Attaches an newly imported managed disk to the VM as the OS disk. The OS (Windows or Linux) for the image must be specified. When attaching an OS disk, the OS settings such as username, password, and `configData` cannot be set.|
+|attach_existing_os_disk|Attaches an existing managed disk to the VM as the OS disk.|
+|attach_data_disk|Attaches an newly imported managed disk to the VM as a data disk.|
+|attach_existing_data_disk|Attaches an existing managed disk to the VM as a data disk.|
 |no_disk|Excludes a data disk (only an OS disk) - common when mounting cloud storage.|
 |domain_name_prefix|Sets the prefix for the domain name of the VM.|
 |address_prefix|Sets the IP address prefix of the VM.|

--- a/src/Farmer/Arm/Disk.fs
+++ b/src/Farmer/Arm/Disk.fs
@@ -1,0 +1,57 @@
+[<AutoOpen>]
+module Farmer.Arm.Disk
+
+open System
+open Farmer
+
+let disks = ResourceType("Microsoft.Compute/disks", "2022-07-02")
+
+type DiskCreation =
+    | Import of SourceUri: Uri * StorageAccountId: ResourceId
+    | Empty of Size: int<Gb>
+
+type Disk =
+    {
+        Name: ResourceName
+        Location: Location
+        Sku: Vm.DiskType option
+        Zones: string list
+        OsType: OS
+        CreationData: DiskCreation
+        Tags: Map<string, string>
+        Dependencies: ResourceId Set
+    }
+
+    interface IArmResource with
+        member this.ResourceId = disks.resourceId this.Name
+
+        member this.JsonModel =
+            {| disks.Create(this.Name, this.Location, dependsOn = this.Dependencies, tags = this.Tags) with
+                sku =
+                    this.Sku
+                    |> Option.map (fun sku -> {| name = sku.ArmValue |} :> obj)
+                    |> Option.toObj
+                zones = if this.Zones.IsEmpty then null else ResizeArray(this.Zones)
+                properties =
+                    {|
+                        creationData =
+                            match this.CreationData with
+                            | Empty _ -> {| createOption = "Empty" |} :> obj
+                            | Import (sourceUri, storageAccountId) ->
+                                {|
+                                    createOption = "Import"
+                                    sourceUri = sourceUri.AbsoluteUri
+                                    storageAccountId = storageAccountId.Eval()
+                                |}
+                                :> obj
+                        diskSizeGB =
+                            match this.CreationData with
+                            | Empty size -> size / 1<Gb> :> obj
+                            | _ -> null
+                        osType =
+                            this.OsType
+                            |> function
+                                | Linux -> "Linux"
+                                | Windows -> "Windows"
+                    |}
+            |}

--- a/src/Farmer/Builders/Builders.Disk.fs
+++ b/src/Farmer/Builders/Builders.Disk.fs
@@ -1,0 +1,99 @@
+[<AutoOpen>]
+module Farmer.Builders.Disk
+
+open Farmer
+open Farmer.Arm.Disk
+
+type DiskConfig =
+    {
+        Name: ResourceName
+        Sku: Vm.DiskType option
+        Zones: string list
+        OsType: OS
+        CreationData: DiskCreation
+        Tags: Map<string, string>
+        Dependencies: ResourceId Set
+    }
+
+    interface IBuilder with
+        member this.ResourceId = disks.resourceId this.Name
+
+        member this.BuildResources location =
+            [
+                {
+                    Name = this.Name
+                    Location = location
+                    Sku = this.Sku
+                    Zones = this.Zones
+                    OsType = this.OsType
+                    CreationData = this.CreationData
+                    Tags = this.Tags
+                    Dependencies = this.Dependencies
+                }
+            ]
+
+type DiskBuilder() =
+
+    // Default yields a 1 terabyte disk partitioned for Windows.
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            Sku = None
+            Zones = []
+            OsType = OS.Windows
+            CreationData = Empty 1024<Gb>
+            Tags = Map.empty
+            Dependencies = Set.empty
+        }
+
+    [<CustomOperation "name">]
+    member _.Name(config: DiskConfig, name) =
+        { config with Name = ResourceName name }
+
+    [<CustomOperation "sku">]
+    member _.Name(config: DiskConfig, diskType) = { config with Sku = Some diskType }
+
+    [<CustomOperation "add_availability_zone">]
+    member _.AddAvailabilityZone(state: DiskConfig, az: string) =
+        { state with
+            Zones = state.Zones @ [ az ]
+        }
+
+    [<CustomOperation "os_type">]
+    member _.OsType(config: DiskConfig, os) = { config with OsType = os }
+
+    [<CustomOperation "create_empty">]
+    member _.CreateEmpty(config: DiskConfig, size: int<Gb>) =
+        { config with
+            CreationData = Empty size
+        }
+
+    [<CustomOperation "import">]
+    member _.Import(config: DiskConfig, sourceVhd: System.Uri, storageAccountId: ResourceId) =
+        { config with
+            CreationData = Import(sourceVhd, storageAccountId)
+        }
+
+    member _.Import(config: DiskConfig, sourceVhd: System.Uri, storageAccount: StorageAccountConfig) =
+        { config with
+            CreationData = Import(sourceVhd, (storageAccount :> IBuilder).ResourceId)
+        }
+
+    member _.Import(config: DiskConfig, sourceVhd: System.Uri, storageAccountName: ResourceName) =
+        { config with
+            CreationData = Import(sourceVhd, Farmer.Arm.Storage.storageAccounts.resourceId storageAccountName)
+        }
+
+    interface ITaggable<DiskConfig> with
+        member _.Add state tags =
+            { state with
+                Tags = state.Tags |> Map.merge tags
+            }
+
+    interface IDependable<DiskConfig> with
+        member _.Add state newDeps =
+            { state with
+                Dependencies = state.Dependencies + newDeps
+            }
+
+let disk = DiskBuilder()

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -87,6 +87,7 @@
     <Compile Include="Arm/DataLakeStore.fs" />
     <Compile Include="Arm/DBforPostgreSQL.fs" />
     <Compile Include="Arm/Devices.fs" />
+    <Compile Include="Arm/Disk.fs" />
     <Compile Include="Arm/DocumentDb.fs" />
     <Compile Include="Arm/EventHub.fs" />
     <Compile Include="Arm/Insights.fs" />
@@ -130,6 +131,7 @@
     <Compile Include="Builders/Builders.ContainerService.fs" />
     <Compile Include="Builders/Builders.DataLake.fs" />
     <Compile Include="Builders/Builders.DeploymentScript.fs" />
+    <Compile Include="Builders/Builders.Disk.fs" />
     <Compile Include="Builders/Builders.Dns.fs" />
     <Compile Include="Builders/Builders.Redis.fs" />
     <Compile Include="Builders/Builders.KeyVault.fs" />

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -39,6 +39,7 @@ let allTests =
                     DedicatedHosts.tests
                     DeploymentScript.tests
                     DiagnosticSettings.tests
+                    Disk.tests
                     Dns.tests
                     EventGrid.tests
                     EventHub.tests

--- a/src/Tests/Disk.fs
+++ b/src/Tests/Disk.fs
@@ -1,0 +1,89 @@
+module Disk
+
+open Expecto
+open Farmer
+open Farmer.Builders
+open Newtonsoft.Json.Linq
+
+let tests =
+    testList
+        "Disk Tests"
+        [
+            test "Import disk builder from VHD" {
+                let deployment =
+                    arm {
+                        add_resources
+                            [
+                                disk {
+                                    name "imported-disk-image"
+                                    sku Vm.DiskType.Premium_LRS
+                                    os_type Linux
+
+                                    import
+                                        (System.Uri
+                                            "https://rxw1n3qxt54dnvfen1gnza5n.blob.core.windows.net/vhds/Ubuntu2004WithJava_20230213141703.vhd")
+                                        (ResourceId.create (
+                                            Arm.Storage.storageAccounts,
+                                            ResourceName "rxw1n3qxt54dnvfen1gnza5n",
+                                            "IT_farmer-imgbldr_Ubuntu2004WithJava_aea5facc-e1b5-47de-aa5b-2c6aafe2161d"
+                                        ))
+                                }
+                            ]
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+
+                let diskProps =
+                    jobj.SelectToken("resources[?(@.name=='imported-disk-image')].properties")
+
+                Expect.isNotNull diskProps "Unable to get disk properties"
+                let os = diskProps.SelectToken "osType"
+                Expect.equal os (JValue "Linux") "osType incorrect"
+                let createOption = diskProps.SelectToken "creationData.createOption"
+                Expect.equal createOption (JValue "Import") "createOption incorrect"
+                let sourceUri = diskProps.SelectToken "creationData.sourceUri"
+
+                Expect.equal
+                    sourceUri
+                    (JValue
+                        "https://rxw1n3qxt54dnvfen1gnza5n.blob.core.windows.net/vhds/Ubuntu2004WithJava_20230213141703.vhd")
+                    "sourceUri incorrect"
+
+                let storageAccountId = diskProps.SelectToken "creationData.storageAccountId"
+
+                Expect.equal
+                    storageAccountId
+                    (JValue
+                        "[resourceId('IT_farmer-imgbldr_Ubuntu2004WithJava_aea5facc-e1b5-47de-aa5b-2c6aafe2161d', 'Microsoft.Storage/storageAccounts', 'rxw1n3qxt54dnvfen1gnza5n')]")
+                    "storageAccountId incorrect"
+
+                let diskSku =
+                    jobj.SelectToken("resources[?(@.name=='imported-disk-image')].sku.name")
+
+                Expect.equal diskSku (JValue "Premium_LRS") "disk sku incorrect"
+            }
+
+            test "Simple empty disk" {
+                let deployment =
+                    arm {
+                        add_resources
+                            [
+                                disk {
+                                    name "empty-disk"
+                                    os_type Linux
+                                    create_empty 128<Gb>
+                                }
+                            ]
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+                let diskProps = jobj.SelectToken("resources[?(@.name=='empty-disk')].properties")
+                Expect.isNotNull diskProps "Unable to get disk properties"
+                let diskSizeGB = diskProps.SelectToken "diskSizeGB"
+                Expect.equal diskSizeGB (JValue 128) "diskSizeGB incorrect"
+                let os = diskProps.SelectToken "osType"
+                Expect.equal os (JValue "Linux") "osType incorrect"
+                let createOption = diskProps.SelectToken "creationData.createOption"
+                Expect.equal createOption (JValue "Empty") "createOption incorrect"
+            }
+        ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="AvailabilityTests.fs" />
     <Compile Include="AzureFirewall.fs" />
     <Compile Include="DiagnosticSettings.fs" />
+    <Compile Include="Disk.fs" />
     <Compile Include="Common.fs" />
     <Compile Include="Functions.fs" />
     <Compile Include="LogicApps.fs" />


### PR DESCRIPTION
This PR closes #904

The changes in this PR are as follows:

* Disks: Create managed disks
* Virtual Machines: Attach existing managed disks.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let disk0 =
    disk {
        name "disk-0"
        sku Vm.DiskType.Premium_LRS
        os_type Linux
        create_empty 1024<Gb>
    }

let disk1 =
    disk {
        name "disk-1"
        sku Vm.DiskType.Standard_LRS
        os_type Linux
        import
            (System.Uri
                "https://mystorageaccount.blob.core.windows.net/vhds/MyVirtualHardDisk.vhd")
            (Arm.Storage.storageAccounts.resourceId "mystorageaccount")
    }

let vmWithAttachedDisks =
    vm {
        name "vm-with-attached-disks"
        vm_size Standard_B1ms
        operating_system UbuntuServer_2204LTS
        username "azureuser"
        attach_data_disk disk0
        attach_data_disk disk1
    }

let deployment =
    arm {
        add_resources
            [
                disk0
                disk1
                vmWithAttachedDisks
            ]
    }
```
