### PR TITLE
Farmer support for network interface

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 Release Notes
 =============
-## 1.7.23
+
+## 1.7.24
 * Network Interface: Adds support for network interface creation.
-* 
 
 ## 1.7.22
 * AVS: Scripting subresource types.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.7.23
+* Network Interface: Adds support for network interface creation.
+* 
 
 ## 1.7.22
 * AVS: Scripting subresource types.

--- a/docs/content/api-overview/resources/network-interface.md
+++ b/docs/content/api-overview/resources/network-interface.md
@@ -13,14 +13,16 @@ communicate with internet, Azure, and on-premises resources. To learn more about
 
 #### Builder Keywords
 
-| Applies To | Keyword          | Purpose                                                                                    |
-|-|------------------|--------------------------------------------------------------------------------------------|
-| networkInterface | name             | Name of the network interface resource                                                     |
-| networkInterface | subnet_prefix     | Sets the subnet prefix of the vnet for network interface                                   |
-| networkInterface | link_to_vnet       | Link to existing vnet or to vnet managed by Farmer                                         |
-| networkInterface | add_static_ip       | Use static ip for the network interface. If not provided, ip will be dynamically allocated |
-| networkInterface | accelerated_networking_flag    | The accelerated networking flag for the network interface. Default is false  |
-| networkInterface | ip_forwarding_flag    | The ip forwarding flag for the network interface. Default is false                         |
+| Applies To | Keyword          | Purpose                                                                                               |
+|-|------------------|-------------------------------------------------------------------------------------------------------|
+| networkInterface | name             | Name of the network interface resource                                                                |
+| networkInterface | link_to_subnet     | Link to existing subnet. If not provided, need to specify the subnet name and prefix for a new subnet |
+| networkInterface | subnet_name     | Sets the name of the vnet subnet for network interface                                                |
+| networkInterface | subnet_prefix     | Sets the prefix of the vnet subnet for network interface                                              |
+| networkInterface | link_to_vnet       | Link to existing vnet or to vnet managed by Farmer                                                    |
+| networkInterface | add_static_ip       | Use static ip for the network interface. If not provided, ip will be dynamically allocated            |
+| networkInterface | accelerated_networking_flag    | The accelerated networking flag for the network interface. Default is false                           |
+| networkInterface | ip_forwarding_flag    | The ip forwarding flag for the network interface. Default is false                                    |
 
 #### Example
 
@@ -41,11 +43,34 @@ arm {
             }
             networkInterface {
                 name "my-network-interface"
+                subnet_name "my-subnet"
                 subnet_prefix "10.0.100.0/24"
                 link_to_vnet (virtualNetworks.resourceId "test-vnet")
                 add_static_ip "10.0.100.10"
                 accelerated_networking_flag false
                 ip_forwarding_flag false
+            }
+        ]
+}
+```
+
+#### Example using existing vnet and subnet with dynamic ip allocation
+
+```fsharp
+#r "nuget:Farmer"
+open Farmer
+open Farmer.Builders
+open Farmer.Builders.NetworkInterface
+
+arm {
+    location Location.EastUS
+
+    add_resources
+        [
+            networkInterface {
+                name "my-network-interface"
+                link_to_subnet "test-subnet"
+                link_to_vnet "test-vnet"
             }
         ]
 }

--- a/docs/content/api-overview/resources/network-interface.md
+++ b/docs/content/api-overview/resources/network-interface.md
@@ -1,0 +1,52 @@
+---
+title: "Network Interface"
+chapter: false
+weight: 5
+---
+
+#### Overview
+The `networkInterface` builder allows you to create network interfaces (NIC) so that Azure virtual machine (VM) can 
+communicate with internet, Azure, and on-premises resources. To learn more about routeServer, reference to 
+[Azure Docs](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-network-interface?tabs=azure-portal)
+
+* NetworkInterface (`Microsoft.Network/networkInterfaces`)
+
+#### Builder Keywords
+
+| Applies To | Keyword          | Purpose                                                                                    |
+|-|------------------|--------------------------------------------------------------------------------------------|
+| networkInterface | name             | Name of the network interface resource                                                     |
+| networkInterface | subnet_prefix     | Sets the subnet prefix of the vnet for network interface                                   |
+| networkInterface | link_to_vnet       | Link to existing vnet or to vnet managed by Farmer                                         |
+| networkInterface | add_static_ip       | Use static ip for the network interface. If not provided, ip will be dynamically allocated |
+| networkInterface | accelerated_networking_flag    | The accelerated networking flag for the network interface. Default is false  |
+| networkInterface | ip_forwarding_flag    | The ip forwarding flag for the network interface. Default is false                         |
+
+#### Example
+
+```fsharp
+#r "nuget:Farmer"
+open Farmer
+open Farmer.Builders
+open Farmer.Builders.NetworkInterface
+
+arm {
+    location Location.EastUS
+
+    add_resources
+        [
+            vnet {
+                name "test-vnet"
+                add_address_spaces [ "10.0.0.0/16" ]
+            }
+            networkInterface {
+                name "my-network-interface"
+                subnet_prefix "10.0.100.0/24"
+                link_to_vnet (virtualNetworks.resourceId "test-vnet")
+                add_static_ip "10.0.100.10"
+                accelerated_networking_flag false
+                ip_forwarding_flag false
+            }
+        ]
+}
+```

