### PR TITLE
VM: Windows Server 2022 Datacenter

### DIFF
--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -822,7 +822,8 @@ module Vm =
     let UbuntuServer_2204LTS =
         makeLinuxVm "0001-com-ubuntu-server-jammy" "canonical" "22_04-lts-gen2"
 
-    let WindowsServer_2022Datacenter = makeWindowsVm "2022-datacenter-azure-edition"
+    let WindowsServer_2022DatacenterAzureEdition = makeWindowsVm "2022-datacenter-azure-edition"
+    let WindowsServer_2022Datacenter = makeWindowsVm "2022-datacenter-g2"
     let WindowsServer_2019Datacenter = makeWindowsVm "2019-Datacenter"
     let WindowsServer_2016Datacenter = makeWindowsVm "2016-Datacenter"
     let WindowsServer_2012R2Datacenter = makeWindowsVm "2012-R2-Datacenter"

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -822,6 +822,7 @@ module Vm =
     let UbuntuServer_2204LTS =
         makeLinuxVm "0001-com-ubuntu-server-jammy" "canonical" "22_04-lts-gen2"
 
+    let WindowsServer_2022Datacenter = makeWindowsVm "2022-datacenter-azure-edition"
     let WindowsServer_2019Datacenter = makeWindowsVm "2019-Datacenter"
     let WindowsServer_2016Datacenter = makeWindowsVm "2016-Datacenter"
     let WindowsServer_2012R2Datacenter = makeWindowsVm "2012-R2-Datacenter"

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -822,7 +822,9 @@ module Vm =
     let UbuntuServer_2204LTS =
         makeLinuxVm "0001-com-ubuntu-server-jammy" "canonical" "22_04-lts-gen2"
 
-    let WindowsServer_2022DatacenterAzureEdition = makeWindowsVm "2022-datacenter-azure-edition"
+    let WindowsServer_2022DatacenterAzureEdition =
+        makeWindowsVm "2022-datacenter-azure-edition"
+
     let WindowsServer_2022Datacenter = makeWindowsVm "2022-datacenter-g2"
     let WindowsServer_2019Datacenter = makeWindowsVm "2019-Datacenter"
     let WindowsServer_2016Datacenter = makeWindowsVm "2016-Datacenter"


### PR DESCRIPTION
Just noticed that the VMs are missing the latest Windows.
I tried to deploy the ARM from Azure Portal and it gave the template:

![image](https://user-images.githubusercontent.com/229355/230723102-b91dcdac-e0a0-4a97-ae62-469b1a92b870.png)

It seems to be all the same as others, just sku being "2022-datacenter-azure-edition".
