### PR TITLE
Fixed scope of RoleAssignment for storage accounts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 ## 1.7.23
 * Route server: Adds support for route server creation.
+* Storage Accounts: Fixes scope of role assignments.
 
 ## 1.7.22
 * AVS: Scripting subresource types.

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -173,7 +173,7 @@ type StorageAccountConfig =
                         RoleDefinitionId = roleAssignment.Role
                         PrincipalId = roleAssignment.Principal
                         PrincipalType = PrincipalType.ServicePrincipal
-                        Scope = ResourceGroup
+                        Scope = SpecificResource this.ResourceId
                         Dependencies =
                             Set
                                 [

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -299,7 +299,11 @@ let tests =
                 Expect.equal roleAssignment.PrincipalId uai.PrincipalId "PrincipalId"
                 Expect.equal roleAssignment.RoleDefinitionId Roles.StorageBlobDataOwner "RoleId"
                 Expect.equal roleAssignment.Name.Value "105eb550-eb9f-56b6-955d-1def9d3139ec" "Storage Account Name"
-                Expect.equal roleAssignment.Scope (Farmer.Arm.RoleAssignment.AssignmentScope.SpecificResource builder.ResourceId) "Scope"
+
+                Expect.equal
+                    roleAssignment.Scope
+                    (Farmer.Arm.RoleAssignment.AssignmentScope.SpecificResource builder.ResourceId)
+                    "Scope"
 
                 Expect.sequenceEqual
                     roleAssignment.Dependencies
@@ -327,6 +331,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.Kind "BlobStorage" "Kind"
                 Expect.equal resource.AccessTier (Nullable AccessTier.Hot) "Access Tier"
                 Expect.equal resource.Sku.Name "Standard_LRS" "Sku Name"
@@ -338,6 +343,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.Kind "FileStorage" "Kind"
                 Expect.equal resource.Sku.Name "Premium_ZRS" "Sku Name"
 
@@ -348,6 +354,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.Kind "BlockBlobStorage" "Kind"
                 Expect.equal resource.Sku.Name "Premium_LRS" "Sku Name"
 
@@ -358,6 +365,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.Kind "Storage" "Kind"
                 Expect.equal resource.Sku.Name "Standard_RAGRS" "Sku Name"
 
@@ -368,6 +376,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.Kind "StorageV2" "Kind"
                 Expect.equal resource.Sku.Name "Premium_LRS" "Sku Name"
             }
@@ -379,6 +388,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.AccessTier (Nullable AccessTier.Cool) "Access Tier"
 
                 let account =
@@ -388,6 +398,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.AccessTier (Nullable AccessTier.Hot) "Access Tier"
 
                 let account =
@@ -397,6 +408,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.AccessTier (Nullable()) "Access Tier"
 
                 let account =
@@ -406,6 +418,7 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
+
                 Expect.equal resource.AccessTier (Nullable AccessTier.Hot) "Access Tier"
             }
             test "Setting default access tier with incompatible sku throws an exception" {
@@ -428,6 +441,7 @@ let tests =
                     }
 
                 let generated = arm { add_resource storage } |> getStorageResource
+
                 Expect.hasLength generated.NetworkRuleSet.IpRules 2 "Wrong number of IP rules"
 
                 Expect.containsAll
@@ -448,6 +462,7 @@ let tests =
                     }
 
                 let generatedStorage = arm { add_resource storage } |> getStorageResource
+
                 Expect.hasLength generatedStorage.NetworkRuleSet.VirtualNetworkRules 2 "Wrong number of vnet rules"
 
                 let allowedSubnets =
@@ -547,6 +562,7 @@ let tests =
                     }
 
                 let properties = (account |> findPropertiesResource "blobServices").properties
+
                 let restore = properties.restorePolicy
 
                 Expect.isTrue restore.enabled ""
