### PR TITLE
Docker Images: Support parsing of tags with one or more colons in tag…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 Release Notes
 =============
+
+## 1.7.30
+* Docker Images: Support parsing of tags with one or more colons in tag name.
+
 ## 1.7.29
 * Bug fix - Add Container Group extensions object under properties block of Container Group
 

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -2049,18 +2049,22 @@ module Containers =
 
         /// Parses an image tag into a DockerImage record.
         static member Parse(tag: string) =
-            match tag.Split([| ':' |], StringSplitOptions.RemoveEmptyEntries) with
-            | [| repo; version |] ->
+            let firstColon = tag.IndexOf ':'
+
+            if firstColon >= 0 && firstColon < tag.Length then
+                let repo, version = tag.Substring(0, firstColon), tag.Substring(firstColon + 1)
+
                 match repo.Split([| '/' |], StringSplitOptions.RemoveEmptyEntries) |> List.ofArray with
                 | first :: rest when (first.Contains ".") ->
                     DockerImage.PrivateImage(first, (rest |> String.concat "/"), Version = Some version)
                 | _ -> DockerImage.PublicImage(repo, Version = Some version)
-            | [| repo |] ->
+            else
+                let repo = tag
+
                 match repo.Split([| '/' |], StringSplitOptions.RemoveEmptyEntries) |> List.ofArray with
                 | first :: rest when (first.Contains ".") ->
                     DockerImage.PrivateImage(first, (rest |> String.concat "/"), None)
                 | _ -> DockerImage.PublicImage(repo, None)
-            | _ -> raiseFarmer $"Malformed docker image tag - incorrect number of version segments: '{tag}'"
 
 /// Credential for accessing an image registry.
 type ImageRegistryCredential =

--- a/src/Tests/Common.fs
+++ b/src/Tests/Common.fs
@@ -159,5 +159,12 @@ let tests =
                     privateRepoNamedContainerVersion.ImageTag
                     "my.azurecr.io/foo/bar:1.2.3"
                     "Private named and versioned container image generated with incorrect tag"
+
+                Expect.equal
+                    (Containers.DockerImage.Parse
+                        "myimages.azurecr.io/image:specialtag@sha256:4f6fd68183af663e87551adccbab7322b7ba3cb6f93e1c9a87e7580a508a99c1")
+                        .ImageTag
+                    "myimages.azurecr.io/image:specialtag@sha256:4f6fd68183af663e87551adccbab7322b7ba3cb6f93e1c9a87e7580a508a99c1"
+                    "Tag with multiple colons parses correctly"
             }
         ]


### PR DESCRIPTION
… name.

This PR closes #1068 

The changes in this PR are as follows:

* Docker Images: Support parsing of tags with one or more colons in tag name.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Bug was in parsing logic, not in deployment, so nothing to test end to end.
