### PR TITLE
external resource role assignment scope

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.20
+* Unmanaged resouce role assignment scope
+
 ## 1.7.19
 * DNS: Adds private resolver and forwarding rulesets
 * PostgreSQL: Adds `FullyQualifiedDomainName` configuration member.

--- a/src/Farmer/Arm/RoleAssignment.fs
+++ b/src/Farmer/Arm/RoleAssignment.fs
@@ -36,6 +36,7 @@ type PrincipalType =
 type AssignmentScope =
     | ResourceGroup
     | SpecificResource of ResourceId
+    | UnmanagedResource of ResourceId
 
 type RoleAssignment =
     {
@@ -63,6 +64,7 @@ type RoleAssignment =
                     [
                         match this.Scope with
                         | SpecificResource resourceId -> resourceId
+                        | UnmanagedResource _
                         | ResourceGroup -> ()
                     ]
 
@@ -70,6 +72,7 @@ type RoleAssignment =
                 scope =
                     match this with
                     | { Scope = ResourceGroup } -> null
+                    | { Scope = UnmanagedResource resourceId } -> resourceId.ArmExpression.Eval()
                     | { Scope = SpecificResource resourceId } -> resourceId.Eval()
                 properties =
                     {|

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -61,6 +61,7 @@ let allTests =
                     PostgreSQL.tests
                     PrivateLink.tests
                     ResourceGroup.tests
+                    RoleAssignment.tests
                     ServiceBus.tests
                     SignalR.tests
                     Sql.tests

--- a/src/Tests/RoleAssignment.fs
+++ b/src/Tests/RoleAssignment.fs
@@ -9,15 +9,19 @@ let tests =
         "RoleAssignment"
         [
             test "Produces opaque resource scope" {
-                let actual : IArmResource = 
-                    { Name = ResourceName "assignment"
-                      RoleDefinitionId = Roles.Contributor
-                      PrincipalId = ArmExpression.create "1" |> PrincipalId
-                      PrincipalType = PrincipalType.User
-                      Scope = privateClouds.resourceId "mySDDC" |> UnmanagedResource 
-                      Dependencies = Set.empty }
+                let actual: IArmResource =
+                    {
+                        Name = ResourceName "assignment"
+                        RoleDefinitionId = Roles.Contributor
+                        PrincipalId = ArmExpression.create "1" |> PrincipalId
+                        PrincipalType = PrincipalType.User
+                        Scope = privateClouds.resourceId "mySDDC" |> UnmanagedResource
+                        Dependencies = Set.empty
+                    }
 
                 "Expected matching scope"
-                |> Expect.stringContains (Newtonsoft.Json.JsonConvert.SerializeObject actual.JsonModel) "\"scope\":\"[resourceId('Microsoft.AVS/privateClouds', 'mySDDC')]\""
+                |> Expect.stringContains
+                    (Newtonsoft.Json.JsonConvert.SerializeObject actual.JsonModel)
+                    "\"scope\":\"[resourceId('Microsoft.AVS/privateClouds', 'mySDDC')]\""
             }
         ]

--- a/src/Tests/RoleAssignment.fs
+++ b/src/Tests/RoleAssignment.fs
@@ -1,0 +1,23 @@
+module RoleAssignment
+
+open Expecto
+open Farmer
+open Farmer.Arm
+
+let tests =
+    testList
+        "RoleAssignment"
+        [
+            test "Produces opaque resource scope" {
+                let actual : IArmResource = 
+                    { Name = ResourceName "assignment"
+                      RoleDefinitionId = Roles.Contributor
+                      PrincipalId = ArmExpression.create "1" |> PrincipalId
+                      PrincipalType = PrincipalType.User
+                      Scope = privateClouds.resourceId "mySDDC" |> UnmanagedResource 
+                      Dependencies = Set.empty }
+
+                "Expected matching scope"
+                |> Expect.stringContains (Newtonsoft.Json.JsonConvert.SerializeObject actual.JsonModel) "\"scope\":\"[resourceId('Microsoft.AVS/privateClouds', 'mySDDC')]\""
+            }
+        ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -67,6 +67,7 @@
     <Compile Include="Types.fs" />
     <Compile Include="TrafficManager.fs" />
     <Compile Include="Dashboards.fs" />
+    <Compile Include="RoleAssignment.fs" />
     <Compile Include="DedicatedHosts.fs" />
     <Compile Include="AllTests.fs" />
   </ItemGroup>


### PR DESCRIPTION
This PR closes #1012 

The original ask focused on removing the version requirement, but that is a huge and orthogonal change to the latter point that implicitly created dependency is actually a blocker.

The changes in this PR are as follows:

* Allows creating scopes for resources Farmer doesn't manage.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
Role assignments have no docs.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
                let actual : IArmResource = 
                    { Name = ResourceName "assignment"
                      RoleDefinitionId = Roles.Contributor
                      PrincipalId = ArmExpression.create "1" |> PrincipalId
                      PrincipalType = PrincipalType.User
                      Scope = privateClouds.resourceId "mySDDC" |> UnmanagedResource 
                      Dependencies = Set.empty }
```
