### PR TITLE
Implementing Virtual Kubelet Extensions Support in Container Group

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.7.28
+* Container Groups: Add support for extensions used by virtual kubelet
 
 ## 1.7.27
 * Action Groups: Adds support for action groups to perform actions when alerts fire.

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -43,7 +43,7 @@ The Container Group builder (`containerGroup`) defines a Container Group.
 | dns_options | Specify DNS options (e.g. 'ndots:2') for the containers in a vnet-attached container group. |
 | dns_search_domains | Specify DNS search domains for the containers in a vnet-attached container group. |
 | depends_on | Specifies the resource or resource ID of resources that must exist before the container group is created. |
-| extensions | Sets the extensions used by virtual kubelet. |
+| add_extensions | Sets the extensions used by virtual kubelet. |
 
 #### Container Instance Builder
 The Container Instance builder (`containerInstance`) is used to define one or more containers to add to the group.

--- a/docs/content/api-overview/resources/container-group.md
+++ b/docs/content/api-overview/resources/container-group.md
@@ -43,6 +43,7 @@ The Container Group builder (`containerGroup`) defines a Container Group.
 | dns_options | Specify DNS options (e.g. 'ndots:2') for the containers in a vnet-attached container group. |
 | dns_search_domains | Specify DNS search domains for the containers in a vnet-attached container group. |
 | depends_on | Specifies the resource or resource ID of resources that must exist before the container group is created. |
+| extensions | Sets the extensions used by virtual kubelet. |
 
 #### Container Instance Builder
 The Container Instance builder (`containerInstance`) is used to define one or more containers to add to the group.

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -134,6 +134,42 @@ type ContainerGroupDnsConfiguration =
             |}
             :> obj
 
+type DeploymentExtensionSpecProperties =
+    {
+        ExtensionType: string
+        Version: string
+        Settings: Map<string, obj> option
+        ProtectedSettings: Map<string, obj> option
+    }
+
+    static member internal JsonModel(spec: DeploymentExtensionSpecProperties) =
+        {|
+            extensionType = spec.ExtensionType
+            version = spec.Version
+            settings =
+                match spec.Settings with
+                | None -> Map.empty
+                | Some settings -> settings
+            protectedSettings =
+                match spec.ProtectedSettings with
+                | None -> Map.empty
+                | Some protectedSettings -> protectedSettings
+        |}
+        :> obj
+
+type DeploymentExtensionSpec =
+    {
+        Name: string
+        Properties: DeploymentExtensionSpecProperties
+    }
+
+    static member internal JsonModel(spec: DeploymentExtensionSpec) =
+        {|
+            name = spec.Name
+            properties = DeploymentExtensionSpecProperties.JsonModel spec.Properties
+        |}
+        :> obj
+
 type ContainerGroup =
     {
         Name: ResourceName
@@ -167,6 +203,7 @@ type ContainerGroup =
         Volumes: Map<string, Volume>
         Tags: Map<string, string>
         Dependencies: Set<ResourceId>
+        Extensions: DeploymentExtensionSpec list
     }
 
     member this.NetworkProfilePath =
@@ -496,4 +533,7 @@ type ContainerGroup =
                             ]
                     |}
                 zones = this.AvailabilityZone |> Option.map Array.singleton |> Option.defaultValue null
+                extensions =
+                    this.Extensions
+                    |> List.map (fun extension -> DeploymentExtensionSpec.JsonModel extension)
             |}

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -533,7 +533,5 @@ type ContainerGroup =
                             ]
                     |}
                 zones = this.AvailabilityZone |> Option.map Array.singleton |> Option.defaultValue null
-                extensions =
-                    this.Extensions
-                    |> List.map (fun extension -> DeploymentExtensionSpec.JsonModel extension)
+                extensions = this.Extensions |> List.map DeploymentExtensionSpec.JsonModel
             |}

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -346,8 +346,11 @@ type ContainerGroupBuilder() =
     member this.Name(state: ContainerGroupConfig, name) = this.Name(state, ResourceName name)
 
     /// Sets the extensions used by virtual kubelet on the container group.
-    [<CustomOperation "extensions">]
-    member _.Extensions(state: ContainerGroupConfig, extensions) = { state with Extensions = extensions }
+    [<CustomOperation "add_extensions">]
+    member _.AddExtensions(state: ContainerGroupConfig, extensions) =
+        { state with
+            Extensions = state.Extensions @ extensions
+        }
 
     /// Sets the OS type (default Linux)
     [<CustomOperation "operating_system">]

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -119,6 +119,8 @@ type ContainerGroupConfig =
         Tags: Map<string, string>
         /// Additional dependencies.
         Dependencies: Set<ResourceId>
+        /// extensions used by virtual kubelet
+        Extensions: DeploymentExtensionSpec list
     }
 
     member private this.ResourceId = containerGroups.resourceId this.Name
@@ -218,6 +220,7 @@ type ContainerGroupConfig =
                     Volumes = this.Volumes
                     Tags = this.Tags
                     Dependencies = this.Dependencies
+                    Extensions = this.Extensions
                 }
             ]
 
@@ -320,6 +323,7 @@ type ContainerGroupBuilder() =
             AvailabilityZone = None
             Tags = Map.empty
             Dependencies = Set.empty
+            Extensions = []
         }
 
     member this.Run(state: ContainerGroupConfig) =
@@ -340,6 +344,10 @@ type ContainerGroupBuilder() =
     member _.Name(state: ContainerGroupConfig, name) = { state with Name = name }
 
     member this.Name(state: ContainerGroupConfig, name) = this.Name(state, ResourceName name)
+
+    /// Sets the extensions used by virtual kubelet on the container group.
+    [<CustomOperation "extensions">]
+    member _.Extensions(state: ContainerGroupConfig, extensions) = { state with Extensions = extensions }
 
     /// Sets the OS type (default Linux)
     [<CustomOperation "operating_system">]

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -427,6 +427,7 @@
     {
       "apiVersion": "2021-10-01",
       "dependsOn": [],
+      "extensions": [],
       "identity": {
         "type": "None"
       },


### PR DESCRIPTION
This PR closes #1063

The changes in this PR are as follows:

* Implementing Virtual Kubelet Extensions Support in Container Group

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
