### PR TITLE
Update Builders.Functions.fs

### DIFF
--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -464,7 +464,7 @@ type FunctionsBuilder() =
 
                     storageAccounts.resourceId storage)
             VersionedRuntime = FunctionsRuntime.DotNetCore31
-            ExtensionVersion = V3
+            ExtensionVersion = V4
             Dependencies = Set.empty
             PublishAs = Code
             Tags = Map.empty

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -283,7 +283,7 @@
             },
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",
-              "value": "~3"
+              "value": "~4"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -830,7 +830,7 @@
             },
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",
-              "value": "~3"
+              "value": "~4"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",


### PR DESCRIPTION
Related to https://github.com/CompositionalIT/farmer/issues/1031 - default ExtensionVersion: V3 -> V4

This PR closes #1031

The changes in this PR are as follows:

* In the Functions Builder default ExtensionVersion: V3 -> V4

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here: This is rather a tiny change.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders

let func =
    functions {
        name "myBareFunction"
        // use_extension_version V4 // -> V4 is officially recommended. With the PR, this line can be removed.
    }

let deployment =
    arm {
        location Location.AustraliaEast
        add_resource func
    }

deployment |> Deploy.execute "myBareFunction_grp" Deploy.NoParameters |> ignore
```
