### PR TITLE
SQL Azure - add support for AD admin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,9 @@
 Release Notes
 =============
-## 1.7.26
-* SQL Azure: Adds support for AD admin
-
 ## 1.7.25
 * Network Security Groups: Fix bug where a SecurityRule without a source throws a meaningful exception
 * Network Security Groups: Add rule to existing security group
+* SQL Azure: Adds support for AD admin
 
 ## 1.7.24
 * Network Interface: Adds support for network interface creation.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.7.26
+* SQL Azure: Adds support for AD admin
+
 ## 1.7.25
 * Network Security Groups: Fix bug where a SecurityRule without a source throws a meaningful exception
 * Network Security Groups: Add rule to existing security group

--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -11,19 +11,28 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 * SQL Azure server (`Microsoft.Sql/servers`)
 
 #### SQL Server Builder Keywords
-| Keyword | Purpose |
-|-|-|
-| name | Sets the name of the SQL server. |
-| add_firewall_rule | Adds a custom firewall rule given a name, start and end IP address range. |
-| add_firewall_rules | As add_firewall_rule but a list of rules |
-| enable_azure_firewall | Adds a firewall rule that enables access to other Azure services. |
-| admin_username | Sets the admin username of the server. |
-| elastic_pool_name | Sets the name of the elastic pool, if required. If not set, Farmer will generate a name for you. |
-| elastic_pool_sku | Sets the sku of the elastic pool, if required. If not set, Farmer will default to Basic 50. |
-| elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database. |
-| elastic_pool_capacity | Sets the optional disk size in MB for the elastic pool for each database. |
-| min_tls_version | Sets the minium TLS version for the SQL server |
+| Keyword | Purpose                                                                                                                         |
+|-|---------------------------------------------------------------------------------------------------------------------------------|
+| name | Sets the name of the SQL server.                                                                                                |
+| active_directory_admin | Sets Active Directory admin of the server                                                                               |
+| add_firewall_rule | Adds a custom firewall rule given a name, start and end IP address range.                                                       |
+| add_firewall_rules | As add_firewall_rule but a list of rules                                                                                        |
+| enable_azure_firewall | Adds a firewall rule that enables access to other Azure services.                                                               |
+| admin_username | Sets the admin username of the server.                                                                                          |
+| elastic_pool_name | Sets the name of the elastic pool, if required. If not set, Farmer will generate a name for you.                                |
+| elastic_pool_sku | Sets the sku of the elastic pool, if required. If not set, Farmer will default to Basic 50.                                     |
+| elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database.                                              |
+| elastic_pool_capacity | Sets the optional disk size in MB for the elastic pool for each database.                                                       |
+| min_tls_version | Sets the minium TLS version for the SQL server                                                                                  |
 | geo_replicate | Geo-replicate all the databases in this server to another location, having NameSuffix after original server and database names. |
+
+#### ActiveDirectoryAdminSettings Members
+| Member | Purpose                                                                    |
+|-|----------------------------------------------------------------------------|
+| Login | Display name of AD admin                                                   |
+| Sid | AD object id of AD admin (user or group)                                   |
+| PrincipalType | ActiveDirectoryPrincipalType User or Group                                 |
+| AdOnlyAuth | Disables SQL authentication. False value required admin_username to be set |
 
 #### SQL Server Configuration Members
 | Member | Purpose |
@@ -43,6 +52,8 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 | use_encryption | Enables transparent data encryption of the database. |
 
 #### Example
