### PR TITLE
Create b2c tenant

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.8.7
+* B2C Tenants: Support for creating B2C Tenants.
+
 ## 1.8.6
 * Route Server: Custom name support for Route Server Public IP.
 

--- a/docs/content/api-overview/resources/b2c-tenant.md
+++ b/docs/content/api-overview/resources/b2c-tenant.md
@@ -1,0 +1,59 @@
+---
+title: "B2C Tenant"
+date: 2024-02-01T00:00:00+01:00
+chapter: false
+weight: 1
+---
+
+#### Overview
+Creates a new B2C tenant, please note that the current implementation only supports the creation of a new B2C tenant.
+
+Usage of this computation expression when a B2C tenant already exists will result in an error, check the [example](#example) for more infos.
+
+#### B2C Tenant Builder Keywords
+| Applies To | Keyword             | Purpose                                                                                                                                                                                  |
+|-|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| B2C Tenant | initial_domain_name | Initial domain name for the B2C tenant as in `initial_domain_name.onmicrosoft.com`                                                                                                       |
+| B2C Tenant | display_name        | Display name for the B2C tenant.                                                                                                                                                         |
+| B2C Tenant | sku                 | [SKU](https://learn.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/list-by-subscription?view=rest-activedirectory-2021-04-01&tabs=HTTP#b2cresourceskuname) for the B2C tenant. |
+| B2C Tenant | country_code        | Country code defined by two capital letter, for examples check the official [docs](https://learn.microsoft.com/en-us/azure/active-directory-b2c/data-residency]                          |
+| B2C Tenant | data_residency      | Data residency for the B2C tenant, for more infos check the official [docs](https://learn.microsoft.com/en-us/azure/active-directory-b2c/data-residency]                                 |
+| B2C Tenant | tags                | Tags for the B2C tenant.                                                                                                                                                                 |
+
+#### Example
+
+Basic creation of a B2C tenant, while avoiding having an error when such tenant already exists.
+
+```fsharp
+open Farmer
+open Farmer.Builders
+open Farmer.Deploy
+
+let initialDomainName = "myb2c"
+
+let myb2c =
+    b2cTenant {
+        initial_domain_name initialDomainName
+        display_name "My B2C"
+        sku B2cTenant.Sku.PremiumP1
+        country_code "FR"
+        data_residency B2cDataResidency.Europe
+    }
+    
+let b2cDoesNotExist (initialDomainName: string) =
+    let output =
+        Az.AzHelpers.executeAz $"resource list --name '{initialDomainName}.onmicrosoft.com'"
+        |> snd
+    not (output.Contains initialDomainName)
+    
+let deployment =
+    arm {
+        location Location.FranceCentral
+        add_resources
+            [
+                // This allows to avoid having an error when the B2C tenant already exists
+                if b2cDoesNotExist initialDomainName then
+                    myb2c
+            ]
+    }
+````

--- a/docs/content/api-overview/resources/b2c-tenant.md
+++ b/docs/content/api-overview/resources/b2c-tenant.md
@@ -26,6 +26,7 @@ Basic creation of a B2C tenant, while avoiding having an error when such tenant 
 
 ```fsharp
 open Farmer
+open Farmer.B2cTenant
 open Farmer.Builders
 open Farmer.Deploy
 
@@ -35,7 +36,7 @@ let myb2c =
     b2cTenant {
         initial_domain_name initialDomainName
         display_name "My B2C"
-        sku B2cTenant.Sku.PremiumP1
+        sku Sku.PremiumP1
         country_code "FR"
         data_residency B2cDataResidency.Europe
     }

--- a/src/Farmer/Arm/B2cTenant.fs
+++ b/src/Farmer/Arm/B2cTenant.fs
@@ -1,0 +1,46 @@
+[<AutoOpen>]
+module Farmer.Arm.B2cTenant
+
+open Farmer
+
+let b2cTenant =
+    ResourceType("Microsoft.AzureActiveDirectory/b2cDirectories", "2021-04-01")
+
+type B2cDomainName =
+    | B2cDomainName of string
+
+    static member internal Empty = B2cDomainName ""
+
+    member this.AsResourceName =
+        match this with
+        | B2cDomainName name -> ResourceName name
+
+type B2cTenant =
+    {
+        Name: B2cDomainName
+        DisplayName: string
+        DataResidency: Location
+        CountryCode: string
+        Tags: Map<string, string>
+        Sku: B2cTenant.Sku
+    }
+
+    interface IArmResource with
+        member this.ResourceId = accounts.resourceId this.Name.AsResourceName
+
+        member this.JsonModel =
+            {| b2cTenant.Create(this.Name.AsResourceName, this.DataResidency, tags = this.Tags) with
+                sku =
+                    {|
+                        name = string this.Sku
+                        tier = "A0"
+                    |}
+                properties =
+                    {|
+                        createTenantProperties =
+                            {|
+                                countryCode = this.CountryCode
+                                displayName = this.DisplayName
+                            |}
+                    |}
+            |}

--- a/src/Farmer/Builders/Builders.B2cTenant.fs
+++ b/src/Farmer/Builders/Builders.B2cTenant.fs
@@ -1,0 +1,98 @@
+[<AutoOpen>]
+module Farmer.Builders.B2cTenant
+
+open Farmer
+open Farmer.Arm
+open Farmer.Validation
+
+type B2cDomainName with
+
+    static member FromInitialDomainName initialDomainName =
+        [ containsOnlyM [ lettersOrNumbers ] ]
+        |> validate "B2c initial domain name" initialDomainName
+        |> Result.map (fun x -> B2cDomainName $"{x}.onmicrosoft.com")
+
+/// Check official documentation for more details: https://learn.microsoft.com/en-us/azure/active-directory-b2c/data-residency#data-residency
+type B2cDataResidency =
+    | UnitedStates
+    | Europe
+    | AsiaPacific
+    | Japan
+    | Australia
+
+    member this.Location =
+        match this with
+        | UnitedStates -> Location "United States"
+        | Europe -> Location "Europe"
+        | AsiaPacific -> Location "Asia Pacific"
+        | Japan -> Location "Japan"
+        | Australia -> Location "Australia"
+
+type B2cTenantConfig =
+    {
+        Name: B2cDomainName
+        DisplayName: string
+        DataResidency: Location
+        CountryCode: string
+        Sku: B2cTenant.Sku
+        Tags: Map<string, string>
+    }
+
+    interface IBuilder with
+        member this.ResourceId = b2cTenant.resourceId this.Name.AsResourceName
+
+        member this.BuildResources _ =
+            [
+                {
+                    B2cTenant.Name = this.Name
+                    DisplayName = this.DisplayName
+                    DataResidency = this.DataResidency
+                    CountryCode = this.CountryCode
+                    Tags = this.Tags
+                    Sku = this.Sku
+                }
+            ]
+
+type B2cTenantBuilder() =
+    member _.Yield _ =
+        {
+            Name = B2cDomainName.Empty
+            DisplayName = ""
+            DataResidency = B2cDataResidency.Europe.Location
+            CountryCode = "FR"
+            Sku = B2cTenant.Sku.PremiumP1
+            Tags = Map.empty
+        }
+
+    [<CustomOperation("initial_domain_name")>]
+    member _.InitialDomainName(state: B2cTenantConfig, name: string) =
+        { state with
+            Name = B2cDomainName.FromInitialDomainName(name).OkValue
+        }
+
+    [<CustomOperation("display_name")>]
+    member _.DisplayName(state: B2cTenantConfig, displayName: string) =
+        { state with DisplayName = displayName }
+
+    [<CustomOperation("sku")>]
+    member _.Sku(state: B2cTenantConfig, sku: B2cTenant.Sku) = { state with Sku = sku }
+
+    /// Data residency location as described in: https://learn.microsoft.com/en-us/azure/active-directory-b2c/data-residency#data-residency
+    [<CustomOperation("data_residency")>]
+    member _.DataResidency(state: B2cTenantConfig, b2cDataResidency: B2cDataResidency) =
+        { state with
+            DataResidency = b2cDataResidency.Location
+        }
+
+    /// Country Code defined by two capital letters (example: FR), as described in: https://learn.microsoft.com/en-us/azure/active-directory-b2c/data-residency#data-residency
+    [<CustomOperation("country_code")>]
+    member _.CountryCode(state: B2cTenantConfig, countryCode: string) =
+        { state with CountryCode = countryCode }
+
+    interface ITaggable<B2cTenantConfig> with
+        member _.Add state tags =
+            { state with
+                Tags = state.Tags |> Map.merge tags
+            }
+
+let b2cTenant = B2cTenantBuilder()

--- a/src/Farmer/Builders/Builders.B2cTenant.fs
+++ b/src/Farmer/Builders/Builders.B2cTenant.fs
@@ -4,6 +4,7 @@ module Farmer.Builders.B2cTenant
 open Farmer
 open Farmer.Arm
 open Farmer.Validation
+open Farmer.B2cTenant
 
 type B2cDomainName with
 
@@ -12,29 +13,13 @@ type B2cDomainName with
         |> validate "B2c initial domain name" initialDomainName
         |> Result.map (fun x -> B2cDomainName $"{x}.onmicrosoft.com")
 
-/// Check official documentation for more details: https://learn.microsoft.com/en-us/azure/active-directory-b2c/data-residency#data-residency
-type B2cDataResidency =
-    | UnitedStates
-    | Europe
-    | AsiaPacific
-    | Japan
-    | Australia
-
-    member this.Location =
-        match this with
-        | UnitedStates -> Location "United States"
-        | Europe -> Location "Europe"
-        | AsiaPacific -> Location "Asia Pacific"
-        | Japan -> Location "Japan"
-        | Australia -> Location "Australia"
-
 type B2cTenantConfig =
     {
         Name: B2cDomainName
         DisplayName: string
         DataResidency: Location
         CountryCode: string
-        Sku: B2cTenant.Sku
+        Sku: Sku
         Tags: Map<string, string>
     }
 
@@ -60,7 +45,7 @@ type B2cTenantBuilder() =
             DisplayName = ""
             DataResidency = B2cDataResidency.Europe.Location
             CountryCode = "FR"
-            Sku = B2cTenant.Sku.PremiumP1
+            Sku = Sku.PremiumP1
             Tags = Map.empty
         }
 
@@ -75,7 +60,7 @@ type B2cTenantBuilder() =
         { state with DisplayName = displayName }
 
     [<CustomOperation("sku")>]
-    member _.Sku(state: B2cTenantConfig, sku: B2cTenant.Sku) = { state with Sku = sku }
+    member _.Sku(state: B2cTenantConfig, sku: Sku) = { state with Sku = sku }
 
     /// Data residency location as described in: https://learn.microsoft.com/en-us/azure/active-directory-b2c/data-residency#data-residency
     [<CustomOperation("data_residency")>]

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -2307,6 +2307,22 @@ module B2cTenant =
         | PremiumP2
         | Standard
 
+    /// Check official documentation for more details: https://learn.microsoft.com/en-us/azure/active-directory-b2c/data-residency#data-residency
+    type B2cDataResidency =
+        | UnitedStates
+        | Europe
+        | AsiaPacific
+        | Japan
+        | Australia
+
+        member this.Location =
+            match this with
+            | UnitedStates -> Location "United States"
+            | Europe -> Location "Europe"
+            | AsiaPacific -> Location "Asia Pacific"
+            | Japan -> Location "Japan"
+            | Australia -> Location "Australia"
+
 module Redis =
     type Sku =
         | Basic

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -2301,6 +2301,12 @@ module ContainerService =
             | Kubenet -> "kubenet"
             | AzureCni -> "azure"
 
+module B2cTenant =
+    type Sku =
+        | PremiumP1
+        | PremiumP2
+        | Standard
+
 module Redis =
     type Sku =
         | Basic

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -121,10 +121,12 @@
     <Compile Include="Arm/LogicApps.fs" />
     <Compile Include="Arm/OperationsManagement.fs" />
     <Compile Include="Arm\Webhook.fs" />
+    <Compile Include="Arm\B2cTenant.fs" />
     <Compile Include="IdentityExtensions.fs" />
     <Compile Include="Builders/Extensions.fs" />
     <Compile Include="Builders\Builders.ActionGroup.fs" />
     <Compile Include="Builders\Builders.AutoscaleSettings.fs" />
+    <Compile Include="Builders\Builders.B2cTenant.fs" />
     <Compile Include="Builders/Builders.UserAssignedIdentity.fs" />
     <Compile Include="Builders/Builders.ResourceGroup.fs" />
     <Compile Include="Builders/Builders.LogAnalytics.fs" />

--- a/src/Tests/AllTests.fs
+++ b/src/Tests/AllTests.fs
@@ -26,6 +26,7 @@ let allTests =
                         AzCli.tests
                     AutoscaleSettings.tests
                     AzureFirewall.tests
+                    B2cTenant.tests
                     Bastion.tests
                     BingSearch.tests
                     Cdn.tests

--- a/src/Tests/B2cTenant.fs
+++ b/src/Tests/B2cTenant.fs
@@ -2,6 +2,7 @@ module B2cTenant
 
 open Expecto
 open Farmer
+open Farmer.B2cTenant
 open Farmer.Builders
 open Newtonsoft.Json.Linq
 
@@ -19,7 +20,7 @@ let tests =
                                 b2cTenant {
                                     initial_domain_name "myb2c"
                                     display_name "My B2C tenant"
-                                    sku B2cTenant.Sku.PremiumP1
+                                    sku Sku.PremiumP1
                                     country_code "FR"
                                     data_residency B2cDataResidency.Europe
                                 }

--- a/src/Tests/B2cTenant.fs
+++ b/src/Tests/B2cTenant.fs
@@ -1,0 +1,69 @@
+module B2cTenant
+
+open Expecto
+open Farmer
+open Farmer.Builders
+open Newtonsoft.Json.Linq
+
+let tests =
+    testList
+        "B2c tenant tests"
+        [
+            test "B2c tenant should generate the expected arm template" {
+                let deployment =
+                    arm {
+                        location Location.FranceCentral
+
+                        add_resources
+                            [
+                                b2cTenant {
+                                    initial_domain_name "myb2c"
+                                    display_name "My B2C tenant"
+                                    sku B2cTenant.Sku.PremiumP1
+                                    country_code "FR"
+                                    data_residency B2cDataResidency.Europe
+                                }
+                            ]
+                    }
+
+                let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+
+                let generatedTemplate = jobj.SelectToken("resources[0]")
+
+                Expect.equal
+                    (generatedTemplate.SelectToken("apiVersion").ToString())
+                    "2021-04-01"
+                    "Invalid ARM template api version"
+
+                Expect.equal
+                    (generatedTemplate.SelectToken("type").ToString())
+                    "Microsoft.AzureActiveDirectory/b2cDirectories"
+                    "Invalid ARM template type"
+
+                Expect.equal
+                    (generatedTemplate.SelectToken("name").ToString())
+                    "myb2c.onmicrosoft.com"
+                    "`name` should match <initial_domain_name>.onmicrosoft.com"
+
+                Expect.equal
+                    (generatedTemplate
+                        .SelectToken("properties.createTenantProperties.displayName")
+                        .ToString())
+                    "My B2C tenant"
+                    "Invalid display name"
+
+                Expect.equal
+                    (generatedTemplate.SelectToken("location").ToString())
+                    "europe"
+                    "`location` should match with the provided `data_residency`"
+
+                Expect.equal
+                    (generatedTemplate
+                        .SelectToken("properties.createTenantProperties.countryCode")
+                        .ToString())
+                    "FR"
+                    "Invalid country code"
+
+                Expect.equal (generatedTemplate.SelectToken("sku.name").ToString()) "PremiumP1" "Invalid sku"
+            }
+        ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="AutoscaleSettings.fs" />
     <Compile Include="AvailabilityTests.fs" />
     <Compile Include="AzureFirewall.fs" />
+    <Compile Include="B2cTenant.fs" />
     <Compile Include="DiagnosticSettings.fs" />
     <Compile Include="Disk.fs" />
     <Compile Include="Common.fs" />


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Allow to create B2c Tenant
* Please note that this does not work for B2C tenant update as it requires another arm template.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders
open Farmer.Deploy

let initialDomainName = "myb2c"

let myb2c =
    b2cTenant {
        initial_domain_name initialDomainName
        display_name "My B2C"
        sku B2cTenant.Sku.PremiumP1
        country_code "FR"
        data_residency B2cDataResidency.Europe
    }
    
let b2cDoesNotExist (initialDomainName: string) =
    let output =
        Az.AzHelpers.executeAz $"resource list --name '{initialDomainName}.onmicrosoft.com'"
        |> snd
    not (output.Contains initialDomainName)
    
let deployment =
    arm {
        location Location.FranceCentral
        add_resources
            [
                // This allows to avoid having an error when the B2C tenant already exists
                if b2cDoesNotExist initialDomainName then
                    myb2c
            ]
    }

```
