### PR TITLE
Fix a bug where extensions object is added outside the properties block of the container group

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 Release Notes
 =============
+## 1.7.29
+* Bug fix - Add Container Group extensions object under properties block of Container Group
+
 ## 1.7.28
 * Container Groups: Add support for extensions used by virtual kubelet
 

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -473,6 +473,7 @@ type ContainerGroup =
                                 this.SubnetIds
                                 |> List.map (fun subnetId -> {| id = subnetId.ResourceId.Eval() |})
                                 |> box
+                        extensions = this.Extensions |> List.map DeploymentExtensionSpec.JsonModel
                         volumes =
                             [
                                 for key, value in Map.toSeq this.Volumes do
@@ -533,5 +534,4 @@ type ContainerGroup =
                             ]
                     |}
                 zones = this.AvailabilityZone |> Option.map Array.singleton |> Option.defaultValue null
-                extensions = this.Extensions |> List.map DeploymentExtensionSpec.JsonModel
             |}

--- a/src/Tests/ContainerGroup.fs
+++ b/src/Tests/ContainerGroup.fs
@@ -1467,6 +1467,7 @@ async {
                                     image "nginx:1.17.6-alpine"
                                 }
                             ]
+
                     }
 
                 let deployment =
@@ -1479,12 +1480,13 @@ async {
                     }
 
                 let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
-                let template = deployment.Template |> Writer.toJson
 
                 let containerGroupJToken =
                     jobj.SelectToken("resources[?(@.name=='container-group-with-extensions')]")
 
-                let extensionsJToken = containerGroupJToken.SelectToken "extensions"
+                let propertiesJToken = containerGroupJToken.SelectToken "properties"
+
+                let extensionsJToken = propertiesJToken.SelectToken "extensions"
 
                 Expect.equal
                     (extensionsJToken.First.SelectToken "name" |> string)
@@ -1585,22 +1587,16 @@ async {
                             ]
                     }
 
-                let deployment =
-                    arm {
-                        add_resources
-                            [
-                                containerGroup
-
-                            ]
-                    }
+                let deployment = arm { add_resources [ containerGroup ] }
 
                 let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
-                let template = deployment.Template |> Writer.toJson
 
                 let containerGroupJToken =
                     jobj.SelectToken("resources[?(@.name=='container-group-with-extensions')]")
 
-                let extensionsJToken = containerGroupJToken.SelectToken "extensions"
+                let propertiesJToken = containerGroupJToken.SelectToken "properties"
+
+                let extensionsJToken = propertiesJToken.SelectToken "extensions"
 
                 Expect.equal
                     (extensionsJToken.First.SelectToken "name" |> string)

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -427,7 +427,6 @@
     {
       "apiVersion": "2021-10-01",
       "dependsOn": [],
-      "extensions": [],
       "identity": {
         "type": "None"
       },
@@ -461,6 +460,7 @@
             }
           }
         ],
+        "extensions": [],
         "imageRegistryCredentials": [],
         "initContainers": [],
         "ipAddress": {


### PR DESCRIPTION
Fix a bug where extensions block is added outside the properties block of the container group
This PR closes #1065

The changes in this PR are as follows:

* Add extensions object in side properties block of a container group

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
