### PR TITLE
Add support for setting service bus max message size

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,11 @@
 Release Notes
 =============
+
+## 1.8.11
+* Service Bus: Added support for setting max message size.
+
 ## 1.8.10
 * Functions: Added support for setting max scale out limit.
-* Service Bus: Added support for setting max message size.
 
 ## 1.8.9
 * Managed Identity: Support for federated identity credentials.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 Release Notes
 =============
 ## 1.8.10
-* Functions: Added support for setting max scale out limit
+* Functions: Added support for setting max scale out limit.
+* Service Bus: Added support for setting max message size.
 
 ## 1.8.9
 * Managed Identity: Support for federated identity credentials.

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -44,6 +44,7 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Topic | duplicate_detection | Whether to enable duplicate detection, and if so, how long to check for. |
 | Topic | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for in minutes. |
 | Topic | enable_partition | Enables partition support on the topic. |
+| Topic | max_message_size | The maximum size of the message payload that can be accepted by the topic in Kilobytes e.g `1024<Kb>`. |
 | Topic | max_topic_size | Maximum size for the topic in Megabytes e.g. `1024<Mb>`. |
 | Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan or a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes, or as an integer days e.g. `4<Days>`. |
 | Topic | link_to_unmanaged_namespace | Instead of creating or modifying a namespace, configure this topic to point to another unmanaged namespace instance. |

--- a/docs/content/api-overview/resources/service-bus.md
+++ b/docs/content/api-overview/resources/service-bus.md
@@ -44,7 +44,7 @@ The Service Bus builder creates service bus namespaces and their associated queu
 | Topic | duplicate_detection | Whether to enable duplicate detection, and if so, how long to check for. |
 | Topic | duplicate_detection_minutes | Whether to enable duplicate detection, and if so, how long to check for in minutes. |
 | Topic | enable_partition | Enables partition support on the topic. |
-| Topic | max_message_size | The maximum size of the message payload that can be accepted by the topic in Kilobytes e.g `1024<Kb>`. |
+| Topic | max_message_size | The maximum size of the message payload that can be accepted by the topic in Kilobytes e.g `1024<Kb>`. **Requires Premium SKU.** |
 | Topic | max_topic_size | Maximum size for the topic in Megabytes e.g. `1024<Mb>`. |
 | Topic | message_ttl | Time To Live (TTL) value for messages expressed as a TimeSpan or a TimeSpan string, such as '01:30:00' 1 hour, 30 minutes, or as an integer days e.g. `4<Days>`. |
 | Topic | link_to_unmanaged_namespace | Instead of creating or modifying a namespace, configure this topic to point to another unmanaged namespace instance. |

--- a/src/Farmer/Arm/ServiceBus.fs
+++ b/src/Farmer/Arm/ServiceBus.fs
@@ -191,6 +191,7 @@ module Namespaces =
             DuplicateDetectionHistoryTimeWindow: IsoDateTime option
             DefaultMessageTimeToLive: IsoDateTime option
             EnablePartitioning: bool option
+            MaxMessageSizeInKilobytes: int<Kb> option
             MaxSizeInMegabytes: int<Mb> option
         }
 
@@ -208,6 +209,7 @@ module Namespaces =
                                 | None -> Nullable()
                             duplicateDetectionHistoryTimeWindow = tryGetIso this.DuplicateDetectionHistoryTimeWindow
                             enablePartitioning = this.EnablePartitioning |> Option.toNullable
+                            maxMessageSizeInKilobytes = this.MaxMessageSizeInKilobytes |> Option.toNullable
                             maxSizeInMegabytes = this.MaxSizeInMegabytes |> Option.toNullable
                         |}
                 |}

--- a/src/Farmer/Builders/Builders.ServiceBus.fs
+++ b/src/Farmer/Builders/Builders.ServiceBus.fs
@@ -329,6 +329,7 @@ type ServiceBusTopicConfig =
         DuplicateDetection: TimeSpan option
         DefaultMessageTimeToLive: TimeSpan option
         EnablePartitioning: bool option
+        MaxMessageSizeInKilobytes: int<Kb> option
         MaxSizeInMegabytes: int<Mb> option
         Subscriptions: Map<ResourceName, ServiceBusSubscriptionConfig>
     }
@@ -356,6 +357,7 @@ type ServiceBusTopicConfig =
                     DuplicateDetectionHistoryTimeWindow = this.DuplicateDetection |> Option.map IsoDateTime.OfTimeSpan
                     DefaultMessageTimeToLive = this.DefaultMessageTimeToLive |> Option.map IsoDateTime.OfTimeSpan
                     EnablePartitioning = this.EnablePartitioning