@@ -611,6 +627,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -636,6 +653,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -666,6 +684,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -705,6 +724,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -725,6 +745,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -744,6 +765,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -764,6 +786,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -783,6 +806,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -805,6 +829,7 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
+
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -331,7 +331,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.Kind "BlobStorage" "Kind"
                 Expect.equal resource.AccessTier (Nullable AccessTier.Hot) "Access Tier"
                 Expect.equal resource.Sku.Name "Standard_LRS" "Sku Name"
@@ -343,7 +342,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.Kind "FileStorage" "Kind"
                 Expect.equal resource.Sku.Name "Premium_ZRS" "Sku Name"
 
@@ -365,7 +363,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.Kind "Storage" "Kind"
                 Expect.equal resource.Sku.Name "Standard_RAGRS" "Sku Name"
 
@@ -376,7 +373,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.Kind "StorageV2" "Kind"
                 Expect.equal resource.Sku.Name "Premium_LRS" "Sku Name"
             }
@@ -388,7 +384,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.AccessTier (Nullable AccessTier.Cool) "Access Tier"
 
                 let account =
@@ -398,7 +393,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.AccessTier (Nullable AccessTier.Hot) "Access Tier"
 
                 let account =
@@ -408,7 +402,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.AccessTier (Nullable()) "Access Tier"
 
                 let account =
@@ -418,7 +411,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.AccessTier (Nullable AccessTier.Hot) "Access Tier"
             }
             test "Setting default access tier with incompatible sku throws an exception" {
@@ -441,7 +433,6 @@ let tests =
                     }
 
                 let generated = arm { add_resource storage } |> getStorageResource
-
                 Expect.hasLength generated.NetworkRuleSet.IpRules 2 "Wrong number of IP rules"
 
                 Expect.containsAll
@@ -462,7 +453,6 @@ let tests =
                     }
 
                 let generatedStorage = arm { add_resource storage } |> getStorageResource
-
                 Expect.hasLength generatedStorage.NetworkRuleSet.VirtualNetworkRules 2 "Wrong number of vnet rules"
 
                 let allowedSubnets =
@@ -562,7 +552,6 @@ let tests =
                     }
 
                 let properties = (account |> findPropertiesResource "blobServices").properties
-
                 let restore = properties.restorePolicy
 
                 Expect.isTrue restore.enabled ""
@@ -627,7 +616,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -653,7 +641,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -684,7 +671,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -724,7 +710,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -745,7 +730,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -765,7 +749,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -786,7 +769,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -806,7 +788,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal
@@ -829,7 +810,6 @@ let tests =
                     arm { add_resource account }
 
                 let jsn = resource.Template |> Writer.toJson
-
                 let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
                 Expect.equal

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -352,7 +352,6 @@ let tests =
                     }
 
                 let resource = arm { add_resource account } |> getStorageResource
-
                 Expect.equal resource.Kind "BlockBlobStorage" "Kind"
                 Expect.equal resource.Sku.Name "Premium_LRS" "Sku Name"
 

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -299,7 +299,7 @@ let tests =
                 Expect.equal roleAssignment.PrincipalId uai.PrincipalId "PrincipalId"
                 Expect.equal roleAssignment.RoleDefinitionId Roles.StorageBlobDataOwner "RoleId"
                 Expect.equal roleAssignment.Name.Value "105eb550-eb9f-56b6-955d-1def9d3139ec" "Storage Account Name"
-                Expect.equal roleAssignment.Scope Farmer.Arm.RoleAssignment.AssignmentScope.ResourceGroup "Scope"
+                Expect.equal roleAssignment.Scope (Farmer.Arm.RoleAssignment.AssignmentScope.SpecificResource builder.ResourceId) "Scope"
 
                 Expect.sequenceEqual
                     roleAssignment.Dependencies


### PR DESCRIPTION
This PR closes #1038

The changes in this PR are as follows:

* In builder: role assignment is to the storage account, not the resource group
* Tests updated

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
