### PR TITLE
Add plural storage containers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 1.8.13
+* Storage: add plural `add_blob_containers`, `add_public_containers`, `add_private_containers`, `add_file_shares`, `add_file_shares_with_quota` and `add_queues (string seq)`.
+* Storage: fix quadratic complexity in `add_queues (StorageQueueConfig seq)`.
+
 ## 1.8.12
 * App Service: Automatic support for App Insights on Linux.
 * LoadBalancer: Linking BackendAddressPool IPs to subnets instead of vnets if configured.

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -23,10 +23,15 @@ The Storage Account builder creates storage accounts and their associated contai
 | sku | Sets the SKU of the storage account. A set of predefined SKU values are available as members in `Storage.Sku`, but you can create the full range of combinations of Kind and SKU as needed. |
 | default_blob_access_tier | Sets the default access tier for blob containers |
 | add_public_container | Adds a general-purpose public storage container |
+| add_public_containers | Adds a list of general-purpose public storage containers |
 | add_private_container | Adds a general-purpose private storage container |
+| add_private_containers | Adds a list of general-purpose private storage containers |
 | add_blob_container | Adds a general-purpose private blob container |
+| add_blob_containers | Adds a list of general-purpose private blob containers |
 | add_file_share | Adds a file share to storage account |
+| add_file_shares | Adds a list of file shares to storage account |
 | add_file_share_with_quota | Adds a file share to storage account with a share quota in Gb |
+| add_file_shares_with_quota | Adds a list of file shares to storage account with a share quota in Gb |
 | add_queue | Adds a queue to the storage account |
 | add_queues | Adds a list of queues to the storage account |
 | add_table | Adds a table to the storage account |

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -255,15 +255,33 @@ type StorageAccountBuilder() =
 
         state
 
