### PR TITLE
Refactor ARM template expression to use a simpler template function t…

### DIFF
--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1947,7 +1947,7 @@ type RoleId =
     member this.ArmValue =
         match this with
         | RoleId roleId ->
-            $"concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '{roleId.Id}')"
+            $"subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '{roleId.Id}')"
             |> ArmExpression.create
 
     member this.Name =

--- a/src/Tests/test-data/aks-with-acr.json
+++ b/src/Tests/test-data/aks-with-acr.json
@@ -85,7 +85,7 @@
       "properties": {
         "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'clusterIdentity')).principalId]",
         "principalType": "ServicePrincipal",
-        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]"
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830')]"
       },
       "type": "Microsoft.Authorization/roleAssignments"
     },
@@ -99,7 +99,7 @@
       "properties": {
         "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'kubeletIdentity')).principalId]",
         "principalType": "ServicePrincipal",
-        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]"
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]"
       },
       "scope": "[resourceId('Microsoft.ContainerRegistry/registries', 'farmercontainerregistry1234')]",
       "type": "Microsoft.Authorization/roleAssignments"


### PR DESCRIPTION
…o achieve the same effect. Updated the sample JSON it is tested against as well.

This PR closes #

The changes in this PR are as follows:

* Uses subscriptionResourceId() instead of subscription(), as a result doesn't need concat() and ends up being simpler
* Updates accordingly the sample file this functionality is tested against

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
