### PR TITLE
Add support for functions max scale out limit

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## 1.8.10
+* Functions: Added support for setting max scale out limit
 
 ## 1.8.9
 * Managed Identity: Support for federated identity credentials.

--- a/docs/content/api-overview/resources/functions.md
+++ b/docs/content/api-overview/resources/functions.md
@@ -52,6 +52,7 @@ The Functions builder is used to create Azure Functions accounts. It abstracts t
 | add_denied_ip_restriction | Adds an 'deny' rule for an ip |
 | link_to_vnet | Enable the VNET integration feature in azure where all outbound traffic from the function with be sent via the specified subnet. Use this operator when the given VNET is in the same deployment |
 | link_to_unmanaged_vnet | Enable the VNET integration feature in azure where all outbound traffic from the function with be sent via the specified subnet. Use this operator when the given VNET is *not* in the same deployment |
+| max_scale_out_limit | Maximum number of workers that a site can scale out to. This setting only applies to the Consumption and Elastic Premium Plans | 
 #### Post-deployment Builder Keywords
 The Functions builder contains special commands that are executed *after* the ARM deployment is completed.
 

--- a/src/Farmer/Arm/Web.fs
+++ b/src/Farmer/Arm/Web.fs
@@ -241,6 +241,7 @@ type Site =
         IpSecurityRestrictions: IpSecurityRestriction list
         LinkToSubnet: SubnetReference option
         VirtualApplications: Map<string, VirtualApplication>
+        FunctionAppScaleLimit: int option
     }
 
     /// Shorthand for SiteType.ResourceType
@@ -421,6 +422,10 @@ type Site =
                                                 preloadEnabled = virtualAppKvp.Value.PreloadEnabled |> Option.toNullable
                                             |})
                                         |> box
+                                functionAppScaleLimit =
+                                    match this.FunctionAppScaleLimit with
+                                    | Some limit -> box limit
+                                    | None -> null
                             |}
                     |}
             |}

--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -402,6 +402,7 @@ type WebAppConfig =
         DockerPort: int option
         ZoneRedundant: FeatureFlag option
         VirtualApplications: Map<string, VirtualApplication>
+        FunctionAppScaleLimit: int option
     }
 
     member this.Name = this.CommonWebConfig.Name
@@ -678,6 +679,7 @@ type WebAppConfig =
                         IpSecurityRestrictions = this.CommonWebConfig.IpSecurityRestrictions
                         LinkToSubnet = this.CommonWebConfig.IntegratedSubnet
                         VirtualApplications = this.VirtualApplications
+                        FunctionAppScaleLimit = this.FunctionAppScaleLimit
                     }
 
                 match keyVault with
@@ -904,6 +906,7 @@ type WebAppBuilder() =
             DockerPort = None
             ZoneRedundant = None
             VirtualApplications = Map []
+            FunctionAppScaleLimit = None
         }
 
     member _.Run(state: WebAppConfig) =

--- a/src/Tests/Functions.fs
+++ b/src/Tests/Functions.fs
@@ -845,6 +845,44 @@ let tests =
                 Expect.hasLength vnetConnections 1 "incorrect number of Vnet connections"
             }
 
+            test "Correctly sets max scale out limit" {
+                let f =
+                    functions {
+                        name "test"
+                        max_scale_out_limit 3
+                    }
+                    :> IBuilder
+
+                let site = f.BuildResources Location.NorthEurope |> List.item 3 :?> Web.Site
+                Expect.equal site.FunctionAppScaleLimit (Some 3) "Incorrectly sets max scale out limit"
+            }
+
+            test "Max scale out limit is not set by default" {
+                let f = functions { name "test" } :> IBuilder
+                let site = f.BuildResources Location.NorthEurope |> List.item 3 :?> Web.Site
+                Expect.equal site.FunctionAppScaleLimit (None) "Sould not set max scale out limit"
+            }
+
+            test "Max scale out limit must be between 1 and 200" {
+                Expect.throws
+                    (fun () ->
+                        functions {
+                            name "test"
+                            max_scale_out_limit 0
+                        }
+                        |> ignore)
+                    "Max scale out limit must be at least 1"
+
+                Expect.throws
+                    (fun () ->
+                        functions {
+                            name "test"
+                            max_scale_out_limit 201
+                        }
+                        |> ignore)
+                    "Max scale out limit must be at most 200"
+            }
+
             let data =
                 [
                     (FunctionsRuntime.DotNetFramework48, "v4.0")


### PR DESCRIPTION
The changes in this PR are as follows:

* Adds max_scale_out_limit to set a maximum number of workers that a site can scale out to in consumption and Elastic Premium Plans

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
I do not currently have access to Azure to test this but I have done so in the past.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let myFunction = functions {
    name "myWebApp"
    sku WebApp.Sku.Y
    max_scale_out_limit 5
}
```
