### PR TITLE
Adds Image Templates for building and publishing VM images.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ Release Notes
 
 ## vNext
 * Galleries: Create Galleries for sharing VM images.
-* Images: Create images in a gallery that can be used to create VMs.
+* Gallery Images: Create images in a gallery that can be used to create VMs.
 * Image Templates: Templates for building and publishing VM images.
 
 ## 1.7.17

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 
 ## vNext
+* Gallery: Create Galleries for sharing VM images.
 * Image Template: Templates for building and publishing VM images.
 
 ## 1.7.17

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## vNext
+* Image Template: Templates for building and publishing VM images.
+
 ## 1.7.17
 * Container Apps: Fix scaler spelling
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,9 @@ Release Notes
 =============
 
 ## vNext
-* Gallery: Create Galleries for sharing VM images.
-* Image Template: Templates for building and publishing VM images.
+* Galleries: Create Galleries for sharing VM images.
+* Images: Create images in a gallery that can be used to create VMs.
+* Image Templates: Templates for building and publishing VM images.
 
 ## 1.7.17
 * Container Apps: Fix scaler spelling

--- a/docs/content/api-overview/resources/gallery.md
+++ b/docs/content/api-overview/resources/gallery.md
@@ -1,0 +1,44 @@
+---
+title: "Gallery"
+date: 2023-02-20T10:20:00-04:00
+weight: 10
+chapter: false
+---
+
+#### Overview
+The `gallery` builder is used to create Galleries for sharing VM images.
+
+* Galleries (`Microsoft.Compute/galleries`)
+
+#### Builder Keywords
+
+| Keyword | Purpose |
+|-|-|
+|name|Name of the gallery resource, up to 80 characters, alphanumerics and periods.|
+|description|Description for the gallery.|
+|sharing_profile|Sharing profile that must be set to share with the community or groups.|
+|soft_delete|Indicate soft deletion of images should be enabled or disabled (default disabled).|
+|add_tags|Add tags to the gallery resource.|
+|depends_on|Add explicit dependencies for the gallery resource.|
+
+#### Example
+
+```fsharp
+open Farmer
+open Farmer.Arm.Gallery
+open Farmer.Builders
+
+gallery {
+    name "mygallery"
+    description "Example Community Image Gallery"
+    sharing_profile (
+        Community {
+            Eula = "End User License Agreement goes here"
+            PublicNamePrefix = "farmages"
+            PublisherContact = "farmer.gallery@example.com"
+            PublisherUri = System.Uri "https://compositionalit.github.io/farmer"
+        }
+    )
+}
+
+```

--- a/docs/content/api-overview/resources/gallery.md
+++ b/docs/content/api-overview/resources/gallery.md
@@ -6,20 +6,39 @@ chapter: false
 ---
 
 #### Overview
-The `gallery` builder is used to create Galleries for sharing VM images.
+The `gallery` builder is used to create Galleries for sharing VM images. These can be used to create virtual machines or virtual machine scale sets that can expand or contract to scale capacity as needed. 
 
 * Galleries (`Microsoft.Compute/galleries`)
+* Gallery Image (`Microsoft.Compute/galleries/images`)
 
 #### Builder Keywords
 
-| Keyword | Purpose |
-|-|-|
-|name|Name of the gallery resource, up to 80 characters, alphanumerics and periods.|
-|description|Description for the gallery.|
-|sharing_profile|Sharing profile that must be set to share with the community or groups.|
-|soft_delete|Indicate soft deletion of images should be enabled or disabled (default disabled).|
-|add_tags|Add tags to the gallery resource.|
-|depends_on|Add explicit dependencies for the gallery resource.|
+| Applies To | Keyword | Purpose |
+|-|-|-|
+|gallery|name|Name of the gallery resource, up to 80 characters, alphanumerics and periods.|
+|gallery|description|Description for the gallery.|
+|gallery|sharing_profile|Sharing profile that must be set to share with the community or groups.|
+|gallery|soft_delete|Indicate soft deletion of images should be enabled or disabled (default disabled).|
+|gallery|add_tags|Add tags to the gallery resource.|
+|gallery|depends_on|Add explicit dependencies for the gallery resource.|
+|image|name|Name of the image in the gallery.|
+|image|gallery_name|Name of the gallery where the image is created.|
+|image|gallery|Specify the gallery in the same deployment. The image will depend on the gallery.|
+|image|architecture|Indicates x64 or ARM 64 images - defaults to x64 if not set.|
+|image|description|Optional description for the image in the gallery.|
+|image|eula|Optional End User License Agreement for using the image.|
+|image|hyperv_generation|The Hyper-V generation for the image. This should be set to match the Hyper-V generation of the source image that was used to create this image.|
+|image|gallery_image_identifier|The publisher, offer, and sku for the image in the gallery.|
+|image|os_state|Indicate if the VM is Generalized or Specialized. A generalized image allows OS configuration options, such as setting the username and password, whereas this is typically set already in a specialized image.|
+|image|os_type|OS type for the image - Windows or Linux|
+|image|privacy_statement_uri|URI where the privacy statement for the use of the image can be found.|
+|image|purchase_plan|A purchase plan name, publisher, and product for the image, for use in a community gallery or marketplace images.|
+|image|recommended_configuration|Recommended range of vCPUs and memory for VMs created from this image.|
+|image|recommended_memory|A recommended range of memory for VMs created from this image. Default is 1 Gb to 32 Gb.|
+|image|recommended_vcpu|A recommended range of vCPUs for VMs created from this image. Default is 1 to 16.|
+|image|release_notes_uri|URI where release notes can be found for the image.|
+|image|add_tags|Add tags to the image resource.|
+|image|depends_on|Add explicit dependencies for the image resource.|
 
 #### Example
 
@@ -28,17 +47,42 @@ open Farmer
 open Farmer.Arm.Gallery
 open Farmer.Builders
 
-gallery {
-    name "mygallery"
-    description "Example Community Image Gallery"
-    sharing_profile (
-        Community {
-            Eula = "End User License Agreement goes here"
-            PublicNamePrefix = "farmages"
-            PublisherContact = "farmer.gallery@example.com"
-            PublisherUri = System.Uri "https://compositionalit.github.io/farmer"
-        }
-    )
-}
+let myGallery = 
+    gallery {
+        name "mygallery"
+        description "Example Community Image Gallery"
+        sharing_profile (
+            Community {
+                Eula = "End User License Agreement goes here"
+                PublicNamePrefix = "farmages"
+                PublisherContact = "farmer.gallery@example.com"
+                PublisherUri = System.Uri "https://compositionalit.github.io/farmer"
+            }
+        )
+    }
 
