### PR TITLE
Update virtual-machine.md

### DIFF
--- a/docs/content/api-overview/resources/virtual-machine.md
+++ b/docs/content/api-overview/resources/virtual-machine.md
@@ -38,7 +38,7 @@ In addition, every VM you create will add a SecureString parameter to the ARM te
 |attach_existing_os_disk|Attaches an existing managed disk to the VM as the OS disk.|
 |attach_data_disk|Attaches an newly imported managed disk to the VM as a data disk.|
 |attach_existing_data_disk|Attaches an existing managed disk to the VM as a data disk.|
-|no_disk|Excludes a data disk (only an OS disk) - common when mounting cloud storage.|
+|no_data_disk|Excludes a data disk (only an OS disk) - common when mounting cloud storage.|
 |domain_name_prefix|Sets the prefix for the domain name of the VM.|
 |address_prefix|Sets the IP address prefix of the VM.|
 |subnet_prefix|Sets the subnet prefix of the VM.|


### PR DESCRIPTION
Correct `no_disk` to `no_data_disk`.

This PR closes #

The changes in this PR are as follows:

* Fixes docs to use the correct `no_data_disk` property instead of `no_disk` for virtual machines.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Docs change only
