### PR TITLE
Subnet: Support `depends_on`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.7.31
+* Subnets: Support for `depends_on` when defining standalone subnets.
+
 ## 1.7.30
 * Docker Images: Support parsing of tags with one or more colons in tag name.
 * Private DNS Zones: Support linking a Private DNS Zone to a Virtual Network to provide DNS resolution within the vnet.

--- a/docs/content/api-overview/resources/vnet.md
+++ b/docs/content/api-overview/resources/vnet.md
@@ -51,6 +51,7 @@ The Virtual Network module contains four builders
 | associate_service_endpoint_policies   | Associates a subnet with an existing service policy.                                      |
 | allow_private_endpoints               | Enable or disable support for private endpoints, default is `Disabled`                    |
 | private_link_service_network_policies | Enable or disable support for private link service network polices, default is `Disabled` |
+| depends_on                            | Add depdendencies on the deployment of another resource.                                  |
 
 ##### Automatically build out an address space: `addressSpace`
 

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -341,6 +341,7 @@ type Subnet =
         AssociatedServiceEndpointPolicies: ResourceId list
         PrivateEndpointNetworkPolicies: FeatureFlag option
         PrivateLinkServiceNetworkPolicies: FeatureFlag option
+        Dependencies: ResourceId Set
     }
 
     member internal this.JsonModelProperties =
@@ -397,11 +398,11 @@ type Subnet =
         member this.JsonModel =
             match this.VirtualNetwork with
             | Some (Managed vnet) ->
-                {| subnets.Create(vnet.Name / this.Name, dependsOn = [ vnet ]) with
+                {| subnets.Create(vnet.Name / this.Name, dependsOn = (this.Dependencies |> Set.add vnet)) with
                     properties = this.JsonModelProperties
                 |}
             | Some (Unmanaged vnet) ->
-                {| subnets.Create(vnet.Name / this.Name) with
+                {| subnets.Create(vnet.Name / this.Name, dependsOn = this.Dependencies) with
                     properties = this.JsonModelProperties
                 |}
             | None -> raiseFarmer "Subnet record must be linked to a virtual network to properly assign the resourceId."

--- a/src/Farmer/Builders/Builders.NetworkInterface.fs
+++ b/src/Farmer/Builders/Builders.NetworkInterface.fs
@@ -75,6 +75,7 @@ type NetworkInterfaceConfig =
                             AssociatedServiceEndpointPolicies = []
                             PrivateEndpointNetworkPolicies = None
                             PrivateLinkServiceNetworkPolicies = None
+                            Dependencies = Set.empty
                         }
 
                         //ipConfig

--- a/src/Farmer/Builders/Builders.RouteServer.fs
+++ b/src/Farmer/Builders/Builders.RouteServer.fs
@@ -85,6 +85,7 @@ type RouteServerConfig =
                     AssociatedServiceEndpointPolicies = []
                     PrivateEndpointNetworkPolicies = None
                     PrivateLinkServiceNetworkPolicies = None
+                    Dependencies = Set.empty
                 }
 
                 //ip configuration

--- a/src/Farmer/Builders/Builders.VirtualNetwork.fs
+++ b/src/Farmer/Builders/Builders.VirtualNetwork.fs
@@ -23,6 +23,7 @@ type SubnetConfig =
         AssociatedServiceEndpointPolicies: ResourceId list
         AllowPrivateEndpoints: FeatureFlag option
         PrivateLinkServiceNetworkPolicies: FeatureFlag option
+        Dependencies: ResourceId Set
     }
 
     member internal this.AsSubnetResource =
@@ -45,6 +46,7 @@ type SubnetConfig =
             // to ENable private endpoints we have to DISable PrivateEndpointNetworkPolicies
             PrivateEndpointNetworkPolicies = this.AllowPrivateEndpoints |> Option.map FeatureFlag.invert
             PrivateLinkServiceNetworkPolicies = this.PrivateLinkServiceNetworkPolicies
+            Dependencies = this.Dependencies
         }
 
     interface IBuilder with
@@ -72,6 +74,7 @@ type SubnetBuilder() =
             AssociatedServiceEndpointPolicies = []
             AllowPrivateEndpoints = None
             PrivateLinkServiceNetworkPolicies = None
+            Dependencies = Set.empty
         }
 
     /// Sets the name of the subnet
@@ -219,6 +222,12 @@ type SubnetBuilder() =
         { state with
             PrivateLinkServiceNetworkPolicies = Some flag
         }
+
+    interface IDependable<SubnetConfig> with
+        member _.Add state newDeps =
+            { state with
+                Dependencies = state.Dependencies + newDeps
+            }
 
 let subnet = SubnetBuilder()
 
@@ -665,6 +674,7 @@ type VirtualNetworkBuilder() =
                             AssociatedServiceEndpointPolicies = serviceEndpointPolicies
                             AllowPrivateEndpoints = allowPrivateEndpoints
                             PrivateLinkServiceNetworkPolicies = privateLinkServiceNetworkPolicies
+                            Dependencies = Set.empty
                         }))
 
         let newAddressSpaces =

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -207,6 +207,7 @@ type VmConfig =
                                     AssociatedServiceEndpointPolicies = []
                                     PrivateEndpointNetworkPolicies = None
                                     PrivateLinkServiceNetworkPolicies = None
+                                    Dependencies = Set.empty
                                 }
                             ]
                         Tags = this.Tags


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Subnets: Support for `depends_on` when defining standalone subnets.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
arm {
    add_resources
        [
            subnet {
                name "subnet1"
                link_to_unmanaged_vnet (virtualNetworks.resourceId vnetName)
                prefix "10.28.0.0/24"
            }
            // `subnet2` will not be deployed until the `subnet1` resource is deployed.
            subnet {
                name "subnet2"
                link_to_unmanaged_vnet (virtualNetworks.resourceId vnetName)
                prefix "10.28.1.0/24"
                depends_on (subnets.resourceId (ResourceName vnetName / ResourceName "subnet1"))
            }
        ]
}
```
