### PR TITLE
Add option to set DAPR protocol for Container Apps

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.9.29
+* Container Apps: Add support for setting Dapr protocol.
 
 ## 1.9.28
 * Container Apps: Add `resources` operation to the `container` builder to set both CPU and memory together using a `ConsumptionPlanResources` discriminated union. This ensures only valid consumption plan resource combinations can be selected at compile time. The individual `cpu_cores` and `memory` operations remain available for use with dedicated plans.

--- a/docs/content/api-overview/resources/container-apps.md
+++ b/docs/content/api-overview/resources/container-apps.md
@@ -46,6 +46,7 @@ The Container Apps builder (`containerApp`) is used to define one or more contai
 | system_identity | Activates the system identity of the Azure Container App. |
 | dapr_app_id | Sets the dapr app id for the app. |
 | dapr_app_port | Sets the dapr app port for the app. |
+| dapr_app_protocol | Sets the dapr app protocol for the app. |
 | replicas | Sets the minimum and maximum replicas to scale the container app. |
 | active_revision_mode | Indicates whether multiple versions of a container app can be active at once.|
 | add_registry_credentials | Adds container image registry credentials for images in this container app, which are a list of server and usernames. Passwords are supplied as secure parameters. |

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -157,7 +157,12 @@ type ContainerApp = {
     ScaleRules: Map<string, ScaleRule>
     Identity: ManagedIdentity
     Replicas: {| Min: int; Max: int |} option
-    DaprConfig: {| AppId: string; Port: uint16 option |} option
+    DaprConfig:
+        {|
+            AppId: string
+            Port: uint16 option
+            Protocol: DaprProtocol option
+        |} option
     Secrets: Map<ContainerAppSettingKey, SecretValue>
     EnvironmentVariables: Map<string, EnvVar>
     ImageRegistryCredentials: ImageRegistryAuthentication list
@@ -300,6 +305,7 @@ type ContainerApp = {
                                         enabled = true
                                         appId = settings.AppId
                                         appPort = settings.Port |> Option.toNullable
+                                        appProtocol = settings.Protocol |> Option.map _.ArmValue |> Option.toObj
                                     |}
                                     :> obj
                                 | None -> {| enabled = false |}

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -45,6 +45,7 @@ type ContainerAppConfig = {
         {|
             AppId: string option
             Port: uint16 option
+            Protocol: DaprProtocol option
         |} option
     Secrets: Map<ContainerAppSettingKey, SecretValue>
     EnvironmentVariables: Map<string, EnvVar>
@@ -128,7 +129,11 @@ type ContainerEnvironmentConfig = {
                         containerApp.DaprConfig
                         |> Option.map (fun x ->
                             match x.AppId with
-                            | Some appId -> {| AppId = appId; Port = x.Port |}
+                            | Some appId -> {|
+                                AppId = appId
+                                Port = x.Port
+                                Protocol = x.Protocol
+                              |}
                             | None ->
                                 raiseFarmer
                                     $"The container app '{containerApp.Name.Value}' requires a Dapr App ID when Dapr is enabled.")
@@ -448,7 +453,11 @@ type ContainerAppBuilder() =
             DaprConfig =
                 state.DaprConfig
                 |> Option.map (fun x -> {| x with AppId = Some appId |})
-                |> Option.defaultWith (fun () -> {| AppId = Some appId; Port = None |})
+                |> Option.defaultWith (fun () -> {|
+                    AppId = Some appId
+                    Port = None
+                    Protocol = None
+                |})
                 |> Some
     }
 
@@ -459,7 +468,26 @@ type ContainerAppBuilder() =
             DaprConfig =
                 state.DaprConfig
                 |> Option.map (fun x -> {| x with Port = Some port |})
-                |> Option.defaultWith (fun () -> {| AppId = None; Port = Some port |})
+                |> Option.defaultWith (fun () -> {|
+                    AppId = None
+                    Port = Some port
+                    Protocol = None
+                |})
+                |> Some
+    }
+
+    /// Configures Dapr protocol in the Azure Container App.
+    [<CustomOperation "dapr_app_protocol">]
+    member _.SetDaprProtocol(state: ContainerAppConfig, protocol: DaprProtocol) = {
+        state with
+            DaprConfig =
+                state.DaprConfig
+                |> Option.map (fun x -> {| x with Protocol = Some protocol |})
+                |> Option.defaultWith (fun () -> {|
+                    AppId = None
+                    Port = None
+                    Protocol = Some protocol
+                |})
                 |> Some
     }
 

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -4218,6 +4218,16 @@ module ContainerApp =
             | Cores3_75 -> 7.5<Gb>
             | Cores4_0 -> 8.0<Gb>
 
+    [<RequireQualifiedAccess>]
+    type DaprProtocol =
+        | Grpc
+        | Http
+
+        member this.ArmValue =
+            match this with
+            | Grpc -> "grpc"
+            | Http -> "http"
+
 namespace Farmer.DiagnosticSettings
 
 open Farmer

--- a/src/Tests/ContainerApps.fs
+++ b/src/Tests/ContainerApps.fs
@@ -58,6 +58,8 @@ let fullContainerAppDeployment =
         ingress_target_port 80us
         ingress_transport Auto
         dapr_app_id "http"
+        dapr_app_port 5000us
+        dapr_app_protocol DaprProtocol.Grpc
         add_http_scale_rule "http-rule" { ConcurrentRequests = 100 }
     }
 
