### PR TITLE
Enable the docker image tag to be specified for a slot.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ Release Notes
 * Gallery Images: Create images in a gallery that can be used to create VMs.
 * Image Templates: Templates for building and publishing VM images.
 * Virtual Machines: Attach existing managed disks.
+* WebApps: Enable the docker image tag to be specified for a slot.
 
 ## 1.7.17
 * Container Apps: Fix scaler spelling

--- a/docs/content/api-overview/resources/web-app.md
+++ b/docs/content/api-overview/resources/web-app.md
@@ -63,7 +63,17 @@ The Web App builder is used to create Azure App Service accounts. It abstracts t
 | Web App | link_to_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. Use this operator when the given VNET is in the same deployment |
 | Web App | link_to_unmanaged_vnet | Enable the VNET integration feature in azure where all outbound traffic from the web app with be sent via the specified subnet. Use this operator when the given VNET is *not* in the same deployment |
 | Web App | add_virtual_applications | Adds list of `virtualApplication` definitions to the webapp |
-| Web App | startup_command | Adds a startup command to be run post-deployment. This is useful on Linux-based web app deployments, where your application is "implicitly" converted into a docker image and may need to be told what to do on startup. 
+| Web App | startup_command | Adds a startup command to be run post-deployment. This is useful on Linux-based web app deployments, where your application is "implicitly" converted into a docker image and may need to be told what to do on startup. |
+| App Slot | name | Sets the name for the slot |
+| App Slot | add_identity | Sets the user managed identity for the slot. |
+| App Slot | system_identity | Sets the system identity to be enabled for the slot. |
+| App Slot | keyvault_identity | Sets the identity for accessing key vault. |
+| App Slot | setting | Set an arbitrary setting for the slot. |
+| App Slot | settings | Sets multiple settings for the slot. |
+| App Slot | connection_string | Adds a connection string setting for the slot |
+| App Slot | docker_image | Sets the docker image to be pulled down from Docker Hub, and the command to execute as a second argument. This enabled a new container to be staged in a slot. |
+| App Slot | add_allowed_ip_restriction | Allows access from this IP when the slot is in production. |
+| App Slot | add_denied_ip_restriction | Denies access from this IP when the slot is in production. |
 | Service Plan | service_plan_name | Sets the name of the service plan. If not set, uses the name of the web app postfixed with "-plan". |
 | Service Plan | runtime_stack | Sets the runtime stack. |
 | Service Plan | operating_system | Sets the operating system. If Linux, App Insights configuration settings will be omitted as they are not supported by Azure App Service. |

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -521,6 +521,27 @@ let tests =
                 Expect.isEmpty extensions "Shouldn't be any extensions"
             }
 
+            test "Can specify different image for slots" {
+                let wa =
+                    webApp {
+                        name "my-webapp-2651A324"
+                        sku (Sku.Standard "S1")
+                        docker_image "nginx:1.22.1" ""
+
+                        add_slots
+                            [
+                                appSlot {
+                                    name "staging"
+                                    docker_image "nginx:1.23.1" ""
+                                }
+                            ]
+                    }
+
+                let (slot: Site) = wa |> getResourceAtIndex 3
+                Expect.equal slot.Name "my-webapp-2651A324/staging" "Resource isn't the 'staging' slot"
+                Expect.equal slot.SiteConfig.LinuxFxVersion "DOCKER|nginx:1.23.1" "Docker image not set on slot"
+            }
+
             test "Handles add_extension correctly" {
                 let wa =
                     webApp {


### PR DESCRIPTION
This PR closes #1005 

The changes in this PR are as follows:

* WebApps: Enable the docker image tag to be specified for a slot.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
webApp {
    name "my-webapp-2651A324"
    sku (Sku.Standard "S1")
    // Production using one image tag.
    docker_image "nginx:1.22.1" ""

    add_slots
        [
            appSlot {
                name "staging"
                // The slot is staging a newer image tag.
                docker_image "nginx:1.23.1" ""
            }
        ]
}
```
