### PR TITLE
Storage-accounts: Add restrict_to_ips taking a list of IPs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.8.8
+* Storage accounts: restrict_to_ips to support a list of IPs.
+
 ## 1.8.7
 * B2C Tenants: Support for creating B2C Tenants.
 

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -35,6 +35,7 @@ The Storage Account builder creates storage accounts and their associated contai
 | add_policies | Adds a list of Policies to the different storage services |
 | enable_versioning | Enabled versioning for different storage services |
 | restrict_to_ip | Restrict access to a given ip address |
+| restrict_to_ips | Restrict access to a given ip address list |
 | restrict_to_subnet | Restrict access to a given virtual network subnet |
 | restrict_to_azure_services | Restrict access to a given set of Azure Services. (Used when access to the storage account already controlled by private endpoint) |
 | disable_public_network_access | Disables public network access to the storage account |

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -571,11 +571,13 @@ type StorageAccountBuilder() =
 
     [<CustomOperation "restrict_to_ips">]
     member this.RestrictToIps(state: StorageAccountConfig, ips: string list) =
-        let allowIps = ips |> List.map(fun ip -> 
-            {
-                Value = IpRuleAddress(System.Net.IPAddress.Parse ip)
-                Action = RuleAction.Allow
-            })
+        let allowIps =
+            ips
+            |> List.map (fun ip ->
+                {
+                    Value = IpRuleAddress(System.Net.IPAddress.Parse ip)
+                    Action = RuleAction.Allow
+                })
 
         match state.NetworkAcls with
         | None ->

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -545,7 +545,7 @@ let tests =
                     storageAccount {
                         name "onlymyhouse24125"
                         restrict_to_ip "8.8.8.8"
-                        restrict_to_ips ["1.2.3.4"]
+                        restrict_to_ips [ "1.2.3.4" ]
                         restrict_to_prefix "8.8.8.0/24"
                     }
 

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -545,6 +545,7 @@ let tests =
                     storageAccount {
                         name "onlymyhouse24125"
                         restrict_to_ip "8.8.8.8"
+                        restrict_to_ips ["1.2.3.4"]
                         restrict_to_prefix "8.8.8.0/24"
                     }
 
@@ -553,7 +554,7 @@ let tests =
 
                 Expect.containsAll
                     (generated.NetworkRuleSet.IpRules |> Seq.map (fun rule -> rule.IPAddressOrRange))
-                    [ "8.8.8.8"; "8.8.8.0/24" ]
+                    [ "8.8.8.8"; "1.2.3.4"; "8.8.8.0/24" ]
                     "Missing IP rules"
             }
             test "Restrict to vnet" {

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -550,7 +550,7 @@ let tests =
                     }
 
                 let generated = arm { add_resource storage } |> getStorageResource
-                Expect.hasLength generated.NetworkRuleSet.IpRules 2 "Wrong number of IP rules"
+                Expect.hasLength generated.NetworkRuleSet.IpRules 3 "Wrong number of IP rules"
 
                 Expect.containsAll
                     (generated.NetworkRuleSet.IpRules |> Seq.map (fun rule -> rule.IPAddressOrRange))


### PR DESCRIPTION
The changes in this PR are as follows:

* Storage account, give list of IPs so it's easier to use the builder if you have already IP-configurations as list.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
- This is a builder-only addition, not data-model or deployment changes.
- It was direct copy of existing restrict_to_ip. If that works already (as in docs it does) then this works too.