@@ -386,6 +388,10 @@ let tests =
             Expect.isNotNull ruleAuth "auth[0] was null"
             Expect.equal (ruleAuth["secretRef"] |> string) connectionSecretName "Incorrect secretRef"
             Expect.equal (ruleAuth["triggerParameter"] |> string) "connection" "Incorrect triggerParameter"
+
+            let daprConfig = httpContainerApp.SelectToken("properties.configuration.dapr")
+            Expect.equal (daprConfig["appPort"] |> uint16) 5000us "Incorrect dapr appPort"
+            Expect.equal (daprConfig["appProtocol"] |> string) "grpc" "Incorrect dapr appProtocol"
         }
 
         test "Makes container app with MSI" {
@@ -572,5 +578,25 @@ let tests =
                     containerResources.Resources.Memory
                     expectedMem
                     $"Incorrect memory for allocation {allocation}"
+        }
+
+        test "Dapr protocol Http is correctly serialized" {
+            let app = containerApp {
+                name "dapr-protocol-test"
+                add_simple_container "mcr.microsoft.com/dotnet/samples" "aspnetapp"
+                dapr_app_id "test-app"
+                dapr_app_protocol DaprProtocol.Http
+            }
+
+            let env = containerEnvironment {
+                name "test-env"
+                add_container app
+            }
+
+            let deployment = arm { add_resource env }
+            let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+            let ca = jobj.SelectToken("resources[?(@.name=='dapr-protocol-test')]")
+            let daprConfig = ca.SelectToken("properties.configuration.dapr")
+            Expect.equal (daprConfig["appProtocol"] |> string) "http" "Incorrect dapr appProtocol for Http"
         }
     ]


### PR DESCRIPTION
This PR closes #1083

The changes in this PR are as follows:

* Container Apps: Add support for setting Dapr protocol.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

I don't have experience using container apps with Dapr in Azure.
This change produces correct ARM config, I've used this doc as a reference - https://learn.microsoft.com/en-us/azure/container-apps/enable-dapr?tabs=arm1
Could somebody test this in Azure.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let httpContainerApp =
    containerApp {
        ...
        // Dapr config
        dapr_app_id "http"
        dapr_app_port 5000us

        // new parameter added by this PR
        dapr_app_protocol "grpc"
        ...
    }

```