--- a/src/Farmer/Builders/Builders.NetworkInterface.fs
+++ b/src/Farmer/Builders/Builders.NetworkInterface.fs
@@ -1,0 +1,129 @@
+module Farmer.Builders.NetworkInterface
+
+open Farmer
+open Farmer.Arm
+open Farmer
+open Farmer.Builders
+open Farmer.Network
+open Farmer.Arm.Network
+
+type NetworkInterfaceConfig =
+    {
+        Name: ResourceName
+        AcceleratedNetworkingflag: FeatureFlag option
+        IpForwarding: FeatureFlag option
+        IsPrimary: bool option
+        VirtualNetwork: LinkedResource option
+        SubnetPrefix: IPAddressCidr
+        PrivateIpAddress: string
+        Tags: Map<string, string>
+    }
+
+    interface IBuilder with
+        member this.ResourceId = networkInterfaces.resourceId this.Name
+
+        member this.BuildResources location =
+            [
+                //vnet
+                let vnetId =
+                    this.VirtualNetwork
+                    |> Option.defaultWith (fun _ -> raiseFarmer "Must set 'vnet' for network interface")
+
+                //subnet
+                {
+                    Subnet.Name = ResourceName "networkInterfaceSubnet"
+                    Prefix = IPAddressCidr.format this.SubnetPrefix
+                    VirtualNetwork = Some(vnetId)
+                    NetworkSecurityGroup = None
+                    Delegations = []
+                    NatGateway = None
+                    ServiceEndpoints = []
+                    AssociatedServiceEndpointPolicies = []
+                    PrivateEndpointNetworkPolicies = None
+                    PrivateLinkServiceNetworkPolicies = None
+                }
+                
+                //ipConfig
+                let subnetIpConfigs = [{
+                    SubnetName = ResourceName "networkInterfaceSubnet"
+                    LoadBalancerBackendAddressPools = []
+                    PublicIpAddress = None
+                    PrivateIpAllocation =
+                        match this.PrivateIpAddress with
+                            | "" -> Some(AllocationMethod.DynamicPrivateIp)
+                            | ip -> Some(AllocationMethod.StaticPrivateIp(System.Net.IPAddress.Parse ip))
+                    Primary = this.IsPrimary
+                }]
+                
+                //network interface
+                {
+                    Name = this.Name
+                    Location = location
+                    EnableAcceleratedNetworking = this.AcceleratedNetworkingflag |> Option.map (fun f -> f.AsBoolean)
+                    EnableIpForwarding = this.IpForwarding |> Option.map (fun f -> f.AsBoolean)
+                    IpConfigs = subnetIpConfigs
+                    Primary = this.IsPrimary
+                    VirtualNetwork = vnetId
+                    NetworkSecurityGroup = None
+                    Tags = this.Tags
+                }
+            ]
+
+type NetworkInterfaceBuilder() =
+    member _.Yield _ =
+        {
+            Name = ResourceName.Empty
+            AcceleratedNetworkingflag = None
+            IpForwarding = None
+            IsPrimary = None
+            VirtualNetwork = None
+            SubnetPrefix =
+                    {
+                        Address = System.Net.IPAddress.Parse("10.0.100.0")
+                        Prefix = 16
+                    }
+            PrivateIpAddress = ""
+            Tags = Map.empty
+        }
+
+    [<CustomOperation "name">]
+    member _.Name(state: NetworkInterfaceConfig, name: string) = { state with Name = ResourceName name }
+
+    [<CustomOperation "accelerated_networking_flag">]
+    member _.AcceleratedNetworkingflag(state: NetworkInterfaceConfig, flag: bool) =
+        { state with
+            AcceleratedNetworkingflag = Some(FeatureFlag.ofBool flag)
+        }
+        
+    [<CustomOperation "ip_forwarding_flag">]
+    member _.IpForwarding(state: NetworkInterfaceConfig, flag: bool) =
+        { state with
+            IpForwarding = Some(FeatureFlag.ofBool flag)
+        }
+
+    [<CustomOperation "is_primary">]
+    member _.IsPrimary(state: NetworkInterfaceConfig, isPrimary: bool) =
+        { state with
+            IsPrimary = Some(isPrimary)
+        }
+
+    // linked to managed vnet created by Farmer and linked by user
+    [<CustomOperation "link_to_vnet">]
+    member _.LinkToVNetId(state: NetworkInterfaceConfig, vnetId: ResourceId) =
+        { state with
+            VirtualNetwork = Some(Managed vnetId)
+        }
+
+    // linked to external existing vnet
+    member _.LinkToVNetId(state: NetworkInterfaceConfig, vnetName: string) =
+        { state with
+            VirtualNetwork = Some(Unmanaged(virtualNetworks.resourceId (ResourceName vnetName)))
+        }
+
+    [<CustomOperation "subnet_prefix">]
+    member _.SubnetPrefix(state: NetworkInterfaceConfig, prefix) = { state with SubnetPrefix = IPAddressCidr.parse prefix }
+    
+    [<CustomOperation "add_static_ip">]
+    member _.StaticIpAllocation(state: NetworkInterfaceConfig, addr) = { state with PrivateIpAddress = addr }
+
+let networkInterface = NetworkInterfaceBuilder()

