### PR TITLE
Add tags support for network interface and route server builder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,13 @@
 Release Notes
 =============
-## 1.7.26
-* Network Interface: Adds support for adding tags
-* Route server: Adds support for adding tags
 
 ## 1.7.25
+* Container Apps: Fix storage queue KEDA scaling rule authentication
 * Network Security Groups: Fix bug where a SecurityRule without a source throws a meaningful exception
 * Network Security Groups: Add rule to existing security group
+* Network Interface: Adds support for adding tags
+* Route server: Adds support for adding tags
 * SQL Azure: Adds support for AD admin
-* Container Apps: Fix storage queue KEDA scaling rule authentication
 
 ## 1.7.24
 * Network Interface: Adds support for network interface creation.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 Release Notes
 =============
+## 1.7.26
+* Network Interface: Adds support for adding tags
+* Route server: Adds support for adding tags
+
 ## 1.7.25
 * Network Security Groups: Fix bug where a SecurityRule without a source throws a meaningful exception
 * Network Security Groups: Add rule to existing security group

--- a/src/Farmer/Builders/Builders.NetworkInterface.fs
+++ b/src/Farmer/Builders/Builders.NetworkInterface.fs
@@ -179,4 +179,10 @@ type NetworkInterfaceBuilder() =
             PrivateIpAddress = AllocationMethod.StaticPrivateIp(System.Net.IPAddress.Parse addr)
         }
 
+    interface ITaggable<NetworkInterfaceConfig> with
+        member _.Add state tags =
+            { state with
+                Tags = state.Tags |> Map.merge tags
+            }
+
 let networkInterface = NetworkInterfaceBuilder()

--- a/src/Farmer/Builders/Builders.RouteServer.fs
+++ b/src/Farmer/Builders/Builders.RouteServer.fs
@@ -174,4 +174,10 @@ type RouteServerBuilder() =
             VirtualNetwork = Some(Unmanaged(virtualNetworks.resourceId (ResourceName vnetName)))
         }
 
+    interface ITaggable<RouteServerConfig> with
+        member _.Add state tags =
+            { state with
+                Tags = state.Tags |> Map.merge tags
+            }
+
 let routeServer = RouteServerBuilder()


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add supportability for adding tags for network interface builder and route server builder 

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
The ITaggable interface is globally used and tested already and no need to be included in doc.