### PR TITLE
When making app-settings into key-vault secret names sanitize the name.

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -444,8 +444,10 @@ type WebAppConfig =
                                         for setting in this.CommonWebConfig.Settings do
                                             match setting.Value with
                                             | LiteralSetting _ -> ()
-                                            | ParameterSetting _ -> SecretConfig.create (setting.Key)
-                                            | ExpressionSetting expr -> SecretConfig.create (setting.Key, expr)
+                                            | ParameterSetting _ ->
+                                                SecretConfig.create (SecretConfig.sanitizeKeyName (setting.Key))
+                                            | ExpressionSetting expr ->
+                                                SecretConfig.create (SecretConfig.sanitizeKeyName (setting.Key), expr)
                                     ]
                             }
 
@@ -457,8 +459,11 @@ type WebAppConfig =
                                     let secret =
                                         match setting.Value with
                                         | LiteralSetting _ -> None
-                                        | ParameterSetting _ -> SecretConfig.create setting.Key |> Some
-                                        | ExpressionSetting expr -> SecretConfig.create (setting.Key, expr) |> Some
+                                        | ParameterSetting _ ->
+                                            SecretConfig.create (SecretConfig.sanitizeKeyName (setting.Key)) |> Some
+                                        | ExpressionSetting expr ->
+                                            SecretConfig.create (SecretConfig.sanitizeKeyName (setting.Key), expr)
+                                            |> Some
 
                                     match secret with
                                     | Some secret ->
@@ -549,7 +554,7 @@ type WebAppConfig =
                                      | ExpressionSetting _ ->
                                          setting.Key,
                                          LiteralSetting
-                                             $"@Microsoft.KeyVault(SecretUri=https://{name.Name.Value}.vault.azure.net/secrets/{setting.Key})"
+                                             $"@Microsoft.KeyVault(SecretUri=https://{name.Name.Value}.vault.azure.net/secrets/{SecretConfig.sanitizeKeyName (setting.Key)})"
                              ]
                              |> Map.ofList)
                         |> Map.toList


### PR DESCRIPTION
This PR closes #1035 

The changes in this PR are as follows:

* When creating keyvault secrets for web app appsettings replace characters unsupported in keyvault secret names with `-`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

* Not sure if documentation needs updating? I think this is a bit of a bugfix?
* Will wait for PR to be accepted in principal before doing the remaining tasks.
