### PR TITLE
Storage Accounts: CORS rules respect format of original URI

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ Release Notes
 * Gallery Images: Create images in a gallery that can be used to create VMs.
 * Image Templates: Templates for building and publishing VM images.
 * Virtual Machines: Attach existing managed disks.
+* Storage Accounts: CORS rules respect format of original URI (fixes #1003)
 
 ## 1.7.17
 * Container Apps: Fix scaler spelling

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -298,7 +298,7 @@ type StorageService =
                                     [
                                         for rule in this.CorsRules do
                                             {|
-                                                allowedOrigins = rule.AllowedOrigins.Emit(fun r -> r.AbsoluteUri)
+                                                allowedOrigins = rule.AllowedOrigins.Emit(fun r -> r.OriginalString)
                                                 allowedMethods =
                                                     [
                                                         for httpMethod in rule.AllowedMethods.Value do

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -506,9 +506,11 @@ let tests =
 
                 let blobSpecificRule = rules.[1]
 
+                Expect.isTrue (not <| blobSpecificRule.allowedOrigins.[0].EndsWith('/')) "Should not add trailing slash"
+
                 Expect.equal
-                    [| "https://compositional-it.com/" |]
                     blobSpecificRule.allowedOrigins
+                    [| "https://compositional-it.com" |]
                     "Incorrect custom allowed origin"
 
                 let queueRule =
@@ -517,7 +519,7 @@ let tests =
 
                 Expect.equal [| "ALLOWED1"; "ALLOWED2" |] queueRule.allowedHeaders "Incorrect factory headers"
                 Expect.equal [| string GET |] queueRule.allowedMethods "Incorrect factory methods"
-                Expect.equal [| "https://compositional-it.com/" |] queueRule.allowedOrigins "Incorrect factory origin"
+                Expect.equal queueRule.allowedOrigins [| "https://compositional-it.com" |] "Incorrect factory origin"
                 Expect.equal [| "exposed1"; "exposed2" |] queueRule.exposedHeaders "Incorrect factory exposed headers"
                 Expect.equal 15 queueRule.maxAgeInSeconds "Incorrect factory max age is seconds"
             }


### PR DESCRIPTION
This PR closes #1003 

The changes in this PR are as follows:

* Storage Accounts: CORS rules respect format of original URI

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
* Bug fix, nothing to update in docs.