### PR TITLE
Add support to Functions builder for DotNet80Isolated

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.8.3
+* Functions: Dotnet 8: Added missing DotNet80Isolated option to fully support functions
+
 ## 1.8.2
 * Virtual Machines: Adds Ubuntu 20.04 ARM 64, 22.04 ARM 64, 23.04, 23.04 ARM 64, 23.10, 23.10 ARM 64
 * Virtual Machines: Adds ARM 64 VM sizes.

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -32,6 +32,7 @@ type FunctionsRuntime with
     static member DotNet60 = DotNet, Some "6.0"
     static member DotNet60Isolated = DotNetIsolated, Some "6.0"
     static member DotNet70Isolated = DotNetIsolated, Some "7.0"
+    static member DotNet80Isolated = DotNetIsolated, Some "8.0"
     static member Node14 = Node, Some "14-lts"
     static member Node12 = Node, Some "12-lts"
     static member Node10 = Node, Some "10-lts"

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -851,6 +851,7 @@ let tests =
                     (FunctionsRuntime.DotNet60Isolated, "v6.0")
                     (FunctionsRuntime.DotNet60, "v6.0")
                     (FunctionsRuntime.DotNet70Isolated, "v7.0")
+                    (FunctionsRuntime.DotNet80Isolated, "v8.0")
                 ]
 
             for runtime, expectedVersion in data do


### PR DESCRIPTION
This is just a tiny addition to the pull request by @martinbryant  (https://github.com/CompositionalIT/farmer/pull/1081)

That one was missing the `FunctionsRuntime.DotNet80Isolated` option.

* Added missing `DotNet80Isolated` support to Functions builder


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.
