### PR TITLE
Support custom name for route server public IP

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.8.6
+* Route Server: Custom name support for Route Server Public IP.
+
 ## 1.8.5
 * Route Server: int64 support for `peerAsn` on BGP connection.
 

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -892,7 +892,7 @@ let tests =
                                             routeServerBGPConnection {
                                                 name "my-bgp-conn-2"
                                                 peer_ip "10.0.1.86"
-                                                peer_asn 4510002310L
+                                                peer_asn 4110002310L
 
                                                 depends_on (
                                                     ResourceId.create (

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -1070,7 +1070,7 @@ let tests =
 
                 Expect.equal
                     (bgpConnWithDep.SelectToken("properties.peerAsn"))
-                    (JValue(4510002310L))
+                    (JValue(4110002310L))
                     "peer_asn long value incorrect did not match"
 
                 let bgpConnWithDepName = bgpConnWithDep.["name"]

--- a/src/Tests/Network.fs
+++ b/src/Tests/Network.fs
@@ -880,6 +880,7 @@ let tests =
                                     sku RouteServer.Sku.Standard
                                     subnet_prefix "10.0.12.0/24"
                                     link_to_vnet (virtualNetworks.resourceId "test-vnet")
+                                    public_ip_name "my-route-server-public-ip-name"
 
                                     add_bgp_connections
                                         [
@@ -925,7 +926,7 @@ let tests =
 
                 Expect.equal
                     publicipName
-                    (JToken.op_Implicit "my-route-server-publicip")
+                    (JToken.op_Implicit "my-route-server-public-ip-name")
                     "Incorrect default value for public ip name"
 
                 let publicipProps = publicip.["properties"]
@@ -974,7 +975,7 @@ let tests =
 
                 Expect.equal
                     (ipConfigDependencies.[0].ToString())
-                    "[resourceId(\u0027Microsoft.Network/publicIPAddresses\u0027, \u0027my-route-server-publicip\u0027)]"
+                    "[resourceId(\u0027Microsoft.Network/publicIPAddresses\u0027, \u0027my-route-server-public-ip-name\u0027)]"
                     "Incorrect ipConfig dependencies"
 
                 Expect.equal
@@ -991,7 +992,7 @@ let tests =
 
                 Expect.equal
                     ipConfigPip
-                    "[resourceId(\u0027Microsoft.Network/publicIPAddresses\u0027, \u0027my-route-server-publicip\u0027)]"
+                    "[resourceId(\u0027Microsoft.Network/publicIPAddresses\u0027, \u0027my-route-server-public-ip-name\u0027)]"
                     "Incorrect publicIPAddress id for ipConfig"
 
                 let ipConfigSubnet = ipConfig.SelectToken("properties.subnet.id").ToString()


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Route Server: Custom name support for Route Server Public IP.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
routeServer {
    name "my-route-server"
    public_ip_name "my-route-server-public-ip-name"
}
```
