### PR TITLE
VM: External diagnostics storage does not generate dependency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## vNext
+* Virtual Machines: External diagnostics storage does not generate dependency
+
 ## 1.7.18
 * Disks: Create managed disks
 * Galleries: Create Galleries for sharing VM images.

--- a/src/Farmer/Arm/Compute.fs
+++ b/src/Farmer/Arm/Compute.fs
@@ -105,7 +105,7 @@ type VirtualMachine =
         Location: Location
         AvailabilityZone: string option
         DiagnosticsEnabled: bool option
-        StorageAccount: ResourceName option
+        StorageAccount: LinkedResource option
         Size: VMSize
         Priority: Priority option
         Credentials: {| Username: string
@@ -134,7 +134,10 @@ type VirtualMachine =
             let dependsOn =
                 [
                     yield! this.NetworkInterfaceIds
-                    yield! this.StorageAccount |> Option.mapList storageAccounts.resourceId
+                    match this.StorageAccount with
+                    | Some (Managed rid) -> rid
+                    | Some (Unmanaged _)
+                    | None -> ()
                     match this.OsDisk with
                     | AttachOsDisk (_, Managed (resourceId)) -> resourceId
                     | _ -> ()
@@ -287,7 +290,7 @@ type VirtualMachine =
                         | Some true ->
                             match this.StorageAccount with
                             | Some storageAccount ->
-                                let resourceId = storageAccounts.resourceId storageAccount
+                                let resourceId = storageAccount.ResourceId
 
                                 let storageUriExpr =
                                     ArmExpression

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -149,7 +149,9 @@ type VmConfig =
                     AvailabilityZone = this.AvailabilityZone
                     Location = location
                     DiagnosticsEnabled = this.DiagnosticsEnabled
-                    StorageAccount = this.DiagnosticsStorageAccount |> Option.map (fun r -> r.resourceId(this).Name)
+                    StorageAccount =
+                        this.DiagnosticsStorageAccount
+                        |> Option.map (fun r -> r.toLinkedResource (this))
                     NetworkInterfaceIds = generatedNics |> List.map (fun nic -> networkInterfaces.resourceId nic.Name)
                     Size = this.Size
                     Priority = this.Priority
@@ -387,10 +389,16 @@ type VirtualMachineBuilder() =
 
     /// Turns on diagnostics support using an externally managed storage account.
     [<CustomOperation "diagnostics_support_external">]
-    member _.StorageAccountNameExternal(state: VmConfig, name) =
+    member _.StorageAccountNameExternal(state: VmConfig, linkedResource: LinkedResource) =
         { state with
             DiagnosticsEnabled = Some true
-            DiagnosticsStorageAccount = Some(LinkedResource name)
+            DiagnosticsStorageAccount = Some(LinkedResource linkedResource)
+        }
+
+    member _.StorageAccountNameExternal(state: VmConfig, id: ResourceId) =
+        { state with
+            DiagnosticsEnabled = Some true
+            DiagnosticsStorageAccount = Some(LinkedResource(Unmanaged id))
         }
 
     /// Turns on diagnostics support using an Azure-managed storage account.


### PR DESCRIPTION
This PR closes #959 

The changes in this PR are as follows:

* Virtual Machines: External diagnostics storage does not generate dependency

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
Bugfix, no doc change.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
vm {
    name "my-vm"
    username "azureuser"
    diagnostics_support_external (Farmer.Arm.Storage.storageAccounts.resourceId "externalvmdiag")
}
```
