### PR TITLE
Route Servers: Support 'depends_on' for routeServerBGPConnection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.7.26
 * Container Apps: Add support for Dapr components
+* Route Servers: Support 'depends_on' for routeServerBGPConnection.
 * WebApps: When creating keyvault secrets for web app appsettings replace characters unsupported in keyvault secret names with `-`
 
 ## 1.7.25

--- a/docs/content/api-overview/resources/route-server.md
+++ b/docs/content/api-overview/resources/route-server.md
@@ -24,6 +24,7 @@ The `routeServer` builder creates a route server to simplify dynamic routing bet
 | routeServerBGPConnection | name                           | Name of the BGP connection                                                 |
 | routeServerBGPConnection | peer_ip                         | The peer IP of the BGP connection                                          |
 | routeServerBGPConnection | peer_asn                        | The peer Asn of the BGP connection                                         |
+| routeServerBGPConnection | depends_on                      | Depend on another resource before deploying this bgp connection            |
 
 #### Example
 

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -230,6 +230,7 @@ type RouteServerBGPConnection =
         PeerIp: string
         PeerAsn: int
         IpConfig: LinkedResource
+        Dependencies: Set<ResourceId>
     }
 
     interface IArmResource with
@@ -246,6 +247,7 @@ type RouteServerBGPConnection =
                     this.RouteServer.ResourceId
                 }
                 |> Set.ofSeq
+                |> Set.union this.Dependencies
 
             {| routeServerBGPConnections.Create(this.RouteServer.Name / this.Name, dependsOn = dependencies) with
                 properties =

--- a/src/Farmer/Builders/Builders.RouteServer.fs
+++ b/src/Farmer/Builders/Builders.RouteServer.fs
@@ -11,10 +11,17 @@ type RSBGPConnectionConfig =
         Name: string
         PeerIp: string
         PeerAsn: int
+        Dependencies: Set<ResourceId>
     }
 
 type RSBGPConnectionBuilder() =
-    member _.Yield _ = { Name = ""; PeerIp = ""; PeerAsn = 0 }
+    member _.Yield _ =
+        {
+            Name = ""
+            PeerIp = ""
+            PeerAsn = 0
+            Dependencies = Set.empty
+        }
 
     [<CustomOperation "name">]
     member _.ConnectionName(state: RSBGPConnectionConfig, name) = { state with Name = name }
@@ -24,6 +31,13 @@ type RSBGPConnectionBuilder() =
 
     [<CustomOperation "peer_asn">]
     member _.PeerAsn(state: RSBGPConnectionConfig, peerAsn) = { state with PeerAsn = peerAsn }
+
+    interface IDependable<RSBGPConnectionConfig> with
+        /// Adds an explicit dependency to this Container App Environment.
+        member _.Add state newDeps =
+            { state with
+                Dependencies = state.Dependencies + newDeps
+            }
 
 let routeServerBGPConnection = RSBGPConnectionBuilder()
 
@@ -111,6 +125,7 @@ type RouteServerConfig =
                                     ResourceName $"{this.Name.Value}-ipconfig"
                                 )
                             )
+                        Dependencies = connection.Dependencies
                     }
             ]
 


### PR DESCRIPTION
The changes in this PR are as follows:

* Route Servers: Support 'depends_on' for routeServerBGPConnection

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
routeServer {
    name "my-route-server"
    link_to_vnet "my-vnet"
    add_bgp_connections [
        routeServerBGPConnection {
            name "elf01"
            peer_ip "100.72.3.4"
            peer_asn 12345
        }
        routeServerBGPConnection {
            name "elf02"
            peer_ip "100.72.3.5"
            peer_asn 12345
            depends_on (ResourceId.create(Farmer.Arm.Network.routeServerBGPConnections, ResourceName "my-route-server", ResourceName "elf01"))
        }
    ]

```
