### PR TITLE
Add support for Resource Group as a source and Azure Function as a target of Event Grid

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.21
+* AVS: Scripting subresource types.
+
 ## 1.7.20
 * Role Assignments: Unmanaged resouce role assignment scope.
 * SQL Azure: Use Capacity instead of SKU for DTU level of a pool.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.7.21
 * AVS: Scripting subresource types.
+* EventGrid: ResourceGroup as a source and Azure Function as a target.
 
 ## 1.7.20
 * Role Assignments: Unmanaged resouce role assignment scope.

--- a/docs/content/api-overview/resources/event-grid.md
+++ b/docs/content/api-overview/resources/event-grid.md
@@ -15,10 +15,11 @@ The Event Grid is a simple but powerful builder that links events from Azure ser
 |  Keyword | Purpose |
 |-|-|
 | topic_name | The name of the topic that will be created. |
-| source | The source of the events. See below for the full list of builder configurations that are supported. |
+| source | Optional, defaults to the current resource group. The source of the events. See below for the full list of builder configurations that are supported. |
 | add_queue_subscriber | Adds a new storage queue subscriber. Requires the storage account config that will receive the events, the queue name and the list of events to subscribe to. |
 | add_webhook_subscriber| Adds a new web hook (HTTP) subscriber. Requires the web app config that will receive the event, associated URI local path and the list of events to subscribe to. Also contains an overload that takes in a Web App name and the full Uri of the web hook. |
 | add_eventhub_subscriber| Adds a new event hub subscriber. Requiresthe event hub builder config that will receive the events and the list of events to subscribe to. |
+| add_function_subscriber| Adds a new Azure Functions subscriber. Requires the function app, the handler name and the list of events to subscribe to. |
 
 ### Supported Sources
 Farmer supports the following Event Grid sources using Farmer builders:

--- a/samples/scripts/eventgrid-fn.fsx
+++ b/samples/scripts/eventgrid-fn.fsx
@@ -1,0 +1,28 @@
+#r "../../src/Tests/bin/Debug/net6.0/Farmer.dll"
+
+open Farmer
+open Farmer.Builders
+
+/// Send events to this function app
+let fnApp = functions { name "gridFnApp" }
+/// And this specific function
+let fnName = ResourceName "eventHandler"
+
+/// The source will default to the resourceGroup() and event grid target will be the function handler.
+let grid = eventGrid {
+    topic_name "src-rg-events"
+    add_function_subscriber fnApp fnName 
+        { MaxEventsPerBatch = 1u; PreferredBatchSizeInKilobytes = 64u }
+        [ SystemEvents.Resources.ResourceWriteSuccess; SystemEvents.Resources.ResourceActionSuccess ]
+}
+
+let deployment = arm {
+    add_resources [
+        grid
+        fnApp
+    ]
+}
+
+// Generate the ARM template here...
+deployment
+|> Writer.quickWrite "farmer-deploy"

--- a/src/Farmer/Arm/AVS.fs
+++ b/src/Farmer/Arm/AVS.fs
@@ -3,3 +3,5 @@ module Farmer.Arm.AVS
 
 open Farmer
 let privateClouds = ResourceType("Microsoft.AVS/privateClouds", "2021-12-01")
+let privateCloudsScriptPackages = ResourceType("Microsoft.AVS/privateClouds/scriptPackages", "2021-12-01")
+let privateCloudsScriptCmdlets = ResourceType("Microsoft.AVS/privateClouds/scriptPackages/scriptCmdlets", "2021-12-01")

--- a/src/Farmer/Arm/AVS.fs
+++ b/src/Farmer/Arm/AVS.fs
@@ -3,5 +3,9 @@ module Farmer.Arm.AVS
 
 open Farmer
 let privateClouds = ResourceType("Microsoft.AVS/privateClouds", "2021-12-01")
-let privateCloudsScriptPackages = ResourceType("Microsoft.AVS/privateClouds/scriptPackages", "2021-12-01")
-let privateCloudsScriptCmdlets = ResourceType("Microsoft.AVS/privateClouds/scriptPackages/scriptCmdlets", "2021-12-01")
+
+let privateCloudsScriptPackages =
+    ResourceType("Microsoft.AVS/privateClouds/scriptPackages", "2021-12-01")
+
+let privateCloudsScriptCmdlets =
+    ResourceType("Microsoft.AVS/privateClouds/scriptPackages/scriptCmdlets", "2021-12-01")

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -30,6 +30,8 @@ let hostNameBindings =
 let virtualNetworkConnections =
     ResourceType("Microsoft.Web/sites/virtualNetworkConnections", "2021-03-01")
 
+let siteFunctions = ResourceType("Microsoft.Web/sites/functions", "2021-03-01")
+
 let slotsVirtualNetworkConnections =
     ResourceType("Microsoft.Web/sites/slots/virtualNetworkConnections", "2021-03-01")
 

--- a/src/Farmer/Builders/Builders.EventGrid.fs
+++ b/src/Farmer/Builders/Builders.EventGrid.fs
@@ -353,10 +353,11 @@ type EventGridBuilder() =
             batchConfig: EndpointBatchConfig,
             events
         ) =
-        let fnName = 
+        let fnName =
             match fnResourceId.ResourceId with
-            | { Type = t; Segments = [handlerName]} when t = Arm.Web.siteFunctions -> handlerName
+            | { Type = t; Segments = [ handlerName ] } when t = Arm.Web.siteFunctions -> handlerName
             | _ -> failwith "Invalid Azure function resourceId, create one with Web.siteFunctions"