--- a/src/Farmer/Builders/Builders.NetworkInterface.fs
+++ b/src/Farmer/Builders/Builders.NetworkInterface.fs
@@ -42,19 +42,22 @@ type NetworkInterfaceConfig =
                     PrivateEndpointNetworkPolicies = None
                     PrivateLinkServiceNetworkPolicies = None
                 }
-                
+
                 //ipConfig
-                let subnetIpConfigs = [{
-                    SubnetName = ResourceName "networkInterfaceSubnet"
-                    LoadBalancerBackendAddressPools = []
-                    PublicIpAddress = None
-                    PrivateIpAllocation =
-                        match this.PrivateIpAddress with
-                            | "" -> Some(AllocationMethod.DynamicPrivateIp)
-                            | ip -> Some(AllocationMethod.StaticPrivateIp(System.Net.IPAddress.Parse ip))
-                    Primary = this.IsPrimary
-                }]
-                
+                let subnetIpConfigs =
+                    [
+                        {
+                            SubnetName = ResourceName "networkInterfaceSubnet"
+                            LoadBalancerBackendAddressPools = []
+                            PublicIpAddress = None
+                            PrivateIpAllocation =
+                                match this.PrivateIpAddress with
+                                | "" -> Some(AllocationMethod.DynamicPrivateIp)
+                                | ip -> Some(AllocationMethod.StaticPrivateIp(System.Net.IPAddress.Parse ip))
+                            Primary = this.IsPrimary
+                        }
+                    ]
+
                 //network interface
                 {
                     Name = this.Name
@@ -78,10 +81,10 @@ type NetworkInterfaceBuilder() =
             IsPrimary = None
             VirtualNetwork = None
             SubnetPrefix =
-                    {
-                        Address = System.Net.IPAddress.Parse("10.0.100.0")
-                        Prefix = 16
-                    }
+                {
+                    Address = System.Net.IPAddress.Parse("10.0.100.0")
+                    Prefix = 16
+                }
             PrivateIpAddress = ""
             Tags = Map.empty
         }
@@ -94,7 +97,7 @@ type NetworkInterfaceBuilder() =
         { state with
             AcceleratedNetworkingflag = Some(FeatureFlag.ofBool flag)
         }
-        
+
     [<CustomOperation "ip_forwarding_flag">]
     member _.IpForwarding(state: NetworkInterfaceConfig, flag: bool) =
         { state with
@@ -121,8 +124,11 @@ type NetworkInterfaceBuilder() =
         }
 
     [<CustomOperation "subnet_prefix">]
-    member _.SubnetPrefix(state: NetworkInterfaceConfig, prefix) = { state with SubnetPrefix = IPAddressCidr.parse prefix }
-    
+    member _.SubnetPrefix(state: NetworkInterfaceConfig, prefix) =
+        { state with
+            SubnetPrefix = IPAddressCidr.parse prefix
+        }
+
     [<CustomOperation "add_static_ip">]
     member _.StaticIpAllocation(state: NetworkInterfaceConfig, addr) = { state with PrivateIpAddress = addr }
 

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -180,6 +180,7 @@
     <Compile Include="Builders\Builders.PrivateEndpoint.fs" />
     <Compile Include="Builders\Builders.RouteTable.fs" />
     <Compile Include="Builders\Builders.HostGroup.fs" />
+    <Compile Include="Builders\Builders.NetworkInterface.fs" />
     <Compile Include="Aliases.fs" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -829,7 +829,7 @@ let tests =
                     "[resourceId('farmer-pls', 'Microsoft.Network/privateLinkServices', 'pls')]"
                     "Incorrect private link service ID"
             }