+                    MaxMessageSizeInKilobytes = this.MaxMessageSizeInKilobytes
                     MaxSizeInMegabytes = this.MaxSizeInMegabytes
                 }
                 for subscription in this.Subscriptions do
@@ -376,6 +378,7 @@ type ServiceBusTopicBuilder() =
             DuplicateDetection = None
             DefaultMessageTimeToLive = None
             EnablePartitioning = None
+            MaxMessageSizeInKilobytes = None
             MaxSizeInMegabytes = None
             Subscriptions = Map.empty
         }
@@ -401,6 +404,13 @@ type ServiceBusTopicBuilder() =
     member _.DuplicateDetection(state: ServiceBusTopicConfig, maxTimeWindow) =
         { state with
             DuplicateDetection = Some(TimeSpan.FromMinutes(float maxTimeWindow))
+        }
+
+    /// The maximum size of the message payload that can be accepted by the topic in kilobytes.
+    [<CustomOperation "max_message_size">]
+    member _.MaxMessageSize(state: ServiceBusTopicConfig, maxMessageSizeInKilobytes: int<Kb>) =
+        { state with
+            MaxMessageSizeInKilobytes = Some maxMessageSizeInKilobytes
         }
 
     /// The maximum size for the topic in megabytes.

--- a/src/Tests/ServiceBus.fs
+++ b/src/Tests/ServiceBus.fs
@@ -475,7 +475,7 @@ let tests =
 
                         Expect.equal sbAuthorizationRule.Name "serviceBus/my-queue/my-rule" "Name is wrong"
                         Expect.equal sbAuthorizationRule.Rights.Count 1 "Wrong number of rights"
-                        Expect.equal sbAuthorizationRule.Rights.[0] (Nullable AccessRights.Manage) "Wrong rights"
+                        Expect.equal sbAuthorizationRule.Rights.[0] AccessRights.Manage "Wrong rights"
                     }
 
                     test "Queue IArmResource has correct resourceId for unmanaged namespace" {
@@ -576,6 +576,24 @@ let tests =
                             topic.DuplicateDetectionHistoryTimeWindow
                             (Nullable(TimeSpan.FromMinutes 15.))
                             "Duplicate detection time incorrect"
+                    }
+                    test "Can create a topic with a max message size" {
+                        let topic: SBTopic =
+                            serviceBus {
+                                name "my-bus"
+
+                                add_topics
+                                    [
+                                        topic {
+                                            name "my-topic"
+                                            max_message_size 1024<Kb>
+                                        }
+                                    ]
+                            }
+                            |> getResourceAtIndex 1
+
+                        Expect.equal topic.Name "my-bus/my-topic" "Name not set"
+                        Expect.equal topic.MaxMessageSizeInKilobytes (Nullable 1024) "Max message size not set"
                     }
                     test "Can create a topic with a max size" {
                         let topic: SBTopic =
@@ -954,7 +972,7 @@ let tests =
 
                         Expect.equal sbAuthorizationRule.Name "serviceBus/my-rule" "Wrong name"
                         Expect.equal sbAuthorizationRule.Rights.Count 1 "Wrong number of rights"
-                        Expect.equal sbAuthorizationRule.Rights.[0] (Nullable AccessRights.Manage) "Wrong rights"
+                        Expect.equal sbAuthorizationRule.Rights.[0] AccessRights.Manage "Wrong rights"
                     }
                 ]
         ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -94,7 +94,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Network" Version="19.20.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.OperationalInsights" Version="0.21.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.10.1-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.SignalR" Version="1.0.1" />
     <PackageReference Include="Microsoft.Azure.Management.Sql" Version="1.43.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" Version="21.0.0" />


### PR DESCRIPTION

The changes in this PR are as follows:
* For a Service Bus Topic it adds the max_message_size [property](https://learn.microsoft.com/en-us/azure/templates/microsoft.servicebus/namespaces/topics?pivots=deployment-language-bicep#sbtopicproperties). This allows configuring the [large messages](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging#large-messages-support) feature in premium subscriptions.
* Updated Microsoft.Azure.Management.ServiceBus to version 5.0.0 to support this setting

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
- I do not currently have access to Azure to test this but I have done so in the past.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let myServiceBus = serviceBus {
    name "my-namespace"
    sku (Premium OneUnit)
    add_topics [
        topic {
            name "topicA"
            max_message_size 1024<Kb>
        }
    ]
}
```
