### PR TITLE
Code coverage is published by default

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,31 +66,19 @@ stages:
         azureSubscription: 'Microsoft Azure Sponsorship(6c9e2629-3964-4b24-bc32-97dafc8c90f3)'
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
-        inlineScript: 'dotnet test -v n -c release -l trx --collect:"XPlat Code Coverage"'
+        inlineScript: 'dotnet test -v n -c release -l trx --collect:"Code Coverage"'
     - task: DotNetCoreCLI@2
       displayName: 'Test Pull Request'
       condition:  and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       inputs:
         command: 'test'
-        arguments: '-v n -c release -l trx --collect:"XPlat Code Coverage"'
+        arguments: '-v n -c release -l trx --collect:"Code Coverage"'
     - task: PublishTestResults@2
       displayName: 'Publish Test Results' # happens automatically on PR builds using @DotNetCoreCLI task
       condition:  not(eq(variables['build.reason'], 'PullRequest'))
       inputs:
         testResultsFiles: '**/*.trx'
         testResultsFormat: VSTest
-    - task: PublishCodeCoverageResults@1
-      displayName: "Publish Code Coverage"
-      condition:  and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')))
-      inputs:
-        codeCoverageTool: 'Cobertura'
-        summaryFileLocation: '$(Build.SourcesDirectory)/src/Tests/TestResults/*/coverage.cobertura.xml'
-    - task: PublishCodeCoverageResults@1
-      displayName: "Publish PR Code Coverage"
-      condition:  and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
-      inputs:
-        codeCoverageTool: 'Cobertura'
-        summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
     - task: DotNetCoreCLI@2
       displayName: 'Package'
       condition: and(succeeded(), eq(variables.imageName, 'ubuntu-latest'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,19 +66,23 @@ stages:
         azureSubscription: 'Microsoft Azure Sponsorship(6c9e2629-3964-4b24-bc32-97dafc8c90f3)'
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
-        inlineScript: 'dotnet test -v n -c release -l trx --collect:"Code Coverage"'
+        inlineScript: 'dotnet test -v n -c release -l trx --collect:"XPlat Code Coverage"'
     - task: DotNetCoreCLI@2
       displayName: 'Test Pull Request'
       condition:  and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       inputs:
         command: 'test'
-        arguments: '-v n -c release -l trx --collect:"Code Coverage"'
+        arguments: '-v n -c release -l trx --collect:"XPlat Code Coverage"'
     - task: PublishTestResults@2
       displayName: 'Publish Test Results' # happens automatically on PR builds using @DotNetCoreCLI task
       condition:  not(eq(variables['build.reason'], 'PullRequest'))
       inputs:
         testResultsFiles: '**/*.trx'
         testResultsFormat: VSTest
+    - task: PublishCodeCoverageResults@2
+      displayName: "Publish code coverage"
+      inputs:
+        summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
     - task: DotNetCoreCLI@2
       displayName: 'Package'
       condition: and(succeeded(), eq(variables.imageName, 'ubuntu-latest'))


### PR DESCRIPTION
Removes the build tasks to publish code coverage since that is done automatically by default.