-    static member private AddContainer(state, access, name: string) = {
+    static member private AddContainers(state, access, names: string seq) = {
         state with
-            Containers = state.Containers @ [ ((StorageResourceName.Create name).OkValue, access) ]
+            Containers =
+                let containers =
+                    names
+                    |> List.ofSeq
+                    |> List.map (fun name -> ((StorageResourceName.Create name).OkValue, access))
+
+                state.Containers @ containers
     }
 
-    static member private AddFileShare(state: StorageAccountConfig, name: string, quota) = {
+    static member private AddContainer(state, access, name: string) =
+        StorageAccountBuilder.AddContainers(state, access, [ name ])
+
+    static member private AddFileShares(state: StorageAccountConfig, names: string seq, quota) = {
         state with
-            FileShares = state.FileShares @ [ (StorageResourceName.Create(name).OkValue, quota) ]
+            FileShares =
+                let fileShares =
+                    names
+                    |> List.ofSeq
+                    |> List.map (fun name -> (StorageResourceName.Create(name).OkValue, quota))
+
+                state.FileShares @ fileShares
     }
+
+    static member private AddFileShare(state: StorageAccountConfig, name: string, quota) =
+        StorageAccountBuilder.AddFileShares(state, [ name ], quota)
 
     /// Sets the name of the storage account.
     [<CustomOperation "name">]
@@ -283,25 +301,50 @@ type StorageAccountBuilder() =
     member _.AddPrivateContainer(state: StorageAccountConfig, name) =
         StorageAccountBuilder.AddContainer(state, Private, name)
 
+    /// Adds private containers.
+    [<CustomOperation "add_private_containers">]
+    member _.AddPrivateContainers(state: StorageAccountConfig, names) =
+        StorageAccountBuilder.AddContainers(state, Private, names)
+
     /// Adds container with anonymous read access for blobs and containers.
     [<CustomOperation "add_public_container">]
     member _.AddPublicContainer(state: StorageAccountConfig, name) =
         StorageAccountBuilder.AddContainer(state, Container, name)
+
+    /// Adds containers with anonymous read access for blobs and containers.
+    [<CustomOperation "add_public_containers">]
+    member _.AddPublicContainers(state: StorageAccountConfig, names) =
+        StorageAccountBuilder.AddContainers(state, Container, names)
 
     /// Adds container with anonymous read access for blobs only.
     [<CustomOperation "add_blob_container">]
     member _.AddBlobContainer(state: StorageAccountConfig, name) =
         StorageAccountBuilder.AddContainer(state, Blob, name)
 
+    /// Adds containers with anonymous read access for blobs only.
+    [<CustomOperation "add_blob_containers">]
+    member _.AddBlobContainers(state: StorageAccountConfig, names) =
+        StorageAccountBuilder.AddContainers(state, Blob, names)
+
     /// Adds a file share with no quota.
     [<CustomOperation "add_file_share">]
     member _.AddFileShare(state: StorageAccountConfig, name) =
         StorageAccountBuilder.AddFileShare(state, name, None)
 
+    /// Adds file shares with no quota.
+    [<CustomOperation "add_file_shares">]
+    member _.AddFileShares(state: StorageAccountConfig, names) =
+        StorageAccountBuilder.AddFileShares(state, names, None)
+
     /// Adds a file share with specified quota.
     [<CustomOperation "add_file_share_with_quota">]
     member _.AddFileShareWithQuota(state: StorageAccountConfig, name: string, quota) =
         StorageAccountBuilder.AddFileShare(state, name, Some quota)
+
+    /// Adds file shares with specified quota.
+    [<CustomOperation "add_file_shares_with_quota">]
+    member _.AddFileSharesWithQuota(state: StorageAccountConfig, names: string list, quota) =
+        StorageAccountBuilder.AddFileShares(state, names, Some quota)
 
     /// Adds a single queue to the storage account.
     [<CustomOperation "add_queue">]

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -348,28 +348,34 @@ type StorageAccountBuilder() =
 
     /// Adds a single queue to the storage account.
     [<CustomOperation "add_queue">]
-    member _.AddQueue(state: StorageAccountConfig, queue: StorageQueueConfig) = {
-        state with
-            Queues = state.Queues @ [ queue ]
-    }
+    member this.AddQueue(state: StorageAccountConfig, queue: StorageQueueConfig) = this.AddQueues(state, [ queue ])
 
+    /// Adds a single queue to the storage account.
     [<CustomOperation "add_queue">]
-    member _.AddQueue(state: StorageAccountConfig, name: string) = {
+    member this.AddQueue(state: StorageAccountConfig, name: string) = this.AddQueues(state, [ name ])
+
+    /// Adds a set of queues to the storage account.
+    [<CustomOperation "add_queues">]
+    member _.AddQueues(state: StorageAccountConfig, names: string seq) = {
         state with
             Queues =
-                state.Queues
-                @ [
-                    {
+                let queues =
+                    names
+                    |> List.ofSeq
+                    |> List.map (fun name -> {
                         Name = StorageResourceName.Create(name).OkValue
                         Metadata = None
-                    }
-                ]
+                    })
+
+                state.Queues @ queues
     }
 
     /// Adds a set of queues to the storage account.
     [<CustomOperation "add_queues">]
-    member this.AddQueues(state: StorageAccountConfig, queues: StorageQueueConfig seq) =
-        (state, queues) ||> Seq.fold (fun state queue -> this.AddQueue(state, queue))
+    member _.AddQueues(state: StorageAccountConfig, queues: StorageQueueConfig seq) = {
+        state with
+            Queues = state.Queues @ List.ofSeq queues
+    }
 
     /// Adds a set of queues to the storage account with the same metadata.
     [<CustomOperation "add_queues">]

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -107,10 +107,13 @@ let tests =
                     add_blob_container "blob"
                     add_private_container "private"
                     add_public_container "public"
+                    add_blob_containers [ "blob1"; "blob2" ]
+                    add_private_containers [ "private1"; "private2" ]
+                    add_public_containers [ "public1"; "public2" ]
                 }
 
                 [
-                    for i in 1..3 do
+                    for i in 1..9 do
                         account |> getResourceAtIndex client.SerializationSettings i
                 ]
 
@@ -120,6 +123,18 @@ let tests =
             Expect.equal resources.[1].PublicAccess.Value PublicAccess.None "private access is wrong"
             Expect.equal resources.[2].Name "storage/default/public" "public name is wrong"
             Expect.equal resources.[2].PublicAccess.Value PublicAccess.Container "container access is wrong"
+            Expect.equal resources.[3].Name "storage/default/blob1" "blob1 name is wrong"
+            Expect.equal resources.[3].PublicAccess.Value PublicAccess.Blob "blob1 access is wrong"
+            Expect.equal resources.[4].Name "storage/default/blob2" "blob2 name is wrong"
+            Expect.equal resources.[4].PublicAccess.Value PublicAccess.Blob "blob2 access is wrong"
+            Expect.equal resources.[5].Name "storage/default/private1" "private1 name is wrong"
+            Expect.equal resources.[5].PublicAccess.Value PublicAccess.None "private1 access is wrong"
+            Expect.equal resources.[6].Name "storage/default/private2" "private2 name is wrong"
+            Expect.equal resources.[6].PublicAccess.Value PublicAccess.None "private2 access is wrong"
+            Expect.equal resources.[7].Name "storage/default/public1" "public1 name is wrong"
+            Expect.equal resources.[7].PublicAccess.Value PublicAccess.Container "public1 access is wrong"
+            Expect.equal resources.[8].Name "storage/default/public2" "public2 name is wrong"
+            Expect.equal resources.[8].PublicAccess.Value PublicAccess.Container "public2 access is wrong"
         }
         test "Creates file shares correctly" {
             let resources: FileShare list =
@@ -127,16 +142,24 @@ let tests =
                     name "storage"
                     add_file_share "share1"
                     add_file_share_with_quota "share2" 1024<Gb>
+                    add_file_shares [ "share3"; "share4" ]
+                    add_file_shares_with_quota [ "share5"; "share6" ] 2048<Gb>
                 }
 
                 [
-                    for i in 1..2 do
+                    for i in 1..6 do
                         account |> getResourceAtIndex client.SerializationSettings i
                 ]
 
             Expect.equal resources.[0].Name "storage/default/share1" "file share name for 'share1' is wrong"
             Expect.equal resources.[1].Name "storage/default/share2" "file share name for 'share2' is wrong"
             Expect.equal resources.[1].ShareQuota (Nullable 1024) "file share quota for 'share2' is wrong"
+            Expect.equal resources.[2].Name "storage/default/share3" "file share name for 'share3' is wrong"
+            Expect.equal resources.[3].Name "storage/default/share4" "file share name for 'share4' is wrong"
+            Expect.equal resources.[4].Name "storage/default/share5" "file share name for 'share5' is wrong"
+            Expect.equal resources.[4].ShareQuota (Nullable 2048) "file share quota for 'share5' is wrong"
+            Expect.equal resources.[5].Name "storage/default/share6" "file share name for 'share6' is wrong"
+            Expect.equal resources.[5].ShareQuota (Nullable 2048) "file share quota for 'share6' is wrong"
         }
         test "Creates tables correctly" {
             let resources: Table list =


### PR DESCRIPTION
The changes in this PR are as follows:

* Storage: add plural `add_blob_containers`, `add_public_containers`, `add_private_containers`, `add_file_shares`, `add_file_shares_with_quota` and `add_queues (string seq)`.
* Storage: fix quadratic complexity in `add_queues (StorageQueueConfig seq)`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let account = storageAccount {
    add_blob_containers [ "blob1"; "blob2" ]
    add_public_containers [ "public1"; "public2" ]
    add_private_containers [ "private1"; "private2" ]
    add_file_shares [ "share1"; "share2" ]
    add_file_shares_with_quota [ "share3"; "share4" ] 1024<Gb>
    add_queues [ "queue1"; "queue2" ]
}
```
