### PR TITLE
Dotnet framework version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.7.26
+* Functions: Add the correct netFrameworkVersion to the template based on the runtime version
+
 ## 1.7.25
 * Network Security Groups: Fix bug where a SecurityRule without a source throws a meaningful exception
 * Network Security Groups: Add rule to existing security group

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -335,9 +335,7 @@ type FunctionsConfig =
                             let possibleVersions = [ "4.0"; "6.0"; "7.0" ]
 
                             match this.VersionedRuntime with
-                            | DotNet, Some version when possibleVersions |> List.contains version -> Some $"v{version}"
-                            | DotNetIsolated, Some version when possibleVersions |> List.contains version ->
-                                Some $"v{version}"
+                            | (DotNet | DotNetIsolated), Some version when possibleVersions |> List.contains version -> Some $"v{version}"
                             | _, _ -> None
                         JavaVersion = None
                         JavaContainer = None

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -333,9 +333,9 @@ type FunctionsConfig =
                                 | _, None -> None
                         NetFrameworkVersion =
                             let possibleVersions = [ "4.0"; "6.0"; "7.0" ]
+
                             match this.VersionedRuntime with
-                            | DotNet, Some version when possibleVersions |> List.contains version ->
-                                Some $"v{version}"
+                            | DotNet, Some version when possibleVersions |> List.contains version -> Some $"v{version}"
                             | DotNetIsolated, Some version when possibleVersions |> List.contains version ->
                                 Some $"v{version}"
                             | _, _ -> None

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -335,7 +335,9 @@ type FunctionsConfig =
                             let possibleVersions = [ "4.0"; "6.0"; "7.0" ]
 
                             match this.VersionedRuntime with
-                            | (DotNet | DotNetIsolated), Some version when possibleVersions |> List.contains version -> Some $"v{version}"
+                            | (DotNet
+                              | DotNetIsolated),
+                              Some version when possibleVersions |> List.contains version -> Some $"v{version}"
                             | _, _ -> None
                         JavaVersion = None
                         JavaContainer = None

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -25,11 +25,13 @@ type VersionedFunctionsRuntime = FunctionsRuntime * string option
 type FunctionsRuntime with
     // These values are defined on FunctionsRuntime to reduce the need for users to be aware of the distinction
     // between FunctionsRuntime and VersionedFunctionsRuntime as well as to provide parity with WebApp runtime
+    static member DotNetFramework48 = DotNet, Some "4.0"
     static member DotNetCore31 = DotNet, Some "3.1"
     static member DotNet50 = DotNet, Some "5.0"
     static member DotNet50Isolated = DotNetIsolated, Some "5.0"
     static member DotNet60 = DotNet, Some "6.0"
     static member DotNet60Isolated = DotNetIsolated, Some "6.0"
+    static member DotNet70Isolated = DotNetIsolated, Some "7.0"
     static member Node14 = Node, Some "14-lts"
     static member Node12 = Node, Some "12-lts"
     static member Node10 = Node, Some "10-lts"
@@ -329,7 +331,14 @@ type FunctionsConfig =
                                 | DotNetIsolated, Some version -> Some $"DOTNET-ISOLATED|{version}"
                                 | _, Some version -> Some $"{functionsRuntime.ToUpper()}|{version}"
                                 | _, None -> None
-                        NetFrameworkVersion = None
+                        NetFrameworkVersion =
+                            let possibleVersions = [ "4.0"; "6.0"; "7.0" ]
+                            match this.VersionedRuntime with
+                            | DotNet, Some version when possibleVersions |> List.contains version ->
+                                Some $"v{version}"
+                            | DotNetIsolated, Some version when possibleVersions |> List.contains version ->
+                                Some $"v{version}"
+                            | _, _ -> None
                         JavaVersion = None
                         JavaContainer = None
                         JavaContainerVersion = None

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -787,4 +787,34 @@ let tests =
                 let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection>
                 Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
             }