-            
+
             test "Creates basic network interface with static ip" {
                 let deployment =
                     arm {
@@ -854,8 +854,8 @@ let tests =
 
                 let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
                 let templateStr = jobj.ToString()
-                
-                 //validate vnet generated
+
+                //validate vnet generated
                 let vnet =
                     jobj.SelectToken "resources[?(@.type=='Microsoft.Network/virtualNetworks')]"
 
@@ -873,7 +873,7 @@ let tests =
                 let subnetProps = subnet.["properties"]
                 let addressPrefix: string = JToken.op_Explicit subnetProps.["addressPrefix"]
                 Expect.equal addressPrefix "10.0.100.0/24" "Incorrect addressPrefix for subnet"
-                
+
                 //validate network interface generated
                 let networkInterface =
                     jobj.SelectToken "resources[?(@.type=='Microsoft.Network/networkInterfaces')]"
@@ -900,42 +900,42 @@ let tests =
                     "Incorrect networkInterface dependencies"
 
                 let networkInterfaceProps = networkInterface.["properties"]
-                
+
                 let enableAcceleratedNetworking: bool =
                     JToken.op_Explicit networkInterfaceProps.["enableAcceleratedNetworking"]
+
                 Expect.equal enableAcceleratedNetworking false "Incorrect default value for enableAcceleratedNetworking"
-                
+
                 let enableIPForwarding: bool =
                     JToken.op_Explicit networkInterfaceProps.["enableIPForwarding"]
+
                 Expect.equal enableIPForwarding false "Incorrect default value for enableIPForwarding"
-                
+
                 //validate ip config generated
                 let ipConfig = networkInterfaceProps.["ipConfigurations"].[0]
                 Expect.isNotNull ipConfig "network interface ip config should be generated"
-                
+
                 let ipConfigName = ipConfig.["name"]
-                Expect.equal
-                    ipConfigName
-                    "ipconfig1"
-                    "Incorrect default value for network interface ip config name"
-                    
+                Expect.equal ipConfigName "ipconfig1" "Incorrect default value for network interface ip config name"
+
                 let ipConfigProps = ipConfig.["properties"]
-                
-                let privateIPAddress: string =
-                    JToken.op_Explicit ipConfigProps.["privateIPAddress"]
+
+                let privateIPAddress: string = JToken.op_Explicit ipConfigProps.["privateIPAddress"]
                 Expect.equal privateIPAddress "10.0.100.10" "Incorrect default value for privateIPAddress"
-                
+
                 let privateIPAllocationMethod: string =
                     JToken.op_Explicit ipConfigProps.["privateIPAllocationMethod"]
+
                 Expect.equal privateIPAllocationMethod "Static" "Incorrect default value for privateIPAllocationMethod"
-                
+
                 let subnetId = ipConfigProps.SelectToken("subnet.id").ToString()
+
                 Expect.equal
                     subnetId
                     "[resourceId(\u0027Microsoft.Network/virtualNetworks/subnets\u0027, \u0027test-vnet\u0027, \u0027networkInterfaceSubnet\u0027)]"
                     "Incorrect subnet id for ipConfig"
             }
-            
+
             test "Creates basic network interface with dynamic ip" {
                 let deployment =
                     arm {
@@ -957,18 +957,20 @@ let tests =
 
                 let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
                 let templateStr = jobj.ToString()
-                
+
                 let networkInterface =
                     jobj.SelectToken "resources[?(@.type=='Microsoft.Network/networkInterfaces')]"
+
                 Expect.isNotNull networkInterface "network interface should be generated"
-                
+
                 let ipConfig = networkInterface.["properties"].["ipConfigurations"].[0]
                 Expect.isNotNull ipConfig "network interface ip config should be generated"
-                
+
                 let ipConfigProps = ipConfig.["properties"]
-                
+
                 let privateIPAllocationMethod: string =
                     JToken.op_Explicit ipConfigProps.["privateIPAllocationMethod"]
+
                 Expect.equal privateIPAllocationMethod "Dynamic" "Incorrect default value for privateIPAllocationMethod"
             }
         ]


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Adding support for azure network interface
* Support both dynamic and static ip allocation

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
#r "nuget:Farmer"
open Farmer
open Farmer.Builders
open Farmer.Builders.NetworkInterface

arm {
    location Location.EastUS
    add_resources
        [
            vnet {
                name "test-vnet"
                add_address_spaces [ "10.0.0.0/16" ]
            }
            networkInterface {
                name "my-network-interface"
                subnet_prefix "10.0.100.0/24"
                link_to_vnet (virtualNetworks.resourceId "test-vnet")
                add_static_ip "10.0.100.10"
                accelerated_networking_flag false
                ip_forwarding_flag false
            }
        ]
}
```
