### PR TITLE
Add user friendly error message for security rule source missing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.7.25
+* Network Security Groups: Fix bug where a SecurityRule without a source throws a meaningful exception
+
 ## 1.7.24
 * Network Interface: Adds support for network interface creation.
 

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -147,6 +147,9 @@ let internal buildNsgRule (nsgName: ResourceName) (rule: SecurityRuleConfig) (pr
         Protocol =
             let protocols = rule.Sources |> List.map (fun (protocol, _, _) -> protocol) |> Set
 
+            if protocols.Count = 0 then
+                raiseFarmer $"You must set a source for security rule {rule.Name.Value}"
+
             if protocols.Count > 1 then
                 AnyProtocol
             else

--- a/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
+++ b/src/Farmer/Builders/Builders.NetworkSecurityGroup.fs
@@ -145,15 +145,12 @@ let internal buildNsgRule (nsgName: ResourceName) (rule: SecurityRuleConfig) (pr
         Description = None
         SecurityGroup = nsgName
         Protocol =
-            let protocols = rule.Sources |> List.map (fun (protocol, _, _) -> protocol) |> Set
+            let protocols = rule.Sources |> List.map (fun (protocol, _, _) -> protocol)
 
-            if protocols.Count = 0 then
-                raiseFarmer $"You must set a source for security rule {rule.Name.Value}"
-
-            if protocols.Count > 1 then
-                AnyProtocol
-            else
-                protocols |> Seq.head
+            match protocols with
+            | [] -> raiseFarmer $"You must set a source for security rule {rule.Name.Value}"
+            | [ protocol ] -> protocol
+            | _ -> AnyProtocol
         SourcePorts = rule.Sources |> List.map (fun (_, _, sourcePort) -> sourcePort) |> Set
         SourceAddresses =
             rule.Sources

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -225,18 +225,13 @@ let tests =
             }
             test "Security rule requires a source" {
                 let createNsg () =
-                    let rule =
-                        securityRule {
-                            name "bar"
-                        }
+                    let rule = securityRule { name "bar" }
 
                     arm {
                         add_resource (
                             nsg {
                                 name "foo"
-                                add_rules [
-                                    rule
-                                ]
+                                add_rules [ rule ]
                             }
                         )
                     }

--- a/src/Tests/NetworkSecurityGroup.fs
+++ b/src/Tests/NetworkSecurityGroup.fs
@@ -223,4 +223,26 @@ let tests =
                     Expect.containsAll rule4.SourceAddressPrefixes [ "10.100.31.0/24"; "10.100.32.0/24" ] ""
                 | _ -> raiseFarmer "Unexpected number of resources in template."
             }
+            test "Security rule requires a source" {
+                let createNsg () =
+                    let rule =
+                        securityRule {
+                            name "bar"
+                        }
+
+                    arm {
+                        add_resource (
+                            nsg {
+                                name "foo"
+                                add_rules [
+                                    rule
+                                ]
+                            }
+                        )
+                    }
+                    |> ignore
+
+                let message = Expect.throwsC createNsg (fun ex -> ex.Message)
+                Expect.equal message "You must set a source for security rule bar" "Wrong exception thrown"
+            }
         ]


### PR DESCRIPTION
This PR closes #1041

The changes in this PR are as follows:

* Security rule builder throws a `FarmerException` when a source is not provided
* Unit test added to verify exception is thrown


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

E2E testing and documentation not done as this PR only changes an existing exception to a friendly exception and does not change any existing output functionality.
