### PR TITLE
AzureWebJobsDashboard only added for V1 function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.27
+* Functions: AzureWebJobsDashboard setting is only added for a V1 Function app
+
 ## 1.7.26
 * Container Apps: Add support for Dapr components
 * Route Servers: Support 'depends_on' for routeServerBGPConnection.

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -212,12 +212,14 @@ type FunctionsConfig =
                         "FUNCTIONS_EXTENSION_VERSION", this.ExtensionVersion.ArmValue
                         "AzureWebJobsStorage",
                         StorageAccount.getConnectionString this.StorageAccountId |> ArmExpression.Eval
-                        "AzureWebJobsDashboard",
-                        StorageAccount.getConnectionString this.StorageAccountId |> ArmExpression.Eval
-
+                        
                         yield!
                             this.AppInsightsKey
                             |> Option.mapList (fun key -> "APPINSIGHTS_INSTRUMENTATIONKEY", key |> ArmExpression.Eval)
+                            
+                        if this.ExtensionVersion = V1 then
+                            "AzureWebJobsDashboard",
+                            StorageAccount.getConnectionString this.StorageAccountId |> ArmExpression.Eval
 
                         if this.CommonWebConfig.OperatingSystem = Windows then
                             "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -212,11 +212,11 @@ type FunctionsConfig =
                         "FUNCTIONS_EXTENSION_VERSION", this.ExtensionVersion.ArmValue
                         "AzureWebJobsStorage",
                         StorageAccount.getConnectionString this.StorageAccountId |> ArmExpression.Eval
-                        
+
                         yield!
                             this.AppInsightsKey
                             |> Option.mapList (fun key -> "APPINSIGHTS_INSTRUMENTATIONKEY", key |> ArmExpression.Eval)
-                            
+
                         if this.ExtensionVersion = V1 then
                             "AzureWebJobsDashboard",
                             StorageAccount.getConnectionString this.StorageAccountId |> ArmExpression.Eval

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -425,10 +425,10 @@ let tests =
 
                 Expect.allEqual expectation true "Slot should have all literal settings"
             }
-            
+
             test "Functions App generates AzureWebJobsDashboard setting on version 1" {
                 let slot = appSlot { name "warm-up" }
-            
+
                 let site =
                     functions {
                         name "func"
@@ -436,21 +436,17 @@ let tests =
                         operating_system Windows
                         use_extension_version V1
                     }
-            
+
                 let slots =
                     site
                     |> getResources
                     |> getResource<Arm.Web.Site>
                     |> List.filter (fun s -> s.ResourceType = Arm.Web.slots)
-            
+
                 let settings = (slots.Item 0).AppSettings |> Option.defaultValue Map.empty
-            
-                let expectation =
-                    [
-                        "AzureWebJobsDashboard"
-                    ]
-                    |> List.map settings.ContainsKey
-            
+
+                let expectation = [ "AzureWebJobsDashboard" ] |> List.map settings.ContainsKey
+
                 Expect.allEqual expectation true "Version 1 function should have AzureWebJobsDashboard setting"
             }
 

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -449,11 +449,8 @@ let tests =
 
                 Expect.allEqual expectation true "Version 1 function should have AzureWebJobsDashboard setting"
             }
-            let cases = [
-                V2
-                V3
-                V4
-            ]
+            let cases = [ V2; V3; V4 ]
+
             for version in cases do
                 test $"Functions App AzureWebJobsDashboard setting is not set on version {version.ArmValue}" {
                     let slot = appSlot { name "warm-up" }
@@ -476,7 +473,9 @@ let tests =
 
                     let expectation = settings.ContainsKey "AzureWebJobsDashboard"
 
-                    Expect.isFalse expectation $"Version {version.ArmValue} function should not have AzureWebJobsDashboard setting"
+                    Expect.isFalse
+                        expectation
+                        $"Version {version.ArmValue} function should not have AzureWebJobsDashboard setting"
                 }
 
             test "Functions App with different settings on slot and service adds both settings to slot" {
@@ -739,6 +738,7 @@ let tests =
                     [ expectedRestriction ]
                     "Should add expected ip security restriction"
             }
+
             test "Supports adding ip restriction for denied ip" {
                 let ip = IPAddressCidr.parse "1.2.3.4/32"
 
@@ -758,6 +758,7 @@ let tests =
                     [ expectedRestriction ]
                     "Should add denied ip security restriction"
             }
+
             test "Supports adding different ip restrictions to site and slot" {
                 let siteIp = IPAddressCidr.parse "1.2.3.4/32"
                 let slotIp = IPAddressCidr.parse "4.3.2.1/32"
@@ -797,6 +798,7 @@ let tests =
                     [ expectedSiteRestriction ]
                     "Site should have correct allowed ip security restriction"
             }
+
             test "Can integrate unmanaged vnet" {
                 let subnetId =
                     Arm.Network.subnets.resourceId (ResourceName "my-vnet", ResourceName "my-subnet")
@@ -818,6 +820,7 @@ let tests =
                 let vnetConnections = resources |> getResource<Web.VirtualNetworkConnection>
                 Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
             }
+
             test "Can integrate managed vnet" {
                 let vnetConfig = vnet { name "my-vnet" }
                 let asp = serverFarms.resourceId "my-asp"

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -130,7 +130,10 @@ let tests =
                         add_extension WebApp.Extensions.Logging
                     }
 
-                let fns = functions { name ("farmerfuncs" + number) }
+                let fns = functions {
+                    name ("farmerfuncs" + number)
+                    use_extension_version V1
+                }
 
                 let svcBus =
                     serviceBus {

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -130,10 +130,11 @@ let tests =
                         add_extension WebApp.Extensions.Logging
                     }
 
-                let fns = functions {
-                    name ("farmerfuncs" + number)
-                    use_extension_version V1
-                }
+                let fns =
+                    functions {
+                        name ("farmerfuncs" + number)
+                        use_extension_version V1
+                    }
 
                 let svcBus =
                     serviceBus {

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -283,7 +283,7 @@
             },
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",
-              "value": "~4"
+              "value": "~1"
             },
             {
               "name": "FUNCTIONS_WORKER_RUNTIME",
@@ -808,10 +808,6 @@
           "alwaysOn": false,
           "appCommandLine": "do it",
           "appSettings": [
-            {
-              "name": "AzureWebJobsDashboard",
-              "value": "[concat('DefaultEndpointsProtocol=https;AccountName=dockerfuncstorage;AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', 'dockerfuncstorage'), '2017-10-01').keys[0].value, ';EndpointSuffix=', environment().suffixes.storage)]"
-            },
             {
               "name": "AzureWebJobsStorage",
               "value": "[concat('DefaultEndpointsProtocol=https;AccountName=dockerfuncstorage;AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', 'dockerfuncstorage'), '2017-10-01').keys[0].value, ';EndpointSuffix=', environment().suffixes.storage)]"


### PR DESCRIPTION
This PR closes #1057 

The changes in this PR are as follows:

* Only add the AzureWebJobsDashboard setting to a V1 function app

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
