### PR TITLE
Network Security Groups: Add rule to existing security group

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@ Release Notes
 =============
 ## 1.7.25
 * Network Security Groups: Fix bug where a SecurityRule without a source throws a meaningful exception
+* Network Security Groups: Add rule to existing security group
 
 ## 1.7.24
 * Network Interface: Adds support for network interface creation.

--- a/docs/content/api-overview/resources/nsg.md
+++ b/docs/content/api-overview/resources/nsg.md
@@ -13,28 +13,30 @@ The Network Security Group builder creates network security groups with rules fo
 
 #### Builder Keywords
 
-| Applies To | Keyword | Purpose |
-|-|-|-|
-| nsg | name | Specifies the name of the network security group |
-| nsg | add_rules | Adds security rules to the network security group |
-| nsg | initial_rule_priority | The priority of the first rule, after which each rule gets an incrementally higher value. Default 100. |
-| nsg | priority_incr | This sets how much priority is increased per each rule. Default 100. |
-| securityRule | name | The name of the security rule |
-| securityRule | description | The description  of the security rule |
-| securityRule | services | The services port(s) and protocol(s) protected by this security rule |
-| securityRule | add_source | Specify access from any source protocol, address, and port |
-| securityRule | add_source_any | Specify access from any address and any port |
-| securityRule | add_source_address | Specify access from a specific address and any port |
-| securityRule | add_source_network | Specify access from a specific network and any port |
-| securityRule | add_source_tag | Specify access from a tagged source such as "Internet", "VirtualNetwork", or "AzureLoadBalancer" |
-| securityRule | add_destination | Specify access to any source protocol, address, and port |
-| securityRule | add_destination_any | Specify access to any address and any port |
-| securityRule | add_destination_address | Specify access to a specific address and any port |
-| securityRule | add_destination_network | Specify access from a specific network and any port |
-| securityRule | add_destination_tag | Specify access to a tagged destination such as "Internet", "VirtualNetwork", or "AzureLoadBalancer" |
-| securityRule | allow | Allows this traffic (the default) |
-| securityRule | deny | Denies this traffic |
-| securityRule | direction | Specify the direction of traffic controlled by the rule - inbound (the default) or outbound. |
+| Applies To | Keyword                        | Purpose                                                                                                |
+|-|--------------------------------|--------------------------------------------------------------------------------------------------------|
+| nsg | name                           | Specifies the name of the network security group                                                       |
+| nsg | add_rules                      | Adds security rules to the network security group                                                      |
+| nsg | initial_rule_priority          | The priority of the first rule, after which each rule gets an incrementally higher value. Default 100. |
+| nsg | priority_incr                  | This sets how much priority is increased per each rule. Default 100.                                   |
+| securityRule | name                           | The name of the security rule                                                                          |
+| securityRule | description                    | The description  of the security rule                                                                  |
+| securityRule | services                       | The services port(s) and protocol(s) protected by this security rule                                   |
+| securityRule | add_source                     | Specify access from any source protocol, address, and port                                             |
+| securityRule | add_source_any                 | Specify access from any address and any port                                                           |
+| securityRule | add_source_address             | Specify access from a specific address and any port                                                    |
+| securityRule | add_source_network             | Specify access from a specific network and any port                                                    |
+| securityRule | add_source_tag                 | Specify access from a tagged source such as "Internet", "VirtualNetwork", or "AzureLoadBalancer"       |
+| securityRule | add_destination                | Specify access to any source protocol, address, and port                                               |
+| securityRule | add_destination_any            | Specify access to any address and any port                                                             |
+| securityRule | add_destination_address        | Specify access to a specific address and any port                                                      |
+| securityRule | add_destination_network        | Specify access from a specific network and any port                                                    |
+| securityRule | add_destination_tag            | Specify access to a tagged destination such as "Internet", "VirtualNetwork", or "AzureLoadBalancer"    |
+| securityRule | allow                          | Allows this traffic (the default)                                                                      |
+| securityRule | deny                           | Denies this traffic                                                                                    |
+| securityRule | direction                      | Specify the direction of traffic controlled by the rule - inbound (the default) or outbound.           |
+| securityRule | priority                       | Explicitly specify the priority of a security rule.                                                    |
+| securityRule | link_to_network_security_group | Specify the nsg when creating a security rule for an existing security group.                          |
 
 #### Basic Example
 


### PR DESCRIPTION
This PR closes #992 

The changes in this PR are as follows:

* Network Security Groups: Add rule to existing security group

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
arm {
    add_resources [
        securityRule {
            name "web-servers"
            description "Public web server access"
            services [ "http", 80; "https", 443 ]
            add_source_tag TCP "Internet"
            add_destination_network "10.100.30.0/24"
            link_to_network_security_group existingNsg
            priority 350
        }
    ]
}
```