+
+##### AD auth not set
 ```fsharp
 open Farmer
 open Farmer.Builders
@@ -50,6 +61,60 @@ open Sql
 
 let myDatabases = sqlServer {
     name "my_server"
+    admin_username "admin_username"
+    enable_azure_firewall
+
+    elastic_pool_name "mypool"
+    elastic_pool_sku PoolSku.Basic100
+
+    add_databases [
+        sqlDb { name "poolDb1" }
+        sqlDb { name "poolDb2" }
+        sqlDb { name "dtuDb"; sku Basic }
+        sqlDb { name "memoryDb"; sku M_8 }
+        sqlDb { name "cpuDb"; sku Fsv2_8 }
+        sqlDb { name "businessCriticalDb"; sku (BusinessCritical Gen5_2) }
+        sqlDb { name "hyperscaleDb"; sku (Hyperscale Gen5_2) }
+        sqlDb {
+            name "generalPurposeDb"
+            sku (GeneralPurpose Gen5_8)
+            db_size (1024<Mb> * 128)
+            hybrid_benefit
+        }
+    ]
+}
+
+let template = arm {
+    location Location.NorthEurope
+    add_resource myDatabases
+}
+
+template
+|> Writer.quickWrite "sql-example"
+
+template
+|> Deploy.execute "my-resource-group" [ "password-for-my_server", "*****" ]
+```
+
+##### AD auth set
+```fsharp
+open Farmer
+open Farmer.Builders
+open Sql
+open Farmer.Arm.Sql
+
+let activeDirectoryAdmin: ActiveDirectoryAdminSettings =
+    {
+        Login = "adadmin"
+        Sid = "F9D49C34-01BA-4897-B7E2-3694BF3DE2CF"
+        PrincipalType = ActiveDirectoryPrincipalType.User
+        AdOnlyAuth = false  // when false, admin_username is required
+                            // when true admin_username is ignored
+    }
+                        
+let myDatabases = sqlServer {
+    name "my_server"
+    active_directory_admin (Some(activeDirectoryAdmin))
     admin_username "admin_username"
     enable_azure_firewall
 

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -37,6 +37,12 @@ type ActiveDirectoryAdminSettings =
         AdOnlyAuth: bool
     }
 
+let (|MixedModeAuth|AdOnlyAuth|SqlOnlyAuth|) activeDirAdmin =
+    match activeDirAdmin with
+    | Some x when x.AdOnlyAuth -> AdOnlyAuth(x)
+    | Some x when not x.AdOnlyAuth -> MixedModeAuth(x)
+    | _ -> SqlOnlyAuth
+
 type SqlServerADAdminJsonProperties =
     {
         administratorType: string
@@ -134,9 +140,9 @@ type Server =
                ) with
                 properties =
                     match this.ActiveDirectoryAdmin with
-                    | Some x when not x.AdOnlyAuth -> this.BuildSqlServerPropertiesWithMixedModeAdministrator(x)
-                    | Some x when x.AdOnlyAuth -> this.BuildSqlServerPropertiesWithADOnlyAdministrator(x)
-                    | _ -> this.BuildSqlServerPropertiesWithSqlOnlyAdministrator()
+                    | MixedModeAuth x -> this.BuildSqlServerPropertiesWithMixedModeAdministrator(x)
+                    | AdOnlyAuth x -> this.BuildSqlServerPropertiesWithADOnlyAdministrator(x)
+                    | SqlOnlyAuth -> this.BuildSqlServerPropertiesWithSqlOnlyAdministrator()
             |}
 
 module Servers =

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -51,7 +51,7 @@ type Server =
     interface IParameters with
         member this.SecureParameters =
             match this.ActiveDirectoryAdmin with
-            | Some(x) when x.AdOnlyAuth -> []
+            | Some (x) when x.AdOnlyAuth -> []
             | _ -> [ this.Credentials.Password ]
 
     interface IArmResource with

--- a/src/Farmer/Arm/Sql.fs
+++ b/src/Farmer/Arm/Sql.fs
@@ -45,6 +45,7 @@ type SqlServerADAdminJsonProperties =
         sid: string
         azureADOnlyAuthentication: bool
     }
+
 type SqlServerJsonProperties =
     {
         version: string
@@ -53,7 +54,7 @@ type SqlServerJsonProperties =
         administratorLoginPassword: string
         administrators: SqlServerADAdminJsonProperties
     }
-    
+
 type Server =
     {
         ServerName: SqlAccountName
@@ -65,7 +66,7 @@ type Server =
         Tags: Map<string, string>
     }
 
-    member private this.BuildSqlSeverPropertiesBase(): SqlServerJsonProperties =
+    member private this.BuildSqlSeverPropertiesBase() : SqlServerJsonProperties =
         {
             version = "12.0"
             minimalTlsVersion =
@@ -78,8 +79,8 @@ type Server =
             administratorLoginPassword = null
             administrators = Unchecked.defaultof<SqlServerADAdminJsonProperties>
         }
-    
-    member private this.BuildSqlServerADOnlyAdmin(x: ActiveDirectoryAdminSettings): SqlServerADAdminJsonProperties =
+
+    member private this.BuildSqlServerADOnlyAdmin(x: ActiveDirectoryAdminSettings) : SqlServerADAdminJsonProperties =
         {
             administratorType = "ActiveDirectory"
             principalType =
@@ -90,32 +91,32 @@ type Server =
             sid = x.Sid
             azureADOnlyAuthentication = true
         }
-        
-    member private this.BuildSqlServerPropertiesWithMixedModeAdministrator(x: ActiveDirectoryAdminSettings): SqlServerJsonProperties =
-        {
-            this.BuildSqlSeverPropertiesBase() with
-                administratorLogin = this.Credentials.Username
-                administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
-                administrators =
-                {
-                    this.BuildSqlServerADOnlyAdmin(x) with
-                        azureADOnlyAuthentication = false 
+
+    member private this.BuildSqlServerPropertiesWithMixedModeAdministrator
+        (x: ActiveDirectoryAdminSettings)
+        : SqlServerJsonProperties =
+        { this.BuildSqlSeverPropertiesBase() with
+            administratorLogin = this.Credentials.Username
+            administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
+            administrators =
+                { this.BuildSqlServerADOnlyAdmin(x) with
+                    azureADOnlyAuthentication = false
                 }
         }
-        
-    member private this.BuildSqlServerPropertiesWithADOnlyAdministrator(x: ActiveDirectoryAdminSettings): SqlServerJsonProperties =
-        {
-            this.BuildSqlSeverPropertiesBase() with
-                administrators = this.BuildSqlServerADOnlyAdmin(x)
+
+    member private this.BuildSqlServerPropertiesWithADOnlyAdministrator
+        (x: ActiveDirectoryAdminSettings)
+        : SqlServerJsonProperties =
+        { this.BuildSqlSeverPropertiesBase() with
+            administrators = this.BuildSqlServerADOnlyAdmin(x)
         }
-        
-    member private this.BuildSqlServerPropertiesWithSqlOnlyAdministrator(): SqlServerJsonProperties =
-        {
-            this.BuildSqlSeverPropertiesBase() with
-                administratorLogin = this.Credentials.Username
-                administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
-        }   
-            
+
+    member private this.BuildSqlServerPropertiesWithSqlOnlyAdministrator() : SqlServerJsonProperties =
+        { this.BuildSqlSeverPropertiesBase() with
+            administratorLogin = this.Credentials.Username
+            administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
+        }
+
     interface IParameters with
         member this.SecureParameters =
             match this.ActiveDirectoryAdmin with
@@ -124,7 +125,7 @@ type Server =
 
     interface IArmResource with
         member this.ResourceId = servers.resourceId this.ServerName.ResourceName
-        
+
         member this.JsonModel =
             {| servers.Create(
                    this.ServerName.ResourceName,

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -237,7 +237,7 @@ type AgentPoolBuilder() =
 
     /// Sets the agent pool to user mode.
     [<CustomOperation "user_mode">]
-    member _.UserMode(state: AgentPoolConfig) = { state with Mode = User }
+    member _.UserMode(state: AgentPoolConfig) = { state with Mode = AgentPoolMode.User }
 
     /// Sets the disk size for the VM's in the agent pool.
     [<CustomOperation "disk_size">]

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -237,7 +237,8 @@ type AgentPoolBuilder() =
 
     /// Sets the agent pool to user mode.
     [<CustomOperation "user_mode">]
-    member _.UserMode(state: AgentPoolConfig) = { state with Mode = AgentPoolMode.User }
+    member _.UserMode(state: AgentPoolConfig) =
+        { state with Mode = AgentPoolMode.User }
 
     /// Sets the disk size for the VM's in the agent pool.
     [<CustomOperation "disk_size">]

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -76,7 +76,7 @@ type SqlAzureConfig =
                     Location = location
                     Credentials =
                         match this.ActiveDirectoryAdmin with
-                        | Some (x) when x.AdOnlyAuth -> Unchecked.defaultof<_>
+                        | AdOnlyAuth _ -> Unchecked.defaultof<_>
                         | _ ->
                             {|
                                 Username = this.AdministratorCredentials.UserName
@@ -315,14 +315,12 @@ type SqlServerBuilder() =
             }
 
         match state.ActiveDirectoryAdmin with
-        | Some x ->
-            if x.AdOnlyAuth then
-                { state with
-                    AdministratorCredentials = Unchecked.defaultof<_>
-                }
-            else
-                getStateWithAdminCredentials ()
-        | _ -> getStateWithAdminCredentials ()
+        | AdOnlyAuth _ ->
+            { state with
+                AdministratorCredentials = Unchecked.defaultof<_>
+            }
+        | MixedModeAuth _ -> getStateWithAdminCredentials ()
+        | SqlOnlyAuth -> getStateWithAdminCredentials ()
 
     /// Sets the name of the SQL server.
     [<CustomOperation "name">]

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -75,8 +75,8 @@ type SqlAzureConfig =
                     ServerName = this.Name
                     Location = location
                     Credentials =
-                        match this.ActiveDirectoryAdmin  with
-                        | Some(x) when x.AdOnlyAuth -> Unchecked.defaultof<_>
+                        match this.ActiveDirectoryAdmin with
+                        | Some (x) when x.AdOnlyAuth -> Unchecked.defaultof<_>
                         | _ ->
                             {|
                                 Username = this.AdministratorCredentials.UserName
@@ -317,9 +317,8 @@ type SqlServerBuilder() =
         match state.ActiveDirectoryAdmin with
         | Some x ->
             if x.AdOnlyAuth then
-                {
-                    state with
-                        AdministratorCredentials =  Unchecked.defaultof<_>
+                { state with
+                    AdministratorCredentials = Unchecked.defaultof<_>
                 }
             else
                 getStateWithAdminCredentials ()

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -96,8 +96,4 @@ let allTests =
 let main _ =
     printfn "Running tests!"
 
-    runTests
-        { defaultConfig with
-            verbosity = Logging.Info
-        }
-        allTests
+    Tests.runTestsWithCLIArgs [] [| (*"--debug"*) |] allTests

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -2,6 +2,7 @@ module Sql
 
 open Expecto
 open Farmer
+open Farmer.Arm
 open Farmer.Sql
 open Farmer.Builders
 open Microsoft.Azure.Management.Sql
@@ -210,6 +211,7 @@ let tests =
                 check "-zz" "cannot start with a dash (-). The invalid value is '-zz'" "Start with dash"
                 check "zz-" "cannot end with a dash (-). The invalid value is 'zz-'" "End with dash"
             }
+
             test "Sets Min TLS version correctly" {
                 let sql =
                     sqlServer {
@@ -324,10 +326,80 @@ let tests =
                     "Incorrect autoPauseDelay"
             }
 
-
             test "Must set a SQL Server account name" {
                 Expect.throws
                     (fun () -> sqlServer { admin_username "test" } |> ignore)
                     "Must set a name on a sql server account"
             }
+
+
+            testTheory
+                "AD Auth"
+                [
+                    (true, ActiveDirectoryPrincipalType.User, null)
+                    (false, ActiveDirectoryPrincipalType.User, "sqladmin")
+                    (true, ActiveDirectoryPrincipalType.Group, null)
+                    (false, ActiveDirectoryPrincipalType.Group, "sqladmin")
+                ]
+            <| fun (adOnlyAuth, principalType, adminUserName) ->
+                let sql =
+                    let activeDirectoryUserAdmin: ActiveDirectoryAdminSettings =
+                        {
+                            Login = "adadmin"
+                            Sid = "F9D49C34-01BA-4897-B7E2-3694BF3DE2CF"
+                            PrincipalType = principalType
+                            AdOnlyAuth = adOnlyAuth
+                        }
+
+                    sqlServer {
+                        name "adtestserver"
+                        active_directory_admin (Some(activeDirectoryUserAdmin))
+                        admin_username adminUserName
+                    }
+
+                let template =
+                    arm {
+                        location Location.AustraliaEast
+                        add_resources [ sql ]
+                    }
+
+                let jsn = template.Template |> Writer.toJson
+                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+
+                Expect.equal
+                    (jobj
+                        .SelectToken("resources[?(@.name=='adtestserver')].properties.administrators.administratorType")
+                        .ToString())
+                    "ActiveDirectory"
+                    "Incorrect administrator type"
+
+                Expect.equal
+                    (jobj
+                        .SelectToken(
+                            "resources[?(@.name=='adtestserver')].properties.administrators.azureADOnlyAuthentication"
+                        )
+                        .ToString())
+                    (adOnlyAuth.ToString())
+                    $"AD only auth should be {adOnlyAuth.ToString()}"
+
+                Expect.equal
+                    (jobj
+                        .SelectToken("resources[?(@.name=='adtestserver')].properties.administrators.login")
+                        .ToString())
+                    "adadmin"
+                    "Incorrect AD login name"
+
+                Expect.equal
+                    (jobj
+                        .SelectToken("resources[?(@.name=='adtestserver')].properties.administrators.principalType")
+                        .ToString())
+                    $"{principalType.ToString()}"
+                    "Incorrect principal type"
+
+                Expect.equal
+                    (jobj
+                        .SelectToken("resources[?(@.name=='adtestserver')].properties.administrators.sid")
+                        .ToString())
+                    "F9D49C34-01BA-4897-B7E2-3694BF3DE2CF"
+                    "Incorrect SID"
         ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -73,7 +73,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="expecto" Version="9.0.4" />
+    <PackageReference Include="expecto" Version="10.1.0" />
     <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="Microsoft.Azure.Management.Cdn" Version="6.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
@@ -100,8 +100,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.13.3" />
-    <PackageReference Update="FSharp.Core" Version="5.0.0" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.14.0" />
+    <PackageReference Update="FSharp.Core" Version="7.0.300" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -16,9 +16,9 @@
       "location": "northeurope",
       "name": "farmersql1979",
       "properties": {
+        "version": "12.0",
         "administratorLogin": "farmersqladmin",
-        "administratorLoginPassword": "[parameters('password-for-farmersql1979')]",
-        "version": "12.0"
+        "administratorLoginPassword": "[parameters('password-for-farmersql1979')]"
       },
       "tags": {
         "displayName": "farmersql1979"

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -12,7 +12,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2019-06-01-preview",
+      "apiVersion": "2022-05-01-preview",
       "location": "northeurope",
       "name": "farmersql1979",
       "properties": {


### PR DESCRIPTION
This PR closes #1036 

The changes in this PR are as follows:

* introduce new type `ActiveDirectoryAdminSettings`
* change to apply these settings to handle
    * sql admin with no AD admin (existing capability)
    * sql admin with AD admin (new)
    * AD admin only (new)

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let activeDirectoryAdmin: ActiveDirectoryAdminSettings =
  {
    Login = "admingroup"
    Sid = "F9D49C34-01BA-4897-B7E2-3694BF3DE2CF"
    PrincipalType = ActiveDirectoryPrincipalType.Group
    AdOnlyAuth = false
  }

sqlServer {
     name "adtestserver"
     active_directory_admin (Some(activeDirectoryAdmin))
     admin_username "sqladminuser"
}
```

## Issues
I have found that ARM templates need modification to switch SQL server configuration among following -
1. sql admin with no AD admin
2. sql admin with AD admin
3. AD admin only

Please refer this blog post - https://www.codez.one/azure-sql-with-managed-identities-part-2/

One possible way forward is to make `AdOnlyAuth` member optional and let the user write correct farmer template by detecting existence of SQL server out of band (using AZ cli or powershell etc)
