### PR TITLE
PostgreSQL: Adds 'FullyQualifiedDomainName' configuration member.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## vNext
+* PostgreSQL: Adds `FullyQualifiedDomainName` configuration member.
+
 ## 1.7.18
 * Disks: Create managed disks
 * Galleries: Create Galleries for sharing VM images.

--- a/docs/content/api-overview/resources/postgresql.md
+++ b/docs/content/api-overview/resources/postgresql.md
@@ -38,6 +38,12 @@ parameter for the admin account password.
 | Server | add_vnet_rule (name:string, virtualNetworkSubnetId:ResourceId) | Adds a vnet rule to the server |
 | Server | add_vnet_rules (rules:(string*ResourceId)list) | As add_vnet_rule but a list of rules |
 
+##### Configuration Members
+
+| Member | Purpose |
+|-|-|
+| FullyQualifiedDomainName | The fully qualified domain name for the server endpoint. |
+
 #### PostgreSQLDb Builder keywords
 | Applies To | Keyword | Purpose |
 |-|-|-|
@@ -65,6 +71,7 @@ let myPostgres = postgreSQL {
 let template = arm {
     location Location.NorthEurope
     add_resource myPostgres
+    output "fqdn" myPostgres.FullyQualifiedDomainName
 }
 
 // WARNING:

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -89,6 +89,13 @@ type PostgreSQLConfig =
                     }
             ]
 
+    /// Generates an expression for the fully qualified domain name for reaching the postgres server.
+    member this.FullyQualifiedDomainName =
+        let serverId = Farmer.Arm.DBforPostgreSQL.servers.resourceId (this.Name)
+
+        ArmExpression
+            .create($"reference({serverId.ArmExpression.Value}).fullyQualifiedDomainName")
+            .Eval()
 
 [<AutoOpen>]
 module private Helpers =


### PR DESCRIPTION
This PR closes #881

The changes in this PR are as follows:

* PostgreSQL: Adds `FullyQualifiedDomainName` configuration member.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders
open Farmer.PostgreSQL

let myPostgres = postgreSQL {
    admin_username "adminallthethings"
    name "aserverformultitudes42"
    capacity 4<VCores>
    storage_size 50<Gb>
    tier GeneralPurpose
    add_database "my_db"
    enable_azure_firewall
}

let template = arm {
    add_resource myPostgres
    // The FQDN is the endpoint for accessing the server and will be populated in an output variable.
    output "fqdn" myPostgres.FullyQualifiedDomainName
}
```