+let myImage =
+    image {
+        name "my-server-image"
+        gallery myGallery
+
+        gallery_image_identifier (
+            {
+                Offer = "my-server"
+                Publisher = "farmages"
+                Sku = "my-server-2023"
+            }
+        )
+
+        hyperv_generation Image.HyperVGeneration.V2
+        os_state Image.OsState.Generalized
+        os_type OS.Linux
+    }
+
+arm {
+    add_resources [
+        myGallery
+        myImage
+    ]
+}
 ```

--- a/docs/content/api-overview/resources/gallery.md
+++ b/docs/content/api-overview/resources/gallery.md
@@ -21,24 +21,24 @@ The `gallery` builder is used to create Galleries for sharing VM images. These c
 |gallery|soft_delete|Indicate soft deletion of images should be enabled or disabled (default disabled).|
 |gallery|add_tags|Add tags to the gallery resource.|
 |gallery|depends_on|Add explicit dependencies for the gallery resource.|
-|image|name|Name of the image in the gallery.|
-|image|gallery_name|Name of the gallery where the image is created.|
-|image|gallery|Specify the gallery in the same deployment. The image will depend on the gallery.|
-|image|architecture|Indicates x64 or ARM 64 images - defaults to x64 if not set.|
-|image|description|Optional description for the image in the gallery.|
-|image|eula|Optional End User License Agreement for using the image.|
-|image|hyperv_generation|The Hyper-V generation for the image. This should be set to match the Hyper-V generation of the source image that was used to create this image.|
-|image|gallery_image_identifier|The publisher, offer, and sku for the image in the gallery.|
-|image|os_state|Indicate if the VM is Generalized or Specialized. A generalized image allows OS configuration options, such as setting the username and password, whereas this is typically set already in a specialized image.|
-|image|os_type|OS type for the image - Windows or Linux|
-|image|privacy_statement_uri|URI where the privacy statement for the use of the image can be found.|
-|image|purchase_plan|A purchase plan name, publisher, and product for the image, for use in a community gallery or marketplace images.|
-|image|recommended_configuration|Recommended range of vCPUs and memory for VMs created from this image.|
-|image|recommended_memory|A recommended range of memory for VMs created from this image. Default is 1 Gb to 32 Gb.|
-|image|recommended_vcpu|A recommended range of vCPUs for VMs created from this image. Default is 1 to 16.|
-|image|release_notes_uri|URI where release notes can be found for the image.|
-|image|add_tags|Add tags to the image resource.|
-|image|depends_on|Add explicit dependencies for the image resource.|
+|galleryImage|name|Name of the image in the gallery.|
+|galleryImage|gallery_name|Name of the gallery where the image is created.|
+|galleryImage|gallery|Specify the gallery in the same deployment. The image will depend on the gallery.|
+|galleryImage|architecture|Indicates x64 or ARM 64 images - defaults to x64 if not set.|
+|galleryImage|description|Optional description for the image in the gallery.|
+|galleryImage|eula|Optional End User License Agreement for using the image.|
+|galleryImage|hyperv_generation|The Hyper-V generation for the image. This should be set to match the Hyper-V generation of the source image that was used to create this image.|
+|galleryImage|gallery_image_identifier|The publisher, offer, and sku for the image in the gallery.|
+|galleryImage|os_state|Indicate if the VM is Generalized or Specialized. A generalized image allows OS configuration options, such as setting the username and password, whereas this is typically set already in a specialized image.|
+|galleryImage|os_type|OS type for the image - Windows or Linux|
+|galleryImage|privacy_statement_uri|URI where the privacy statement for the use of the image can be found.|
+|galleryImage|purchase_plan|A purchase plan name, publisher, and product for the image, for use in a community gallery or marketplace images.|
+|galleryImage|recommended_configuration|Recommended range of vCPUs and memory for VMs created from this image.|
+|galleryImage|recommended_memory|A recommended range of memory for VMs created from this image. Default is 1 Gb to 32 Gb.|
+|igalleryImagemage|recommended_vcpu|A recommended range of vCPUs for VMs created from this image. Default is 1 to 16.|
+|galleryImage|release_notes_uri|URI where release notes can be found for the image.|
+|galleryImage|add_tags|Add tags to the image resource.|
+|galleryImage|depends_on|Add explicit dependencies for the image resource.|
 
 #### Example
 
@@ -62,7 +62,7 @@ let myGallery =
     }
 
 let myImage =
-    image {
+    galleryImage {
         name "my-server-image"
         gallery myGallery
 

--- a/docs/content/api-overview/resources/image-template.md
+++ b/docs/content/api-overview/resources/image-template.md
@@ -1,0 +1,109 @@
+---
+title: "Image Template"
+date: 2023-02-19T10:20:00-04:00
+weight: 10
+chapter: false
+---
+
+#### Overview
+The Image Template builder is used to create Image Templates for generating VM images. An image template starts with a source image, runs several customizations, and then can finally distribute the image to one or more destinations, including an Azure Image Gallery, a managed image, or a VHD file.
+
+* Image Templates (`Microsoft.VirtualMachineImages/imageTemplates`)
+
+#### Builder Keywords
+
+| Applies To | Keyword | Purpose |
+|-|-|-|
+| imageTemplate | name | Sets the name of the App Insights instance. |
+| imageTemplate | add_identity | Adds a managed identity to the the imageTemplate that it uses to access resources when building the image and to publish images to a gallery. |
+| imageTemplate | build_timeout | Timeout for the image builder, after which it will fail. Default is 4 hours. |
+| imageTemplate | source_platform_image | Specify the source image to be customized from the Azure Gallery. | 
+| imageTemplate | source_managed_image | Specify the source as an existing managed image. |
+| imageTemplate | source_shared_image_version | Specify the source image to be customized from a shared image gallery. |
+| imageTemplate | add_customizers | Add customizers to make changes to the image being built. |
+| imageTemplate | add_distributors | Specify one or more output distributions for the newly built image. |
+| imageTemplate | add_tags | Add tags to the image template resource. |
+| imageTemplate | depends_on | Add explicit dependencies for the imageTemplate resource. |
+| fileCustomizer | name | Name for the file customizer as shown in logs. |
+| fileCustomizer | source_uri | Location to download the file. |
+| fileCustomizer | destination | Location to save the downloaded file - needs to be under /tmp on Linux or an existing location on Windows. |
+| fileCustomizer | checksum | The SHA 256 checksum to validate the file. |
+| shellCustomizer | name | The name of the customizer as shown in logs. |
+| shellCustomizer | inline_statements | A list of shell commands to run. |
+| shellScriptCustomizer | name | The name of the customizer as shown in logs. |
+| shellScriptCustomizer | script_uri | A script to download and run. |
+| shellScriptCustomizer | checksum | The SHA 256 checksum to validate the file. |
+| powerShellCustomizer | name | The name of the customizer as shown in logs. |
+| powerShellCustomizer | inline_statements | A list of PowerShell commands to run. |
+| powerShellCustomizer | run_as_elevated | Run the commands in an elevated PowerShell session. |
+| powerShellCustomizer | run_as_system | Run the commands that need to execute as the System. |
+| powerShellCustomizer | valid_exit_codes | A list of exit codes to treat as successful. |
+| powerShellScriptCustomizer | name | The name of the customizer as shown in logs. |
+| powerShellScriptCustomizer | script_uri | A PowerShell script to download and run. |
+| powerShellScriptCustomizer | checksum | The SHA 256 checksum to validate the file. |
+| powerShellScriptCustomizer | run_as_elevated | Run the commands in an elevated PowerShell session. |
+| powerShellScriptCustomizer | run_as_system | Run the commands that need to execute as the System. |
+| powerShellScriptCustomizer | valid_exit_codes | A list of exit codes to treat as successful. |
+| windowsRestartCustomizer | restart_command |  Command to execute the restart (optional). The default is 'shutdown /r /f /t 0 /c \"packer restart\"' |
+| windowsRestartCustomizer | restart_check_command | Command to check if restart succeeded (optional). |
+| windowsRestartCustomizer | restart_timeout | Restart timeout specified as a string of magnitude and unit. For example, 5m (5 minutes) or 2h (2 hours). The default is: 5m. |
+| windowsUpdateCustomizer | search_criteria | Optional, defines which type of updates are installed (like Recommended or Important), BrowseOnly=0 and IsInstalled=0 (Recommended) is the default. |
+| windowsUpdateCustomizer | filters | Optional, allows you to specify a filter to include or exclude updates. |
+| windowsUpdateCustomizer | update_limit | Optional, defines how many updates can be installed, default 1000. |
+| managedImageDistributor | image_id | Target image ID of the image to build. The resource group should exist and be accessible. Either 'image_id' or 'image_name' must be set. |
+| managedImageDistributor | image_name | Target image name of the image to build in the same resource group. Either 'image_id' or 'image_name' must be set. |
+| managedImageDistributor | location | Azure region where the managed image should be created (required). |
+| managedImageDistributor | run_output_name | A label for the run, shown in logs and in the portal. |
+| managedImageDistributor | add_tags | An optional list of tags that will be added on the image. |
+| sharedImageDistributor | gallery_image_id | Target ID for the gallery image to create. It can reference the image itself or a specific version to create. |
+| sharedImageDistributor | add_replication_regions | Azure regions where the managed image should be replicated. First in the list should be the location of the image gallery. |
+| sharedImageDistributor | exclude_from_latest | Option to ensure the image will not be the "latest" version so it will always be pulled by version number. |
+| sharedImageDistributor | run_output_name | A label for the run, shown in logs and in the portal. |
+| sharedImageDistributor | add_tags | An optional list of tags that will be added on the gallery image. |
+| vhdDistributor | run_output_name | A label for the run, shown in logs and in the portal. |
+| vhdDistributor | add_tags | An optional list of tags that will be added on the virtual hard disk. |
+
+#### Example
+
+```fsharp
+open Farmer
+open Farmer.Builders
+
+imageTemplate {
+    name "Ubuntu2004WithJava"
+    add_identity msi
+    source_platform_image Vm.UbuntuServer_2004LTS
+
+    add_customizers
+        [
+            shellCustomizer {
+                name "install-jdk"
+
+                inline_statements
+                    [
+                        "set -eux"
+                        "sudo apt-get update"
+                        "sudo apt-get -y upgrade"
+                        "sudo apt-get -y install openjdk-17-jre-headless"
+                    ]
+            }
+        ]
+
+    add_distributors
+        [
+            sharedImageDistributor {
+                gallery_image_id
+                    (ResourceType("Microsoft.Compute/galleries/images", "2020-09-30")
+                        .resourceId (
+                            ResourceName "my-image-gallery",
+                            ResourceName "java-server-os"
+                        )
+                    )
+                add_replication_regions [ Location.EastUS ]
+                add_tags [
+                    "image-type", "java"
+                ]
+            }
+        ]
+}
+```

--- a/src/Farmer/Arm/Gallery.fs
+++ b/src/Farmer/Arm/Gallery.fs
@@ -1,0 +1,74 @@
+[<AutoOpen>]
+module Farmer.Arm.Gallery
+
+open System
+open Farmer
+open Farmer.Arm
+open Farmer.GalleryValidation
+
+let galleries = ResourceType("Microsoft.Compute/galleries", "2022-03-03")
+let iamges = ResourceType("Microsoft.Compute/galleries/images", "2022-03-03")
+
+type CommunityGalleryInfo =
+    {
+        Eula: string
+        PublicNamePrefix: string
+        PublisherContact: string
+        PublisherUri: Uri
+    }
+
+type SharingProfile =
+    | Community of CommunityGalleryInfo
+    | Groups
+    | Private
+
+type SoftDeletePolicy = { IsSoftDeleteEnabled: bool }
+
+type ImageGallery =
+    {
+        Name: GalleryName
+        Location: Location
+        Description: string option
+        SharingProfile: SharingProfile option
+        SoftDeletePolicy: SoftDeletePolicy option
+        Tags: Map<string, string>
+        Dependencies: Set<ResourceId>
+    }
+
+    interface IArmResource with
+        member this.ResourceId = galleries.resourceId this.Name.ResourceName
+
+        member this.JsonModel =
+            {| galleries.Create(this.Name.ResourceName, this.Location, dependsOn = this.Dependencies, tags = this.Tags) with
+                properties =
+                    {|
+                        description = this.Description
+                        sharingProfile =
+                            match this.SharingProfile with
+                            | None -> null
+                            | Some sharingProfile ->
+                                match sharingProfile with
+                                | Community info ->
+                                    {|
+                                        permissions = "Community"
+                                        communityGalleryInfo =
+                                            {|
+                                                eula = info.Eula
+                                                publicNamePrefix = info.PublicNamePrefix
+                                                publisherContact = info.PublisherContact
+                                                publisherUri = info.PublisherUri.AbsoluteUri
+                                            |}
+                                    |}
+                                    :> obj
+                                | Groups -> {| permissions = "Groups" |} :> obj
+                                | Private -> {| permissions = "Private" |} :> obj
+                        softDeletePolicy =
+                            match this.SoftDeletePolicy with
+                            | Some policy ->
+                                {|
+                                    isSoftDeleteEnabled = policy.IsSoftDeleteEnabled
+                                |}
+                                :> obj
+                            | None -> null
+                    |}
+            |}

--- a/src/Farmer/Arm/Gallery.fs
+++ b/src/Farmer/Arm/Gallery.fs
@@ -7,7 +7,7 @@ open Farmer.Image
 open Farmer.GalleryValidation
 
 let galleries = ResourceType("Microsoft.Compute/galleries", "2022-03-03")
-let images = ResourceType("Microsoft.Compute/galleries/images", "2022-03-03")
+let galleryImages = ResourceType("Microsoft.Compute/galleries/images", "2022-03-03")
 
 let imageVersions =
     ResourceType("Microsoft.Compute/galleries/images/versions", "2022-03-03")
@@ -127,10 +127,11 @@ type GalleryImage =
     }
 
     interface IArmResource with
-        member this.ResourceId = images.resourceId (this.GalleryName.ResourceName, this.Name)
+        member this.ResourceId =
+            galleryImages.resourceId (this.GalleryName.ResourceName, this.Name)
 
         member this.JsonModel =
-            {| images.Create(
+            {| galleryImages.Create(
                    this.GalleryName.ResourceName / this.Name,
                    this.Location,
                    dependsOn = this.Dependencies,

--- a/src/Farmer/Arm/Gallery.fs
+++ b/src/Farmer/Arm/Gallery.fs
@@ -3,11 +3,14 @@ module Farmer.Arm.Gallery
 
 open System
 open Farmer
-open Farmer.Arm
+open Farmer.Image
 open Farmer.GalleryValidation
 
 let galleries = ResourceType("Microsoft.Compute/galleries", "2022-03-03")
-let iamges = ResourceType("Microsoft.Compute/galleries/images", "2022-03-03")
+let images = ResourceType("Microsoft.Compute/galleries/images", "2022-03-03")
+
+let imageVersions =
+    ResourceType("Microsoft.Compute/galleries/images/versions", "2022-03-03")
 
 type CommunityGalleryInfo =
     {
@@ -24,7 +27,7 @@ type SharingProfile =
 
 type SoftDeletePolicy = { IsSoftDeleteEnabled: bool }
 
-type ImageGallery =
+type Gallery =
     {
         Name: GalleryName
         Location: Location
@@ -70,5 +73,110 @@ type ImageGallery =
                                 |}
                                 :> obj
                             | None -> null
+                    |}
+            |}
+
+type GalleryImageIdentifier =
+    {
+        Offer: string
+        Publisher: string
+        Sku: string
+    }
+
+type ImagePurchasePlan =
+    {
+        PlanName: string
+        PlanProduct: string
+        PlanPublisher: string
+    }
+
+type RecommendedMachineConfiguration =
+    {
+        MemoryMin: int<Gb>
+        MemoryMax: int<Gb>
+        VCpuMin: int
+        VCpuMax: int
+    }
+
+    static member Default =
+        {
+            MemoryMin = 1<Gb>
+            MemoryMax = 32<Gb>
+            VCpuMin = 1
+            VCpuMax = 16
+        }
+
+type GalleryImage =
+    {
+        Name: ResourceName
+        GalleryName: GalleryName
+        Location: Location
+        Architecture: Architecture option
+        Description: string
+        Eula: string option
+        HyperVGeneration: HyperVGeneration
+        Identifier: GalleryImageIdentifier
+        OsState: OsState
+        OsType: OS
+        PrivacyStatementUri: Uri option
+        PurchasePlan: ImagePurchasePlan option
+        Recommended: RecommendedMachineConfiguration
+        ReleaseNoteUri: Uri option
+        Tags: Map<string, string>
+        Dependencies: Set<ResourceId>
+    }
+
+    interface IArmResource with
+        member this.ResourceId = images.resourceId (this.GalleryName.ResourceName, this.Name)
+
+        member this.JsonModel =
+            {| images.Create(
+                   this.GalleryName.ResourceName / this.Name,
+                   this.Location,
+                   dependsOn = this.Dependencies,
+                   tags = this.Tags
+               ) with
+                properties =
+                    {|
+                        architecture = this.Architecture |> Option.map (fun arch -> arch.ArmValue) |> Option.toObj
+                        description = this.Description
+                        eula = this.Eula |> Option.toObj
+                        hyperVGeneration = this.HyperVGeneration.ArmValue
+                        identifier =
+                            {|
+                                offer = this.Identifier.Offer
+                                publisher = this.Identifier.Publisher
+                                sku = this.Identifier.Sku
+                            |}
+                        osState = this.OsState.ArmValue
+                        osType = string<OS> this.OsType
+                        privacyStatementUri =
+                            this.PrivacyStatementUri
+                            |> Option.map (fun uri -> uri.AbsoluteUri)
+                            |> Option.toObj
+                        purchasePlan =
+                            match this.PurchasePlan with
+                            | None -> null
+                            | Some plan ->
+                                {|
+                                    name = plan.PlanName
+                                    product = plan.PlanProduct
+                                    publisher = plan.PlanPublisher
+                                |}
+                                :> obj
+                        recommended =
+                            {|
+                                memory =
+                                    {|
+                                        min = this.Recommended.MemoryMin
+                                        max = this.Recommended.MemoryMax
+                                    |}
+                                vCPUs =
+                                    {|
+                                        min = this.Recommended.VCpuMin
+                                        max = this.Recommended.VCpuMax
+                                    |}
+                            |}
+                        releaseNoteUri = this.ReleaseNoteUri |> Option.map (fun uri -> uri.AbsoluteUri) |> Option.toObj
                     |}
             |}

--- a/src/Farmer/Arm/ImageTemplate.fs
+++ b/src/Farmer/Arm/ImageTemplate.fs
@@ -3,32 +3,24 @@ module Farmer.Arm.ImageTemplate
 
 open System
 open Farmer
+open Farmer.Arm.Gallery
 
 let imageTemplates =
     ResourceType("Microsoft.VirtualMachineImages/imageTemplates", "2022-02-14")
 
 let images = ResourceType("Microsoft.Compute/images", "2022-08-01")
 
-type PlatformImagePurchasePlan =
-    {
-        PlanName: string
-        PlanProduct: string
-        PlanPublisher: string
-    }
-
 type PlatformImageSource =
     {
-        Offer: string
-        PlanInfo: PlatformImagePurchasePlan option
-        Publisher: string
-        Sku: string
+        ImageIdentifier: GalleryImageIdentifier
+        PlanInfo: ImagePurchasePlan option
         Version: string
     }
 
     member this.JsonModel =
         {|
             ``type`` = "PlatformImage"
-            offer = this.Offer
+            offer = this.ImageIdentifier.Offer
             planInfo =
                 match this.PlanInfo with
                 | Some plan ->
@@ -39,8 +31,8 @@ type PlatformImageSource =
                     |}
                     :> obj
                 | None -> null
-            publisher = this.Publisher
-            sku = this.Sku
+            publisher = this.ImageIdentifier.Publisher
+            sku = this.ImageIdentifier.Sku
             version =
                 if String.IsNullOrEmpty this.Version then
                     "latest"

--- a/src/Farmer/Arm/ImageTemplate.fs
+++ b/src/Farmer/Arm/ImageTemplate.fs
@@ -1,0 +1,343 @@
+[<AutoOpen>]
+module Farmer.Arm.ImageTemplate
+
+open System
+open Farmer
+
+let imageTemplates =
+    ResourceType("Microsoft.VirtualMachineImages/imageTemplates", "2022-02-14")
+
+let images = ResourceType("Microsoft.Compute/images", "2022-08-01")
+
+type PlatformImagePurchasePlan =
+    {
+        PlanName: string
+        PlanProduct: string
+        PlanPublisher: string
+    }
+
+type PlatformImageSource =
+    {
+        Offer: string
+        PlanInfo: PlatformImagePurchasePlan option
+        Publisher: string
+        Sku: string
+        Version: string
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "PlatformImage"
+            offer = this.Offer
+            planInfo =
+                match this.PlanInfo with
+                | Some plan ->
+                    {|
+                        planName = plan.PlanName
+                        planProduct = plan.PlanProduct
+                        planPublisher = plan.PlanPublisher
+                    |}
+                    :> obj
+                | None -> null
+            publisher = this.Publisher
+            sku = this.Sku
+            version =
+                if String.IsNullOrEmpty this.Version then
+                    "latest"
+                else
+                    this.Version
+        |}
+        :> obj
+
+type ManagedImageSource =
+    {
+        ImageId: ResourceId
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "ManagedImage"
+            imageId = this.ImageId.Eval()
+        |}
+        :> obj
+
+type SharedImageVersionSource =
+    {
+        ImageId: ResourceId
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "SharedImageVersion"
+            imageId = this.ImageId.Eval()
+        |}
+        :> obj
+
+[<RequireQualifiedAccess>]
+type ImageBuilderSource =
+    | Platform of PlatformImageSource
+    | Managed of ManagedImageSource
+    | SharedVersion of SharedImageVersionSource
+
+    member this.JsonModel =
+        match this with
+        | Platform src -> src.JsonModel
+        | Managed src -> src.JsonModel
+        | SharedVersion src -> src.JsonModel
+
+type FileCustomizer =
+    {
+        Name: string
+        Destination: string
+        SourceUri: Uri
+        Sha256Checksum: string option
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "File"
+            name = this.Name
+            destination = this.Destination
+            sha256Checksum = this.Sha256Checksum |> Option.toObj
+            sourceUri = this.SourceUri.AbsoluteUri
+        |}
+        :> obj
+
+type ShellScriptCustomizer =
+    {
+        Name: string
+        ScriptUri: Uri
+        Sha256Checksum: string option
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "Shell"
+            name = this.Name
+            scriptUri = this.ScriptUri.AbsoluteUri
+            sha256Checksum = this.Sha256Checksum |> Option.toObj
+        |}
+        :> obj
+
+type ShellCustomizer =
+    {
+        Name: string
+        Inline: string list
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "Shell"
+            ``inline`` = this.Inline
+            name = this.Name
+        |}
+        :> obj
+
+type PowerShellScriptCustomizer =
+    {
+        Name: string
+        ScriptUri: Uri
+        Sha256Checksum: string option
+        RunAsSystem: bool
+        RunAsElevated: bool
+        ValidExitCodes: int list
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "PowerShell"
+            name = this.Name
+            scriptUri = this.ScriptUri.AbsoluteUri
+            sha256Checksum = this.Sha256Checksum |> Option.toObj
+            runAsSystem = this.RunAsSystem
+            runAsElevated = this.RunAsElevated
+            validExitCodes =
+                if this.ValidExitCodes.IsEmpty then
+                    null
+                else
+                    ResizeArray(this.ValidExitCodes)
+        |}
+        :> obj
+
+type PowerShellCustomizer =
+    {
+        Name: string
+        Inline: string list
+        RunAsSystem: bool
+        RunAsElevated: bool
+        ValidExitCodes: int list
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "PowerShell"
+            ``inline`` = this.Inline
+            name = this.Name
+            runAsSystem = this.RunAsSystem
+            runAsElevated = this.RunAsElevated
+            validExitCodes =
+                if this.ValidExitCodes.IsEmpty then
+                    null
+                else
+                    ResizeArray(this.ValidExitCodes)
+        |}
+        :> obj
+
+type WindowsRestartCustomizer =
+    {
+        RestartCheckCommand: string option
+        RestartCommand: string option
+        RestartTimeout: string option // 5m for 5 minutes, 2h for two hours
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "WindowsRestart"
+            restartCheckCommand = this.RestartCheckCommand
+            restartCommand = this.RestartCommand
+            restartTimeout = this.RestartTimeout
+        |}
+        :> obj
+
+type WindowsUpdateCustomizer =
+    {
+        Filters: string list
+        SearchCriteria: string option // defaults to "BrowseOnly=0 and IsInstalled=0" (Recommended)
+        UpdateLimit: int option // defaults to limit of 1000 updates
+    }
+
+    member this.JsonModel =
+        {|
+            ``type`` = "WindowsUpdate"
+            filters =
+                if this.Filters.IsEmpty then
+                    null
+                else
+                    ResizeArray(this.Filters)
+            searchCriteria = this.SearchCriteria |> Option.toObj
+            updateLimit = this.UpdateLimit |> Option.map box |> Option.toObj
+        |}
+        :> obj
+
+[<RequireQualifiedAccess>]
+type Customizer =
+    | File of FileCustomizer
+    | PowerShell of PowerShellCustomizer
+    | PowerShellScript of PowerShellScriptCustomizer
+    | Shell of ShellCustomizer
+    | ShellScript of ShellScriptCustomizer
+    | WindowsRestart of WindowsRestartCustomizer
+    | WindowsUpdate of WindowsUpdateCustomizer
+
+    member this.JsonModel =
+        match this with
+        | File customizer -> customizer.JsonModel
+        | PowerShell customizer -> customizer.JsonModel
+        | PowerShellScript customizer -> customizer.JsonModel
+        | Shell customizer -> customizer.JsonModel
+        | ShellScript customizer -> customizer.JsonModel
+        | WindowsRestart customizer -> customizer.JsonModel
+        | WindowsUpdate customizer -> customizer.JsonModel
+
+type ManagedImageDistributor =
+    {
+        ImageId: ResourceId
+        RunOutputName: string
+        Location: string
+        ArtifactTags: Map<string, string>
+    }
+
+type SharedImageDistributor =
+    {
+        GalleryImageId: ResourceId
+        RunOutputName: string
+        ReplicationRegions: Location list
+        ExcludeFromLatest: bool option
+        ArtifactTags: Map<string, string>
+    }
+
+type VhdDistributor =
+    {
+        RunOutputName: string
+        ArtifactTags: Map<string, string>
+    }
+
+[<RequireQualifiedAccess>]
+type Distibutor =
+    | ManagedImage of ManagedImageDistributor
+    | SharedImage of SharedImageDistributor
+    | VHD of VhdDistributor
+
+    member this.JsonModel =
+        match this with
+        | ManagedImage distributor ->
+            {|
+                ``type`` = "ManagedImage"
+                imageId = distributor.ImageId.Eval()
+                location = distributor.Location
+                artifactTags =
+                    if distributor.ArtifactTags.IsEmpty then
+                        null
+                    else
+                        distributor.ArtifactTags :> obj
+            |}
+            :> obj
+        | SharedImage distributor ->
+            {|
+                ``type`` = "SharedImage"
+                galleryImageId = distributor.GalleryImageId.Eval()
+                replicationRegions = distributor.ReplicationRegions |> List.map (fun location -> location.ArmValue)
+                runOutputName = distributor.RunOutputName
+                excludeFromLatest = distributor.ExcludeFromLatest |> Option.map box |> Option.toObj
+                artifactTags =
+                    if distributor.ArtifactTags.IsEmpty then
+                        null
+                    else
+                        distributor.ArtifactTags :> obj
+            |}
+        | VHD distributor ->
+            {|
+                ``type`` = "VHD"
+                runOutputName = distributor.RunOutputName
+                artifactTags =
+                    if distributor.ArtifactTags.IsEmpty then
+                        null
+                    else
+                        distributor.ArtifactTags :> obj
+            |}
+            :> obj
+
+type ImageBuilder =
+    {
+        Name: ResourceName
+        Location: Location
+        Identity: Identity.ManagedIdentity
+        BuildTimeoutInMinutes: int option
+        Source: ImageBuilderSource
+        Customize: Customizer list
+        Distribute: Distibutor list
+        Tags: Map<string, string>
+        Dependencies: ResourceId Set
+    }
+
+    interface IArmResource with
+        member this.ResourceId = imageTemplates.resourceId this.Name
+
+        member this.JsonModel =
+            let dependencies =
+                seq {
+                    yield! this.Identity.Dependencies
+                    yield! this.Dependencies
+                }
+                |> Set.ofSeq
+
+            {| imageTemplates.Create(this.Name, this.Location, dependsOn = dependencies, tags = this.Tags) with
+                identity = this.Identity.ToArmJson
+                properties =
+                    {|
+                        buildTimeoutInMinutes = this.BuildTimeoutInMinutes |> Option.map box |> Option.toObj
+                        source = this.Source.JsonModel
+                        customize = this.Customize |> List.map (fun customizer -> customizer.JsonModel)
+                        distribute = this.Distribute |> List.map (fun distributor -> distributor.JsonModel)
+                    |}
+            |}

--- a/src/Farmer/Builders/Builders.Gallery.fs
+++ b/src/Farmer/Builders/Builders.Gallery.fs
@@ -1,7 +1,9 @@
 [<AutoOpen>]
 module Farmer.Builders.Gallery
 
+open System
 open Farmer
+open Farmer.Image
 open Farmer.GalleryValidation
 open Farmer.Arm.Gallery
 
@@ -78,3 +80,215 @@ type GalleryBuilder() =
             }
 
 let gallery = GalleryBuilder()
+
+type GalleryImageConfig =
+    {
+        Name: ResourceName
+        GalleryName: GalleryName
+        Architecture: Architecture option
+        Description: string option
+        Eula: string option
+        HyperVGeneration: HyperVGeneration option
+        Identifier: GalleryImageIdentifier option
+        OsState: OsState option
+        OsType: OS option
+        PrivacyStatementUri: Uri option
+        PurchasePlan: ImagePurchasePlan option
+        Recommended: RecommendedMachineConfiguration option
+        ReleaseNoteUri: Uri option
+        Tags: Map<string, string>
+        Dependencies: Set<ResourceId>
+    }
+
+    interface IBuilder with
+        member this.ResourceId = images.resourceId (this.GalleryName.ResourceName, this.Name)
+
+        member this.BuildResources location =
+            [
+                {
+                    Name = this.Name
+                    GalleryName = this.GalleryName
+                    Location = location
+                    Architecture = this.Architecture
+                    Description = this.Description |> Option.toObj
+                    Eula = this.Eula
+                    HyperVGeneration =
+                        this.HyperVGeneration
+                        |> Option.defaultWith (fun _ -> raiseFarmer "Gallery image 'hyperv_generation' is required.")
+                    Identifier =
+                        this.Identifier
+                        |> Option.defaultWith (fun _ -> raiseFarmer "Gallery image 'identifier' is required.")
+                    OsState = this.OsState |> Option.defaultValue Generalized
+                    OsType =
+                        this.OsType
+                        |> Option.defaultWith (fun _ -> raiseFarmer "Gallery image 'os_type' is required.")
+                    PrivacyStatementUri = this.PrivacyStatementUri
+                    PurchasePlan = this.PurchasePlan
+                    Recommended = this.Recommended |> Option.defaultValue RecommendedMachineConfiguration.Default
+                    ReleaseNoteUri = this.ReleaseNoteUri
+                    Tags = this.Tags
+                    Dependencies = this.Dependencies
+                }
+            ]
+
+type ImageBuilder() =
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            GalleryName = GalleryName.Empty
+            Architecture = None
+            Description = None
+            Eula = None
+            HyperVGeneration = None
+            Identifier = None
+            OsState = None
+            OsType = None
+            PrivacyStatementUri = None
+            PurchasePlan = None
+            Recommended = None
+            ReleaseNoteUri = None
+            Tags = Map.empty
+            Dependencies = Set.empty
+        }
+
+    member _.Run(config: GalleryImageConfig) =
+        if config.Name = ResourceName.Empty then
+            raiseFarmer "Gallery image 'name' is required."
+
+        if config.GalleryName = GalleryName.Empty then
+            raiseFarmer "Gallery image 'gallery_name' is required."
+
+        if config.HyperVGeneration.IsNone then
+            raiseFarmer "Gallery image 'hyperv_generation' is required."
+
+        if config.Identifier.IsNone then
+            raiseFarmer "Gallery image 'gallery_image_identifier' is required."
+
+        if config.OsType.IsNone then
+            raiseFarmer "Gallery image 'os_type' is required."
+
+        config
+
+    [<CustomOperation "name">]
+    member _.Name(config: GalleryImageConfig, name) =
+        { config with Name = ResourceName name }
+
+    [<CustomOperation "gallery_name">]
+    member _.GalleryName(config: GalleryImageConfig, galleryName) =
+        { config with
+            GalleryName = GalleryName.Create(galleryName).OkValue
+        }
+
+    [<CustomOperation "gallery">]
+    member _.Gallery(config: GalleryImageConfig, galleryConfig: GalleryConfig) =
+        { config with
+            GalleryName = galleryConfig.Name
+            Dependencies = config.Dependencies |> Set.add (galleryConfig :> IBuilder).ResourceId
+        }
+
+    [<CustomOperation "architecture">]
+    member _.Architecture(config: GalleryImageConfig, architecture) =
+        { config with
+            Architecture = Some architecture
+        }
+
+    [<CustomOperation "description">]
+    member _.Description(config: GalleryImageConfig, description) =
+        { config with
+            Description = Some description
+        }
+
+    [<CustomOperation "eula">]
+    member _.Eula(config: GalleryImageConfig, eula) = { config with Eula = Some eula }
+
+    [<CustomOperation "hyperv_generation">]
+    member _.HyperVGeneration(config: GalleryImageConfig, hyperVGeneration) =
+        { config with
+            HyperVGeneration = Some hyperVGeneration
+        }
+
+    [<CustomOperation "gallery_image_identifier">]
+    member _.Identifier(config: GalleryImageConfig, identifier) =
+        { config with
+            Identifier = Some identifier
+        }
+
+    [<CustomOperation "os_state">]
+    member _.OsState(config: GalleryImageConfig, osState) = { config with OsState = Some osState }
+
+    [<CustomOperation "os_type">]
+    member _.OsType(config: GalleryImageConfig, osType) = { config with OsType = Some osType }
+
+    [<CustomOperation "privacy_statement_uri">]
+    member _.PrivacyStatementUri(config: GalleryImageConfig, privacyStatementUri: Uri) =
+        { config with
+            PrivacyStatementUri = Some privacyStatementUri
+        }
+
+    member this.PrivacyStatementUri(config, privacyStatementUri: string) =
+        this.PrivacyStatementUri(config, Uri privacyStatementUri)
+
+    [<CustomOperation "purchase_plan">]
+    member _.PurchasePlan(config: GalleryImageConfig, purchasePlan) =
+        { config with
+            PurchasePlan = Some purchasePlan
+        }
+
+    [<CustomOperation "recommended_configuration">]
+    member _.RecommendedConfiguration(config: GalleryImageConfig, recommended) =
+        { config with
+            Recommended = Some recommended
+        }
+
+    [<CustomOperation "recommended_memory">]
+    member _.RecommendedMemory(config: GalleryImageConfig, min, max) =
+        let existing =
+            config.Recommended
+            |> Option.defaultValue RecommendedMachineConfiguration.Default
+
+        { config with
+            Recommended =
+                Some
+                    { existing with
+                        MemoryMin = min
+                        MemoryMax = max
+                    }
+        }
+
+    [<CustomOperation "recommended_vcpu">]
+    member _.RecommendedVCpu(config: GalleryImageConfig, min, max) =
+        let existing =
+            config.Recommended
+            |> Option.defaultValue RecommendedMachineConfiguration.Default
+
+        { config with
+            Recommended =
+                Some
+                    { existing with
+                        VCpuMin = min
+                        VCpuMax = max
+                    }
+        }
+
+    [<CustomOperation "release_notes_uri">]
+    member _.ReleaseNoteUri(config: GalleryImageConfig, releaseNoteUri) =
+        { config with
+            ReleaseNoteUri = Some releaseNoteUri
+        }
+
+    member this.ReleaseNoteUri(config, releaseNoteUri: string) =
+        this.ReleaseNoteUri(config, Uri releaseNoteUri)
+
+    interface ITaggable<GalleryImageConfig> with
+        member _.Add state tags =
+            { state with
+                Tags = state.Tags |> Map.merge tags
+            }
+
+    interface IDependable<GalleryImageConfig> with
+        member _.Add state resources =
+            { state with
+                Dependencies = state.Dependencies + resources
+            }
+
+let image = ImageBuilder()

--- a/src/Farmer/Builders/Builders.Gallery.fs
+++ b/src/Farmer/Builders/Builders.Gallery.fs
@@ -101,7 +101,8 @@ type GalleryImageConfig =
     }
 
     interface IBuilder with
-        member this.ResourceId = images.resourceId (this.GalleryName.ResourceName, this.Name)
+        member this.ResourceId =
+            galleryImages.resourceId (this.GalleryName.ResourceName, this.Name)
 
         member this.BuildResources location =
             [
@@ -131,7 +132,7 @@ type GalleryImageConfig =
                 }
             ]
 
-type ImageBuilder() =
+type GalleryImageBuilder() =
     member _.Yield _ =
         {
             Name = ResourceName.Empty
@@ -291,4 +292,4 @@ type ImageBuilder() =
                 Dependencies = state.Dependencies + resources
             }
 
-let image = ImageBuilder()
+let galleryImage = GalleryImageBuilder()

--- a/src/Farmer/Builders/Builders.Gallery.fs
+++ b/src/Farmer/Builders/Builders.Gallery.fs
@@ -1,0 +1,80 @@
+[<AutoOpen>]
+module Farmer.Builders.Gallery
+
+open Farmer
+open Farmer.GalleryValidation
+open Farmer.Arm.Gallery
+
+type GalleryConfig =
+    {
+        Name: GalleryName
+        Description: string option
+        SharingProfile: SharingProfile option
+        SoftDelete: FeatureFlag option
+        Tags: Map<string, string>
+        Dependencies: Set<ResourceId>
+    }
+
+    interface IBuilder with
+        member this.ResourceId = galleries.resourceId this.Name.ResourceName
+
+        member this.BuildResources location =
+            [
+                {
+                    Name = this.Name
+                    Location = location
+                    Description = this.Description
+                    SharingProfile = this.SharingProfile
+                    SoftDeletePolicy =
+                        this.SoftDelete
+                        |> Option.map (fun flag -> { IsSoftDeleteEnabled = flag.AsBoolean })
+                    Tags = this.Tags
+                    Dependencies = this.Dependencies
+                }
+            ]
+
+type GalleryBuilder() =
+    member _.Yield _ =
+        {
+            Name = GalleryName.Empty
+            Description = None
+            SharingProfile = None
+            SoftDelete = None
+            Tags = Map.empty
+            Dependencies = Set.empty
+        }
+
+    [<CustomOperation "name">]
+    member _.Name(config: GalleryConfig, name: string) =
+        { config with
+            Name = GalleryName.Create(name).OkValue
+        }
+
+    [<CustomOperation "description">]
+    member _.Description(config: GalleryConfig, description) =
+        { config with
+            Description = Some description
+        }
+
+    [<CustomOperation "sharing_profile">]
+    member _.SharingProfile(config: GalleryConfig, sharingProfile) =
+        { config with
+            SharingProfile = Some sharingProfile
+        }
+
+    [<CustomOperation "soft_delete">]
+    member _.SoftDelete(config: GalleryConfig, flag: FeatureFlag) = { config with SoftDelete = Some flag }
+
+    interface ITaggable<GalleryConfig> with
+        member _.Add state tags =
+            { state with
+                Tags = state.Tags |> Map.merge tags
+            }
+
+    interface IDependable<GalleryConfig> with
+        member _.Add state resources =
+            { state with
+                Dependencies = state.Dependencies + resources
+            }
+
+let gallery = GalleryBuilder()

--- a/src/Farmer/Builders/Builders.ImageTemplate.fs
+++ b/src/Farmer/Builders/Builders.ImageTemplate.fs
@@ -3,6 +3,7 @@ module Farmer.Builders.ImageTemplate
 
 open Farmer
 open Farmer.Arm.ImageTemplate
+open Farmer.Arm.Gallery
 open Farmer.Identity
 
 type ImageTemplateConfig =
@@ -74,10 +75,13 @@ type ImageTemplateBuilder() =
     member this.PlatformImageSource(config: ImageTemplateConfig, image: Vm.ImageDefinition) =
         let imageSource =
             {
-                Offer = image.Offer.ArmValue
+                ImageIdentifier =
+                    {
+                        Publisher = image.Publisher.ArmValue
+                        Offer = image.Offer.ArmValue
+                        Sku = image.Sku.ArmValue
+                    }
                 PlanInfo = None
-                Publisher = image.Publisher.ArmValue
-                Sku = image.Sku.ArmValue
                 Version = "latest"
             }
 

--- a/src/Farmer/Builders/Builders.ImageTemplate.fs
+++ b/src/Farmer/Builders/Builders.ImageTemplate.fs
@@ -1,0 +1,502 @@
+[<AutoOpen>]
+module Farmer.Builders.ImageTemplate
+
+open Farmer
+open Farmer.Arm.ImageTemplate
+open Farmer.Identity
+
+type ImageTemplateConfig =
+    {
+        Name: ResourceName
+        Identity: Identity.ManagedIdentity
+        BuildTimeoutInMinutes: int option
+        Source: ImageBuilderSource option
+        Customize: Customizer list
+        Distribute: Distibutor list
+        Dependencies: Set<ResourceId>
+        Tags: Map<string, string>
+    }
+
+    interface IBuilder with
+        member this.ResourceId = imageTemplates.resourceId this.Name
+
+        member this.BuildResources location =
+            [
+                {
+                    Name = this.Name
+                    Location = location
+                    Identity = this.Identity
+                    BuildTimeoutInMinutes = this.BuildTimeoutInMinutes
+                    Source =
+                        match this.Source with
+                        | Some source -> source
+                        | None -> raiseFarmer "Image template requires a 'source'"
+                    Customize = this.Customize
+                    Distribute = this.Distribute
+                    Dependencies = this.Dependencies
+                    Tags = this.Tags
+                }
+            ]
+
+type ImageTemplateBuilder() =
+
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            Identity = ManagedIdentity.Empty
+            BuildTimeoutInMinutes = None
+            Source = None
+            Customize = []
+            Distribute = []
+            Dependencies = Set.empty
+            Tags = Map.empty
+        }
+
+    [<CustomOperation "name">]
+    member _.Name(config: ImageTemplateConfig, name: string) =
+        { config with Name = ResourceName name }
+
+    [<CustomOperation "build_timeout">]
+    member _.BuildTimeout(config: ImageTemplateConfig, timeoutMinutes: int<Minutes>) =
+        { config with
+            BuildTimeoutInMinutes = Some(timeoutMinutes / 1<Minutes>)
+        }
+
+    member this.BuildTimeout(config, timeout: System.TimeSpan) =
+        this.BuildTimeout(config, int timeout.TotalMinutes * 1<Minutes>)
+
+    [<CustomOperation "source_platform_image">]
+    member _.PlatformImageSource(config: ImageTemplateConfig, imageSource: PlatformImageSource) =
+        { config with
+            Source = Some(ImageBuilderSource.Platform imageSource)
+        }
+
+    member this.PlatformImageSource(config: ImageTemplateConfig, image: Vm.ImageDefinition) =
+        let imageSource =
+            {
+                Offer = image.Offer.ArmValue
+                PlanInfo = None
+                Publisher = image.Publisher.ArmValue
+                Sku = image.Sku.ArmValue
+                Version = "latest"
+            }
+
+        this.PlatformImageSource(config, imageSource)
+
+    [<CustomOperation "source_managed_image">]
+    member _.ManagedImageSource(config: ImageTemplateConfig, imageId: ResourceId) =
+        { config with
+            Source = Some(ImageBuilderSource.Managed { ImageId = imageId })
+        }
+
+    [<CustomOperation "source_shared_image_version">]
+    member _.SharedImageVersionSource(config: ImageTemplateConfig, imageId: ResourceId) =
+        { config with
+            Source = Some(ImageBuilderSource.SharedVersion { ImageId = imageId })
+        }
+
+    [<CustomOperation "add_customizers">]
+    member _.AddCustomizer(config: ImageTemplateConfig, customizers) =
+        { config with
+            Customize = config.Customize @ customizers
+        }
+
+    [<CustomOperation "add_distributors">]
+    member _.AddCustomizer(config: ImageTemplateConfig, distributors) =
+        { config with
+            Distribute = config.Distribute @ distributors
+        }
+
+    interface IIdentity<ImageTemplateConfig> with
+        member _.Add state updater =
+            { state with
+                Identity = updater state.Identity
+            }
+
+    interface ITaggable<ImageTemplateConfig> with
+        member _.Add state tags =
+            { state with
+                Tags = state.Tags |> Map.merge tags
+            }
+
+    interface IDependable<ImageTemplateConfig> with
+        member _.Add state resources =
+            { state with
+                Dependencies = state.Dependencies + resources
+            }
+
+let imageTemplate = ImageTemplateBuilder()
+
+type FileCustomizerBuilder() =
+    member _.Yield _ =
+        {
+            Name = null
+            SourceUri = null
+            Destination = null
+            Sha256Checksum = None
+        }
+
+    member _.Run(customizer: FileCustomizer) =
+        if isNull customizer.SourceUri then
+            raiseFarmer "fileCustomizer must have 'source_uri'"
+
+        if isNull customizer.Destination then
+            raiseFarmer "fileCustomizer must have 'destination'"
+
+        Customizer.File customizer
+
+    [<CustomOperation "name">]
+    member _.Name(customizer: FileCustomizer, name) = { customizer with Name = name }
+
+    [<CustomOperation "source_uri">]
+    member _.SourceUri(customizer: FileCustomizer, uri) = { customizer with SourceUri = uri }
+
+    member this.SourceUri(customizer: FileCustomizer, uri: string) =
+        this.SourceUri(customizer, System.Uri uri)
+
+    [<CustomOperation "destination">]
+    member _.Destination(customizer: FileCustomizer, destination) =
+        { customizer with
+            Destination = destination
+        }
+
+    [<CustomOperation "checksum">]
+    member _.Checksum(customizer: FileCustomizer, checksum) =
+        { customizer with
+            Sha256Checksum = Some checksum
+        }
+
+/// File customizer for downloading small files to the image, < 20MB. For larger files, use a shell or inline command
+/// in a shell or powershell customizer.
+let fileCustomizer = FileCustomizerBuilder()
+
+type ShellCustomizerBuilder() =
+    member _.Yield _ = { Name = null; Inline = [] }
+
+    member _.Run(customizer: ShellCustomizer) = Customizer.Shell customizer
+
+    [<CustomOperation "name">]
+    member _.Name(customizer: ShellCustomizer, name) = { customizer with Name = name }
+
+    [<CustomOperation "inline_statements">]
+    member _.InlineStatements(customizer: ShellCustomizer, inlineStatements) =
+        { customizer with
+            Inline = inlineStatements
+        }
+
+/// Shell customizer for running shell commands defined as inline strings.
+let shellCustomizer = ShellCustomizerBuilder()
+
+type ShellScriptCustomizerBuilder() =
+    member _.Yield _ =
+        {
+            Name = null
+            ScriptUri = null
+            Sha256Checksum = None
+        }
+
+    member _.Run(customizer: ShellScriptCustomizer) =
+        if isNull customizer.ScriptUri then
+            raiseFarmer "shellScriptCustomizer must have 'script_uri'"
+
+        Customizer.ShellScript customizer
+
+    [<CustomOperation "name">]
+    member _.InlineShell(customizer: ShellScriptCustomizer, name) = { customizer with Name = name }
+
+    [<CustomOperation "script_uri">]
+    member _.ScriptUri(customizer: ShellScriptCustomizer, uri) = { customizer with ScriptUri = uri }
+
+    member this.ScriptUri(customizer: ShellScriptCustomizer, uri: string) =
+        this.ScriptUri(customizer, System.Uri uri)
+
+    [<CustomOperation "checksum">]
+    member _.Checksum(customizer: ShellScriptCustomizer, checksum) =
+        { customizer with
+            Sha256Checksum = Some checksum
+        }
+
+/// Shell script customizer to download a shell script to execute.
+let shellScriptCustomizer = ShellScriptCustomizerBuilder()
+
+type PowerShellCustomizerBuilder() =
+    member _.Yield _ =
+        {
+            Name = null
+            Inline = []
+            RunAsElevated = false
+            RunAsSystem = false
+            ValidExitCodes = []
+        }
+
+    member _.Run(customizer: PowerShellCustomizer) = Customizer.PowerShell customizer
+
+    [<CustomOperation "name">]
+    member _.Name(customizer: PowerShellCustomizer, name) = { customizer with Name = name }
+
+    [<CustomOperation "inline_statements">]
+    member _.InlineShell(customizer: PowerShellCustomizer, inlineStatements) =
+        { customizer with
+            Inline = inlineStatements
+        }
+
+    [<CustomOperation "run_as_elevated">]
+    member _.RunAsElevated(customizer: PowerShellCustomizer, runAsElevated) =
+        { customizer with
+            RunAsElevated = runAsElevated
+        }
+
+    [<CustomOperation "run_as_system">]
+    member _.RunAsSystem(customizer: PowerShellCustomizer, runAsSystem) =
+        { customizer with
+            RunAsSystem = runAsSystem
+        }
+
+    [<CustomOperation "valid_exit_codes">]
+    member _.ValidExitCodes(customizer: PowerShellCustomizer, validExitCodes) =
+        { customizer with
+            ValidExitCodes = customizer.ValidExitCodes @ validExitCodes
+        }
+
+/// PowerShell customizer for running PowerShell commands on Windows images defined as inline strings.
+let powerShellCustomizer: PowerShellCustomizerBuilder =
+    PowerShellCustomizerBuilder()
+
+type PowerShellScriptCustomizerBuilder() =
+    member _.Yield _ =
+        {
+            Name = null
+            ScriptUri = null
+            Sha256Checksum = None
+            RunAsElevated = false
+            RunAsSystem = false
+            ValidExitCodes = []
+        }
+
+    member _.Run(customizer: PowerShellScriptCustomizer) = Customizer.PowerShellScript customizer
+
+    [<CustomOperation "name">]
+    member _.Name(customizer: PowerShellScriptCustomizer, name) = { customizer with Name = name }
+
+    [<CustomOperation "run_as_elevated">]
+    member _.RunAsElevated(customizer: PowerShellScriptCustomizer, runAsElevated) =
+        { customizer with
+            RunAsElevated = runAsElevated
+        }
+
+    [<CustomOperation "run_as_system">]
+    member _.RunAsSystem(customizer: PowerShellScriptCustomizer, runAsSystem) =
+        { customizer with
+            RunAsSystem = runAsSystem
+        }
+
+    [<CustomOperation "valid_exit_codes">]
+    member _.ValidExitCodes(customizer: PowerShellScriptCustomizer, validExitCodes) =
+        { customizer with
+            ValidExitCodes = customizer.ValidExitCodes @ validExitCodes
+        }
+
+    [<CustomOperation "script_uri">]
+    member _.ScriptUri(customizer: PowerShellScriptCustomizer, uri) = { customizer with ScriptUri = uri }
+
+    member this.ScriptUri(customizer: PowerShellScriptCustomizer, uri: string) =
+        this.ScriptUri(customizer, System.Uri uri)
+
+    [<CustomOperation "checksum">]
+    member _.Checksum(customizer: PowerShellScriptCustomizer, checksum) =
+        { customizer with
+            Sha256Checksum = Some checksum
+        }
+
+/// PowerShell script customizer for downloading a PowerShell script to run on Windows images.
+let powerShellScriptCustomizer = PowerShellScriptCustomizerBuilder()
+
+type WindowsRestartCustomizerBuilder() =
+    member _.Yield _ =
+        {
+            RestartCommand = None
+            RestartCheckCommand = None
+            RestartTimeout = None
+        }
+
+    member _.Run(customizer: WindowsRestartCustomizer) = Customizer.WindowsRestart customizer
+
+    [<CustomOperation "restart_command">]
+    member _.RestartCommand(customizer: WindowsRestartCustomizer, restartCommand) =
+        { customizer with
+            RestartCommand = Some restartCommand
+        }
+
+    [<CustomOperation "restart_check_command">]
+    member _.RestartCheckCommand(customizer: WindowsRestartCustomizer, restartCheckCommand) =
+        { customizer with
+            RestartCheckCommand = Some restartCheckCommand
+        }
+
+    [<CustomOperation "restart_timeout">]
+    member _.RestartTimeout(customizer: WindowsRestartCustomizer, restartTimeout) =
+        { customizer with
+            RestartTimeout = Some restartTimeout
+        }
+
+/// Windows Restart Customizer to restart Windows while building the image.
+let windowsRestartCustomizer = WindowsRestartCustomizerBuilder()
+
+type WindowsUpdateCustomizerBuilder() =
+    member _.Yield _ =
+        {
+            SearchCriteria = None
+            Filters = []
+            UpdateLimit = None
+        }
+
+    member _.Run(customizer: WindowsUpdateCustomizer) = Customizer.WindowsUpdate customizer
+
+    [<CustomOperation "search_criteria">]
+    member _.SearchCriteria(customizer: WindowsUpdateCustomizer, searchCriteria) =
+        { customizer with
+            SearchCriteria = Some searchCriteria
+        }
+
+    [<CustomOperation "filters">]
+    member _.Filters(customizer: WindowsUpdateCustomizer, filters) =
+        { customizer with
+            Filters = customizer.Filters @ filters
+        }
+
+    [<CustomOperation "update_limit">]
+    member _.Destination(customizer: WindowsUpdateCustomizer, updateLimit) =
+        { customizer with
+            UpdateLimit = Some updateLimit
+        }
+
+/// Windows Update Customizer to install Windows updates while building the image.
+let windowsUpdateCustomizer = WindowsUpdateCustomizerBuilder()
+
+type ManagedImageDistributorBuilder() =
+    member _.Yield _ =
+        {
+            ImageId = images.resourceId ResourceName.Empty
+            RunOutputName = "managed-image-run"
+            Location = null
+            ArtifactTags = Map.empty
+        }
+
+    member _.Run(distributor: ManagedImageDistributor) =
+        if distributor.ImageId = images.resourceId ResourceName.Empty then
+            raiseFarmer "Must set 'image_id' for managedImageDistributor"
+
+        if System.String.IsNullOrEmpty distributor.Location then
+            raiseFarmer "Must set 'location' for managedImageDistributor"
+
+        Distibutor.ManagedImage distributor
+
+    [<CustomOperation "image_id">]
+    member _.ImageId(distibutor: ManagedImageDistributor, imageId) = { distibutor with ImageId = imageId }
+
+    [<CustomOperation "image_name">]
+    member _.Image(distibutor: ManagedImageDistributor, imageName: ResourceName) =
+        { distibutor with
+            ImageId = images.resourceId imageName
+        }
+
+    [<CustomOperation "location">]
+    member _.Location(distibutor: ManagedImageDistributor, location: Location) =
+        { distibutor with
+            Location = location.ArmValue
+        }
+
+    [<CustomOperation "run_output_name">]
+    member _.RunOutputName(distibutor: ManagedImageDistributor, runOutputName) =
+        { distibutor with
+            RunOutputName = runOutputName
+        }
+
+    [<CustomOperation "add_tags">]
+    member _.AddTags(distibutor: ManagedImageDistributor, tags) =
+        { distibutor with
+            ArtifactTags = distibutor.ArtifactTags |> Map.merge tags
+        }
+
+/// Managed Image Distributor to copy the image that is built to a managed image.
+let managedImageDistributor = ManagedImageDistributorBuilder()
+
+type SharedImageDistributorBuilder() =
+    let emptyGalleryImageId =
+        ResourceType("Microsoft.Compute/galleries/images", "2020-09-30")
+            .resourceId (ResourceName.Empty, ResourceName.Empty)
+
+    member _.Yield _ =
+        {
+            GalleryImageId = emptyGalleryImageId
+            RunOutputName = "shared-image-run"
+            ReplicationRegions = List.empty
+            ExcludeFromLatest = None
+            ArtifactTags = Map.empty
+        }
+
+    member _.Run(distributor: SharedImageDistributor) =
+        if distributor.GalleryImageId = emptyGalleryImageId then
+            raiseFarmer "Must set 'gallery_image_id' for sharedImageDistributor"
+
+        if distributor.ReplicationRegions.IsEmpty then
+            raiseFarmer "Must 'add_replication_regions' for sharedImageDistributor"
+
+        Distibutor.SharedImage distributor
+
+    [<CustomOperation "gallery_image_id">]
+    member _.Image(distibutor: SharedImageDistributor, galleryImageId: ResourceId) =
+        { distibutor with
+            GalleryImageId = galleryImageId
+        }
+
+    [<CustomOperation "add_replication_regions">]
+    member _.Image(distibutor: SharedImageDistributor, locations: Location list) =
+        { distibutor with
+            ReplicationRegions = distibutor.ReplicationRegions @ locations
+        }
+
+    [<CustomOperation "exclude_from_latest">]
+    member _.Image(distibutor: SharedImageDistributor, excludeFromLatest) =
+        { distibutor with
+            ExcludeFromLatest = Some excludeFromLatest
+        }
+
+    [<CustomOperation "run_output_name">]
+    member _.RunOutputName(distibutor: SharedImageDistributor, runOutputName) =
+        { distibutor with
+            RunOutputName = runOutputName
+        }
+
+    [<CustomOperation "add_tags">]
+    member _.AddTags(distibutor: SharedImageDistributor, tags) =
+        { distibutor with
+            ArtifactTags = distibutor.ArtifactTags |> Map.merge tags
+        }
+
+/// Shared Image Distributor to copy the image that is built to a gallery of shared images.
+let sharedImageDistributor = SharedImageDistributorBuilder()
+
+type VhdDistributorBuilder() =
+    member _.Yield _ =
+        {
+            RunOutputName = "vhd-run"
+            ArtifactTags = Map.empty
+        }
+
+    member _.Run(distributor: VhdDistributor) = Distibutor.VHD distributor
+
+    [<CustomOperation "run_output_name">]
+    member _.RunOutputName(distibutor: VhdDistributor, runOutputName) =
+        { distibutor with
+            RunOutputName = runOutputName
+        }
+
+    [<CustomOperation "add_tags">]
+    member _.AddTags(distibutor: VhdDistributor, tags) =
+        { distibutor with
+            ArtifactTags = distibutor.ArtifactTags |> Map.merge tags
+        }
+
+/// VHD Distributor to simply leave the virtual hard disk that is built in a generated storage account.
+let vhdDistributor = VhdDistributorBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -865,6 +865,34 @@ module Vm =
             | Regular -> "Regular"
             | Spot _ -> "Spot"
 
+module Image =
+    type Architecture =
+        | Arm64
+        | X64
+
+        member this.ArmValue =
+            match this with
+            | Arm64 -> "Arm64"
+            | X64 -> "x64"
+
+    type OsState =
+        | Generalized
+        | Specialized
+
+        member this.ArmValue =
+            match this with
+            | Generalized -> "Generalized"
+            | Specialized -> "Specialized"
+
+    type HyperVGeneration =
+        | V1
+        | V2
+
+        member this.ArmValue =
+            match this with
+            | V1 -> "V1"
+            | V2 -> "V2"
+
 module internal Validation =
     // ANDs two validation rules
     let (<+>) a b v = a v && b v
@@ -1632,7 +1660,6 @@ module GalleryValidation =
         member this.ResourceName =
             match this with
             | GalleryName name -> name
-
 
 module Search =
     type HostingMode =

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -976,6 +976,9 @@ module internal Validation =
     let lettersNumbersOrDash =
         "alphanumeric characters or the dash (-)", Char.IsLetterOrDigit <|> (snd dash)
 
+    let lettersNumbersOrDot =
+        "alphanumeric characters or the dot (.)", Char.IsLetterOrDigit <|> (snd dot)
+
     let lettersNumbersDashOrDot =
         "alphanumeric characters, a dash (-) or a dot (.)", Char.IsLetterOrDigit <|> (snd dash) <|> (snd dot)
 
@@ -1611,6 +1614,25 @@ module ContainerRegistryValidation =
         member this.ResourceName =
             match this with
             | ContainerRegistryName name -> name
+
+module GalleryValidation =
+    open Validation
+
+    type GalleryName =
+        private
+        | GalleryName of ResourceName
+
+        static member Create name =
+            [ containsOnly lettersNumbersOrDot; nonEmptyLengthBetween 1 80 ]
+            |> validate "Image Gallery Name" name
+            |> Result.map (ResourceName >> GalleryName)
+
+        static member internal Empty = GalleryName ResourceName.Empty
+
+        member this.ResourceName =
+            match this with
+            | GalleryName name -> name
+
 
 module Search =
     type HostingMode =

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -89,6 +89,7 @@
     <Compile Include="Arm/Devices.fs" />
     <Compile Include="Arm/DocumentDb.fs" />
     <Compile Include="Arm/EventHub.fs" />
+    <Compile Include="Arm/Gallery.fs" />
     <Compile Include="Arm/ImageTemplate.fs" />
     <Compile Include="Arm/Insights.fs" />
     <Compile Include="Arm\AvailabilityTest.fs" />
@@ -132,6 +133,7 @@
     <Compile Include="Builders/Builders.DataLake.fs" />
     <Compile Include="Builders/Builders.DeploymentScript.fs" />
     <Compile Include="Builders/Builders.Dns.fs" />
+    <Compile Include="Builders/Builders.Gallery.fs" />
     <Compile Include="Builders/Builders.ImageTemplate.fs" />
     <Compile Include="Builders/Builders.Redis.fs" />
     <Compile Include="Builders/Builders.KeyVault.fs" />

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -89,6 +89,7 @@
     <Compile Include="Arm/Devices.fs" />
     <Compile Include="Arm/DocumentDb.fs" />
     <Compile Include="Arm/EventHub.fs" />
+    <Compile Include="Arm/ImageTemplate.fs" />
     <Compile Include="Arm/Insights.fs" />
     <Compile Include="Arm\AvailabilityTest.fs" />
     <Compile Include="Arm/KeyVault.fs" />
@@ -131,6 +132,7 @@
     <Compile Include="Builders/Builders.DataLake.fs" />
     <Compile Include="Builders/Builders.DeploymentScript.fs" />
     <Compile Include="Builders/Builders.Dns.fs" />
+    <Compile Include="Builders/Builders.ImageTemplate.fs" />
     <Compile Include="Builders/Builders.Redis.fs" />
     <Compile Include="Builders/Builders.KeyVault.fs" />
     <Compile Include="Builders/Builders.Bastion.fs" />

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -45,6 +45,7 @@ let allTests =
                     ExpressRoute.tests
                     Functions.tests
                     IotHub.tests
+                    Gallery.tests
                     ImageTemplate.tests
                     JsonRegression.tests
                     KeyVault.tests

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -45,6 +45,7 @@ let allTests =
                     ExpressRoute.tests
                     Functions.tests
                     IotHub.tests
+                    ImageTemplate.tests
                     JsonRegression.tests
                     KeyVault.tests
                     Network.tests

--- a/src/Tests/Gallery.fs
+++ b/src/Tests/Gallery.fs
@@ -1,0 +1,67 @@
+module Gallery
+
+open Expecto
+open Farmer
+open Farmer.Builders
+open Farmer.Arm.Gallery
+open Newtonsoft.Json.Linq
+
+let tests =
+    testList
+        "Image Gallery"
+        [
+            test "Builds basic image gallery" {
+                let deployment =
+                    arm {
+                        location Location.EastUS
+
+                        add_resources
+                            [
+                                gallery {
+                                    name "mygallery"
+                                    description "Example Image Gallery"
+                                }
+                            ]
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+                let gallery = jobj.SelectToken "resources[?(@.name=='mygallery')]"
+                Expect.isNotNull gallery "Gallery is not included in deployment template"
+                let galleryDesc = gallery.SelectToken "properties.description"
+                Expect.equal galleryDesc (JValue "Example Image Gallery") "incorrect description"
+            }
+            test "Build community image gallery" {
+                let deployment =
+                    arm {
+                        location Location.EastUS
+
+                        add_resources
+                            [
+                                gallery {
+                                    name "mygallery"
+                                    description "Example Community Image Gallery"
+
+                                    sharing_profile (
+                                        Community
+                                            {
+                                                Eula = "End User License Agreement goes here"
+                                                PublicNamePrefix = "farmages"
+                                                PublisherContact = "farmer.gallery@example.com"
+                                                PublisherUri = System.Uri "https://compositionalit.github.io/farmer"
+                                            }
+                                    )
+                                }
+                            ]
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+                let gallery = jobj.SelectToken "resources[?(@.name=='mygallery')]"
+                let galleryPermissions = gallery.SelectToken "properties.sharingProfile.permissions"
+                Expect.equal galleryPermissions (JValue "Community") "incorrect permissions on community gallery"
+
+                let galleryDesc =
+                    gallery.SelectToken "properties.sharingProfile.communityGalleryInfo.publicNamePrefix"
+
+                Expect.equal galleryDesc (JValue "farmages") "incorrect communityGalleryInfo.publicNamePrefix"
+            }
+        ]

--- a/src/Tests/Gallery.fs
+++ b/src/Tests/Gallery.fs
@@ -64,4 +64,100 @@ let tests =
 
                 Expect.equal galleryDesc (JValue "farmages") "incorrect communityGalleryInfo.publicNamePrefix"
             }
+
+            test "Create basic image" {
+                let deployment =
+                    arm {
+                        add_resources
+                            [
+                                image {
+                                    name "javaserver"
+                                    gallery_name "mygallery"
+
+                                    gallery_image_identifier (
+                                        {
+                                            GalleryImageIdentifier.Offer = "ubuntu-java"
+                                            Publisher = "farmages"
+                                            Sku = "ubuntu-20-java-17"
+                                        }
+                                    )
+
+                                    hyperv_generation Image.HyperVGeneration.V2
+                                    os_state Image.OsState.Generalized
+                                    os_type OS.Linux
+                                }
+                            ]
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+                let image = jobj.SelectToken "resources[?(@.name=='mygallery/javaserver')]"
+                Expect.isNotNull image "Image not found by gallery/image name"
+                Expect.isEmpty image.["dependsOn"] "Image should have no dependencies"
+                let imageProps = image.["properties"]
+                Expect.equal imageProps.["hyperVGeneration"] (JValue "V2") "Incorrect Hyper-V generation"
+                Expect.equal imageProps.["osState"] (JValue "Generalized") "Incorrect OS state"
+                Expect.equal imageProps.["osType"] (JValue "Linux") "Incorrect OS type"
+                let identifier = imageProps.["identifier"]
+                Expect.isNotNull identifier "Image properties missing 'identifier'"
+                Expect.equal identifier.["offer"] (JValue "ubuntu-java") "Incorrect identifier.offer"
+                Expect.equal identifier.["publisher"] (JValue "farmages") "Incorrect identifier.publisher"
+                Expect.equal identifier.["sku"] (JValue "ubuntu-20-java-17") "Incorrect identifier.sku"
+                let recommended = imageProps.["recommended"]
+                Expect.isNotNull recommended "properties.recommended is missing"
+
+                Expect.equal
+                    (recommended.SelectToken "memory.max")
+                    (JValue 32)
+                    "properties.recommended.memory.max incorrect"
+
+                Expect.equal
+                    (recommended.SelectToken "vCPUs.max")
+                    (JValue 16)
+                    "properties.recommended.vCPUs.max incorrect"
+            }
+
+            test "Create gallery and image" {
+                let myGallery =
+                    gallery {
+                        name "mygallery"
+                        description "Example Private Gallery"
+                    }
+
+                let myGalleryImage =
+                    image {
+                        name "ubuntu-java-17-server"
+                        gallery myGallery
+
+                        gallery_image_identifier (
+                            {
+                                GalleryImageIdentifier.Offer = "ubuntu-java"
+                                Publisher = "farmages"
+                                Sku = "ubuntu-20-java-17"
+                            }
+                        )
+
+                        hyperv_generation Image.HyperVGeneration.V2
+                        os_state Image.OsState.Generalized
+                        os_type OS.Linux
+                    }
+
+                let deployment =
+                    arm {
+                        location Location.EastUS
+                        add_resources [ myGallery; myGalleryImage ]
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+
+                let image =
+                    jobj.SelectToken "resources[?(@.name=='mygallery/ubuntu-java-17-server')]"
+
+                Expect.isNotNull image "Image not found by gallery/image name"
+                Expect.hasLength image.["dependsOn"] 1 "Image should have 1 dependency"
+
+                Expect.equal
+                    image.["dependsOn"].[0]
+                    (JValue "[resourceId('Microsoft.Compute/galleries', 'mygallery')]")
+                    "Image should depend on gallery"
+            }
         ]

--- a/src/Tests/Gallery.fs
+++ b/src/Tests/Gallery.fs
@@ -70,7 +70,7 @@ let tests =
                     arm {
                         add_resources
                             [
-                                image {
+                                galleryImage {
                                     name "javaserver"
                                     gallery_name "mygallery"
 
@@ -124,7 +124,7 @@ let tests =
                     }
 
                 let myGalleryImage =
-                    image {
+                    galleryImage {
                         name "ubuntu-java-17-server"
                         gallery myGallery
 

--- a/src/Tests/ImageTemplate.fs
+++ b/src/Tests/ImageTemplate.fs
@@ -28,9 +28,12 @@ let tests =
                         Source =
                             {
                                 PlanInfo = None
-                                Publisher = "canonical"
-                                Offer = "0001-com-ubuntu-server-focal"
-                                Sku = "20_04-lts-gen2"
+                                ImageIdentifier =
+                                    {
+                                        Publisher = "canonical"
+                                        Offer = "0001-com-ubuntu-server-focal"
+                                        Sku = "20_04-lts-gen2"
+                                    }
                                 Version = null
                             }
                             |> ImageBuilderSource.Platform

--- a/src/Tests/ImageTemplate.fs
+++ b/src/Tests/ImageTemplate.fs
@@ -1,0 +1,186 @@
+module ImageTemplate
+
+open Expecto
+open Newtonsoft.Json.Linq
+open Farmer
+open Farmer.Builders
+open Farmer.Arm.ImageTemplate
+
+let tests =
+    testList
+        "Image Template Tests"
+        [
+            test "Builds basic customized image" {
+                let msi = createUserAssignedIdentity "imgbldr"
+
+                let imageBuilder =
+                    {
+                        Name = ResourceName "Ubuntu2004WithJava"
+                        Location = Location.EastUS
+                        Identity =
+                            {
+                                SystemAssigned = Disabled
+                                UserAssigned = [ msi.UserAssignedIdentity ]
+                            }
+                        Tags = Map.empty
+                        Dependencies = Set.empty
+                        BuildTimeoutInMinutes = None
+                        Source =
+                            {
+                                PlanInfo = None
+                                Publisher = "canonical"
+                                Offer = "0001-com-ubuntu-server-focal"
+                                Sku = "20_04-lts-gen2"
+                                Version = null
+                            }
+                            |> ImageBuilderSource.Platform
+                        Customize =
+                            [
+                                {
+                                    Name = "install-jdk"
+                                    Inline =
+                                        [
+                                            "set -eux"
+                                            "sudo apt-get update"
+                                            "sudo apt-get -y upgrade"
+                                            "sudo apt-get -y install openjdk-17-jre-headless"
+                                        ]
+                                }
+                                |> Customizer.Shell
+                            ]
+                        Distribute =
+                            [
+                                {
+                                    RunOutputName = "testVhdRun"
+                                    ArtifactTags = Map.empty
+                                }
+                                |> Distibutor.VHD
+                            ]
+                    }
+
+                let deployment =
+                    arm {
+                        location Location.EastUS
+                        add_resource msi
+                        add_resource imageBuilder
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+                let imageTemplate = jobj.SelectToken "resources[?(@.name == 'Ubuntu2004WithJava')]"
+                Expect.isNotNull imageTemplate "imageTemplate missing from deployment"
+                Expect.isNotNull (imageTemplate.SelectToken "identity") "imageTemplate.identity not set"
+
+                let source = imageTemplate.SelectToken "properties.source"
+                Expect.equal source.["offer"] (JValue "0001-com-ubuntu-server-focal") "Incorrect source.offer"
+                Expect.equal source.["publisher"] (JValue "canonical") "Incorrect source.publisher"
+                Expect.equal source.["sku"] (JValue "20_04-lts-gen2") "Incorrect source.sku"
+                Expect.equal source.["type"] (JValue "PlatformImage") "Incorrect source.type"
+                Expect.equal source.["version"] (JValue "latest") "Incorrect source.version"
+
+                let customize = imageTemplate.SelectToken "properties.customize"
+                Expect.hasLength customize 1 "customize length incorrect"
+                Expect.equal customize.[0].["type"] (JValue "Shell") "customize[0].type incorrect"
+                Expect.isNotNull customize.[0].["inline"] "Shell customization missing inline"
+                Expect.hasLength customize.[0].["inline"] 4 "Incorrect shell inline values"
+
+                let distribute = imageTemplate.SelectToken "properties.distribute"
+                Expect.hasLength distribute 1 "distribute length incorrect"
+                Expect.equal distribute.[0].["runOutputName"] (JValue "testVhdRun") "Incorrect distribute.runOutputName"
+                Expect.equal distribute.[0].["type"] (JValue "VHD") "Incorrect distribute.type"
+
+            }
+
+            test "Customized image template builder" {
+                let msi = createUserAssignedIdentity "imgbldr"
+
+                let imageBuilder =
+                    imageTemplate {
+                        name "Ubuntu2004WithJava"
+                        add_identity msi
+                        source_platform_image Vm.UbuntuServer_2004LTS
+
+                        add_customizers
+                            [
+                                shellCustomizer {
+                                    name "install-jdk"
+
+                                    inline_statements
+                                        [
+                                            "set -eux"
+                                            "sudo apt-get update"
+                                            "sudo apt-get -y upgrade"
+                                            "sudo apt-get -y install openjdk-17-jre-headless"
+                                        ]
+                                }
+                                shellScriptCustomizer { script_uri "https://whatever.example.com/install.sh" }
+                            ]
+
+                        add_distributors
+                            [
+                                vhdDistributor { run_output_name "testVhdRun" }
+                                sharedImageDistributor {
+                                    gallery_image_id (
+                                        ResourceType("Microsoft.Compute/galleries/images", "2020-09-30")
+                                            .resourceId (ResourceName "my-image-gallery", ResourceName "java-server-os")
+                                    )
+
+                                    add_replication_regions [ Location.EastUS ]
+                                    add_tags [ "image-type", "java" ]
+                                }
+                            ]
+                    }
+
+                let deployment =
+                    arm {
+                        location Location.EastUS
+                        add_resource msi
+                        add_resource imageBuilder
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+                let imageTemplate = jobj.SelectToken "resources[?(@.name == 'Ubuntu2004WithJava')]"
+                Expect.isNotNull imageTemplate "imageTemplate missing from deployment"
+                Expect.isNotNull (imageTemplate.SelectToken "identity") "imageTemplate.identity not set"
+
+                let source = imageTemplate.SelectToken "properties.source"
+                Expect.equal source.["offer"] (JValue "0001-com-ubuntu-server-focal") "Incorrect source.offer"
+                Expect.equal source.["publisher"] (JValue "canonical") "Incorrect source.publisher"
+                Expect.equal source.["sku"] (JValue "20_04-lts-gen2") "Incorrect source.sku"
+                Expect.equal source.["type"] (JValue "PlatformImage") "Incorrect source.type"
+                Expect.equal source.["version"] (JValue "latest") "Incorrect source.version"
+
+                let customize = imageTemplate.SelectToken "properties.customize"
+                Expect.hasLength customize 2 "customize length incorrect"
+                Expect.equal customize.[0].["type"] (JValue "Shell") "customize[0].type incorrect"
+                Expect.isNotNull customize.[0].["inline"] "Shell customization missing inline"
+                Expect.hasLength customize.[0].["inline"] 4 "Incorrect shell inline values"
+                Expect.equal customize.[1].["type"] (JValue "Shell") "customize[1].type incorrect"
+
+                Expect.equal
+                    customize.[1].["scriptUri"]
+                    (JValue "https://whatever.example.com/install.sh")
+                    "Incorrect shell scriptUri"
+
+                let distribute = imageTemplate.SelectToken "properties.distribute"
+                Expect.hasLength distribute 2 "distribute length incorrect"
+                Expect.equal distribute.[0].["runOutputName"] (JValue "testVhdRun") "Incorrect distribute.runOutputName"
+                Expect.equal distribute.[0].["type"] (JValue "VHD") "Incorrect distribute.[0].type"
+                Expect.isNull (distribute.[0].SelectToken "artifactTags") "distrbute.[0] should not have 'artifactTags'"
+                Expect.equal distribute.[1].["type"] (JValue "SharedImage") "Incorrect distribute.[1].type"
+
+                Expect.equal
+                    distribute.[1].["galleryImageId"]
+                    (JValue "[resourceId('Microsoft.Compute/galleries/images', 'my-image-gallery', 'java-server-os')]")
+                    "Incorrect distribute.[1].galleryImageId"
+
+                Expect.equal
+                    distribute.[1].["runOutputName"]
+                    (JValue "shared-image-run")
+                    "Incorrect 'runOutputName' for shared iamge distributor"
+
+                Expect.equal
+                    (distribute.[1].SelectToken "artifactTags.image-type")
+                    (JValue "java")
+                    "distrbute.[1].artifactTags in correct"
+            }
+        ]

--- a/src/Tests/ImageTemplate.fs
+++ b/src/Tests/ImageTemplate.fs
@@ -123,8 +123,10 @@ let tests =
                                 vhdDistributor { run_output_name "testVhdRun" }
                                 sharedImageDistributor {
                                     gallery_image_id (
-                                        ResourceType("Microsoft.Compute/galleries/images", "2020-09-30")
-                                            .resourceId (ResourceName "my-image-gallery", ResourceName "java-server-os")
+                                        Farmer.Arm.Gallery.galleryImages.resourceId (
+                                            ResourceName "my-image-gallery",
+                                            ResourceName "java-server-os"
+                                        )
                                     )
 
                                     add_replication_regions [ Location.EastUS ]
@@ -172,8 +174,8 @@ let tests =
                 Expect.equal distribute.[1].["type"] (JValue "SharedImage") "Incorrect distribute.[1].type"
 
                 Expect.equal
-                    distribute.[1].["galleryImageId"]
-                    (JValue "[resourceId('Microsoft.Compute/galleries/images', 'my-image-gallery', 'java-server-os')]")
+                    (string distribute.[1].["galleryImageId"])
+                    ("[resourceId('Microsoft.Compute/galleries/images', 'my-image-gallery', 'java-server-os')]")
                     "Incorrect distribute.[1].galleryImageId"
 
                 Expect.equal

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="Dns.fs" />
     <Compile Include="ExpressRoute.fs" />
     <Compile Include="EventHub.fs" />
+    <Compile Include="ImageTemplate.fs" />
     <Compile Include="Network.fs" />
     <Compile Include="LoadBalancer.fs" />
     <Compile Include="NetworkSecurityGroup.fs" />

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="Dns.fs" />
     <Compile Include="ExpressRoute.fs" />
     <Compile Include="EventHub.fs" />
+    <Compile Include="Gallery.fs" />
     <Compile Include="ImageTemplate.fs" />
     <Compile Include="Network.fs" />
     <Compile Include="LoadBalancer.fs" />


### PR DESCRIPTION
The changes in this PR are as follows:

* Galleries: Create Galleries for sharing VM images.
* Images: Create images in a gallery that can be used to create VMs.
* Image Templates: Templates for building and publishing VM images.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders

arm {
    location Location.EastUS

    add_resources
        [
            gallery {
                name "mygallery"
                description "Example Image Gallery"
            }
            imageTemplate {
                name "Ubuntu2004WithJava"
                add_identity msi
                source_platform_image Vm.UbuntuServer_2004LTS
            
                add_customizers
                    [
                        shellCustomizer {
                            name "install-jdk"
            
                            inline_statements
                                [
                                    "set -eux"
                                    "sudo apt-get update"
                                    "sudo apt-get -y upgrade"
                                    "sudo apt-get -y install openjdk-17-jre-headless"
                                ]
                        }
                    ]
            
                add_distributors
                    [
                        sharedImageDistributor {
                            gallery_image_id
                                (ResourceType("Microsoft.Compute/galleries/images", "2020-09-30")
                                    .resourceId (
                                        ResourceName "mygallery",
                                        ResourceName "java-server-os"
                                    )
                                )
                            add_replication_regions [ Location.EastUS ]
                            add_tags [
                                "image-type", "java"
                            ]
                        }
                    ]
            }
        ]
}
```