+
         let endpoint =
             {
                 ResourceId = fnResourceId

--- a/src/Tests/EventGrid.fs
+++ b/src/Tests/EventGrid.fs
@@ -22,7 +22,12 @@ let tests =
                 let b = eventGrid { topic_name "my-topic" } :> IBuilder
                 let resources = b.BuildResources Location.WestEurope
                 let t = resources.[0] :?> Topic
-                Expect.equal t.TopicType.ResourceType.Type (Arm.ResourceGroup.resourceGroups.Type) "Incorrect default topic type"
+
+                Expect.equal
+                    t.TopicType.ResourceType.Type
+                    (Arm.ResourceGroup.resourceGroups.Type)
+                    "Incorrect default topic type"
+
                 Expect.equal t.Source (ResourceName "[resourceGroup().name]") "Incorrect default source name"
             }
             test "Creates a storage source correctly" {
@@ -37,21 +42,34 @@ let tests =
                 Expect.equal grid.Source (ResourceName "test", Topics.StorageAccount) "Invalid Source"
             }
             test "Creates a function subscriber correctly" {
-                let fnRef = 
-                    Arm.Web.siteFunctions.resourceId(ResourceName "testFn", ResourceName "testHandler") |> Unmanaged
+                let fnRef =
+                    Arm.Web.siteFunctions.resourceId (ResourceName "testFn", ResourceName "testHandler")
+                    |> Unmanaged
 
                 let grid =
-                    eventGrid { 
-                        add_function_subscriber fnRef
-                                                { MaxEventsPerBatch = 1u; PreferredBatchSizeInKilobytes = 64u }
-                                                [ SystemEvents.Resources.ResourceWriteSuccess ] 
+                    eventGrid {
+                        add_function_subscriber
+                            fnRef
+                            {
+                                MaxEventsPerBatch = 1u
+                                PreferredBatchSizeInKilobytes = 64u
+                            }
+                            [ SystemEvents.Resources.ResourceWriteSuccess ]
                     }
 
                 let sub = grid.Subscriptions.[0]
                 Expect.equal sub.Name (ResourceName "testFn-testHandler-fn") "Incorrect subscription name"
-                Expect.equal sub.Endpoint (EndpointType.AzureFunction { ResourceId = fnRef
-                                                                        MaxEventsPerBatch = 1u
-                                                                        PreferredBatchSizeInKilobytes = 64u }) "Incorrect endpoint type"
+
+                Expect.equal
+                    sub.Endpoint
+                    (EndpointType.AzureFunction
+                        {
+                            ResourceId = fnRef
+                            MaxEventsPerBatch = 1u
+                            PreferredBatchSizeInKilobytes = 64u
+                        })
+                    "Incorrect endpoint type"
+
                 Expect.equal sub.SystemEvents [ SystemEvents.Resources.ResourceWriteSuccess ] "Incorrect system events"
             }
             test "Creates a queue subscriber correctly" {

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -59,7 +59,7 @@
       "type": "Microsoft.ServiceBus/namespaces/queues"
     },
     {
-      "apiVersion": "2020-04-01-preview",
+      "apiVersion": "2022-06-15",
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', 'isaacgriddevprac')]"
       ],
@@ -73,7 +73,7 @@
       "type": "Microsoft.EventGrid/systemTopics"
     },
     {
-      "apiVersion": "2020-04-01-preview",
+      "apiVersion": "2022-06-15",
       "dependsOn": [
         "[resourceId('Microsoft.EventGrid/systemTopics', 'newblobscreated')]",
         "[resourceId('Microsoft.ServiceBus/namespaces/queues', 'farmereventpubservicebusns', 'events')]"
@@ -96,7 +96,7 @@
       "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions"
     },
     {
-      "apiVersion": "2020-04-01-preview",
+      "apiVersion": "2022-06-15",
       "dependsOn": [
         "[resourceId('Microsoft.EventGrid/systemTopics', 'newblobscreated')]",
         "[resourceId('Microsoft.Storage/storageAccounts/queueServices/queues', 'isaacgriddevprac', 'default', 'todo')]"


### PR DESCRIPTION
This PR closes #1029 and #1030 

The changes in this PR are as follows:

* Switch to more recent EventGrid API
* Defaults to Resource Group as the source for eventGrid
* Exposes Microsoft.Resources.* events for subscriptions
* Introduces 2 overloads of `add_function_subscriber` to specify Azure Function as subscription target
  - with `function` resource defined in the current deployment
  - with  `LinkedResource` reference to function handler already deployed separately

I think the latter overload will be more widely used as the handler, not just the function has to exist when subscription is created. This means the code has be deployed that exposes the handler, which is often a separate from ARM step.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp

/// Send events to this function that was deployed separately
let fnRef = 
    { Arm.Web.siteFunctions.resourceId(ResourceName "gridFnApp", ResourceName "eventHandler") with 
        ResourceGroup = Some "fn-rg" }
    |> Unmanaged

/// The source will default to the resourceGroup() and event grid target will be the function handler.
let grid = eventGrid {
    topic_name "src-rg-events"
    add_function_subscriber fnRef 
        { MaxEventsPerBatch = 1u; PreferredBatchSizeInKilobytes = 64u }
        [ SystemEvents.Resources.ResourceWriteSuccess; SystemEvents.Resources.ResourceActionSuccess ]
}

// deploy into the resource group that we want to be the source of events
let deployment = arm {
    add_resources [
        grid
    ]
}
```
