### PR TITLE
Route Server: int64 support for 'peerAsn' on BGP connection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.8.5
+* Route Server: int64 support for `peerAsn` on BGP connection.
+
 ## 1.8.4
 * Autoscale Settings: Adds support for defining autoscale settings for VM scale sets.
 

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -232,7 +232,7 @@ type RouteServerBGPConnection =
         Name: ResourceName
         RouteServer: LinkedResource
         PeerIp: string
-        PeerAsn: int
+        PeerAsn: int64
         IpConfig: LinkedResource
         Dependencies: Set<ResourceId>
     }

--- a/src/Farmer/Builders/Builders.RouteServer.fs
+++ b/src/Farmer/Builders/Builders.RouteServer.fs
@@ -10,7 +10,7 @@ type RSBGPConnectionConfig =
     {
         Name: string
         PeerIp: string
-        PeerAsn: int
+        PeerAsn: int64
         Dependencies: Set<ResourceId>
     }
 
@@ -30,7 +30,10 @@ type RSBGPConnectionBuilder() =
     member _.PeerIp(state: RSBGPConnectionConfig, peerIp) = { state with PeerIp = peerIp }
 
     [<CustomOperation "peer_asn">]
-    member _.PeerAsn(state: RSBGPConnectionConfig, peerAsn) = { state with PeerAsn = peerAsn }
+    member _.PeerAsn(state: RSBGPConnectionConfig, peerAsn: int64) = { state with PeerAsn = peerAsn }
+
+    member this.PeerAsn(state: RSBGPConnectionConfig, peerAsn: int) =
+        this.PeerAsn(state, System.Convert.ToInt64(peerAsn))
 
     interface IDependable<RSBGPConnectionConfig> with
         /// Adds an explicit dependency to this Container App Environment.

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -891,7 +891,7 @@ let tests =
                                             routeServerBGPConnection {
                                                 name "my-bgp-conn-2"
                                                 peer_ip "10.0.1.86"
-                                                peer_asn 65000
+                                                peer_asn 4510002310L
 
                                                 depends_on (
                                                     ResourceId.create (
@@ -1066,6 +1066,11 @@ let tests =
                     jobj.SelectToken "resources[?(@.name=='my-route-server/my-bgp-conn-2')]"
 
                 Expect.isNotNull bgpConnWithDep "bgp connection with dependency should be generated"
+
+                Expect.equal
+                    (bgpConnWithDep.SelectToken("properties.peerAsn"))
+                    (JValue(4510002310L))
+                    "peer_asn long value incorrect did not match"
 
                 let bgpConnWithDepName = bgpConnWithDep.["name"]
 


### PR DESCRIPTION
The changes in this PR are as follows:

* Route Server: int64 for `peerAsn` on BGP connection.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
routeServerBGPConnection {
    name "my-bgp-conn"
    peer_ip "10.0.1.85"
    peer_asn 4510002310L
}
```