+            test "Supports .NET framework 4.8 in netFramework field" {
+                let app =
+                    functions {
+                        name "net6"
+                        use_runtime FunctionsRuntime.DotNetFramework48
+                    }
+
+                let site = app |> getResources |> getResource<Web.Site> |> List.head
+                Expect.equal site.NetFrameworkVersion.Value "v4.0" "Wrong dotnet version"
+            }
+            test "Supports .NET 6 in netFramework field" {
+                let app =
+                    functions {
+                        name "net6"
+                        use_runtime FunctionsRuntime.DotNet60
+                    }
+
+                let site = app |> getResources |> getResource<Web.Site> |> List.head
+                Expect.equal site.NetFrameworkVersion.Value "v6.0" "Wrong dotnet version"
+            }
+            test "Supports .NET 7 netFramework field" {
+                let app =
+                    functions {
+                        name "net6"
+                        use_runtime FunctionsRuntime.DotNet70Isolated
+                    }
+
+                let site = app |> getResources |> getResource<Web.Site> |> List.head
+                Expect.equal site.NetFrameworkVersion.Value "v7.0" "Wrong dotnet version"
+            }
         ]

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -787,34 +787,21 @@ let tests =
                 let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection>
                 Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
             }
-            test "Supports .NET framework 4.8 in netFramework field" {
-                let app =
-                    functions {
-                        name "net6"
-                        use_runtime FunctionsRuntime.DotNetFramework48
-                    }
+            let data = [
+                (FunctionsRuntime.DotNetFramework48, "v4.0")
+                (FunctionsRuntime.DotNet60Isolated, "v6.0")
+                (FunctionsRuntime.DotNet60, "v6.0")
+                (FunctionsRuntime.DotNet70Isolated, "v7.0")
+            ]
+            for runtime, expectedVersion in data do
+                test "Supports correct version in netFrameworkVersion field" {
+                    let app =
+                        functions {
+                            name expectedVersion
+                            use_runtime runtime
+                        }
 
-                let site = app |> getResources |> getResource<Web.Site> |> List.head
-                Expect.equal site.NetFrameworkVersion.Value "v4.0" "Wrong dotnet version"
-            }
-            test "Supports .NET 6 in netFramework field" {
-                let app =
-                    functions {
-                        name "net6"
-                        use_runtime FunctionsRuntime.DotNet60
-                    }
-
-                let site = app |> getResources |> getResource<Web.Site> |> List.head
-                Expect.equal site.NetFrameworkVersion.Value "v6.0" "Wrong dotnet version"
-            }
-            test "Supports .NET 7 netFramework field" {
-                let app =
-                    functions {
-                        name "net6"
-                        use_runtime FunctionsRuntime.DotNet70Isolated
-                    }
-
-                let site = app |> getResources |> getResource<Web.Site> |> List.head
-                Expect.equal site.NetFrameworkVersion.Value "v7.0" "Wrong dotnet version"
-            }
+                    let site = app |> getResources |> getResource<Web.Site> |> List.head
+                    Expect.equal site.NetFrameworkVersion.Value expectedVersion "Wrong netFrameworkVersion"
+                }
         ]

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -794,10 +794,11 @@ let tests =
                 (FunctionsRuntime.DotNet70Isolated, "v7.0")
             ]
             for runtime, expectedVersion in data do
-                test "Supports correct version in netFrameworkVersion field" {
+                let dotnetVersion = runtime |> fst |> string
+                test $"Supports correct version {dotnetVersion}-{expectedVersion} in netFrameworkVersion field" {
                     let app =
                         functions {
-                            name expectedVersion
+                            name dotnetVersion
                             use_runtime runtime
                         }
 

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -787,14 +787,17 @@ let tests =
                 let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection>
                 Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
             }
-            let data = [
-                (FunctionsRuntime.DotNetFramework48, "v4.0")
-                (FunctionsRuntime.DotNet60Isolated, "v6.0")
-                (FunctionsRuntime.DotNet60, "v6.0")
-                (FunctionsRuntime.DotNet70Isolated, "v7.0")
-            ]
+            let data =
+                [
+                    (FunctionsRuntime.DotNetFramework48, "v4.0")
+                    (FunctionsRuntime.DotNet60Isolated, "v6.0")
+                    (FunctionsRuntime.DotNet60, "v6.0")
+                    (FunctionsRuntime.DotNet70Isolated, "v7.0")
+                ]
+
             for runtime, expectedVersion in data do
                 let dotnetVersion = runtime |> fst |> string
+
                 test $"Supports correct version {dotnetVersion}-{expectedVersion} in netFrameworkVersion field" {
                     let app =
                         functions {


### PR DESCRIPTION
This PR closes #1051

The changes in this PR are as follows:

* when selecting the dotnet version, the field netFrameworkversion is now populated with the correct value
* unit tests for the above

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
