### PR TITLE
Add support for Flexible Servers, databases and firewalls.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.inlayHints.enabled": "offUnlessPressed"
+}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 Release Notes
 =============
+## vNext
+* PostgreSQL: Support for Flexible Servers.
 
 ## 1.8.13
 * PostgreSQL: Use the correct ResourceId (used in e.g. depends_on calls)

--- a/docs/content/api-overview/resources/postgresql.md
+++ b/docs/content/api-overview/resources/postgresql.md
@@ -12,8 +12,9 @@ It supports features such as firewall, autogrow and version selection.
 Every PostgreSQL Azure server you create will automatically create a SecureString
 parameter for the admin account password.
 
-> There is support for newer "Flexible" as well as the original "Single Instance" server type.
+> There is support for newer "Flexible" as well as the original "Single Server" server type.
 > Several keywords are overloaded to cater for both server types.
+> By default, the builder uses Flexible Server model.
 
 * PostgreSQL server (`Microsoft.DBforPostgreSQL/servers`)
 * PostgreSQL server (`Microsoft.DBforPostgreSQL/flexibleServers`)
@@ -58,7 +59,7 @@ parameter for the admin account password.
 
 #### Example
 
-* Original "Single Instance" model
+* Original "Single Server" model
 
 ```fsharp
 open Farmer
@@ -70,9 +71,13 @@ let myPostgres = postgreSQL {
     name "aserverformultitudes42"
     capacity 4<VCores>
     storage_size 50<Gb>
-    tier GeneralPurpose
     add_database "my_db"
     enable_azure_firewall
+
+    // overloaded or single-instance-specific keywords
+    tier GeneralPurpose
+    server_version Version.VS_11
+    capacity 1<VCores>
 }
 
 let template = arm {
@@ -93,10 +98,13 @@ let myPostgres = postgreSQL {
     name "aserverformultitudes42"
     admin_username "adminallthethings"
     storage_size 64<Gb>
-    tier FlexibleTier.Burstable_B1ms
-    storage_performance_tier Vm.DiskPerformanceTier.P10
     add_database "my_db"
     enable_azure_firewall
     storage_autogrow true
+
+    // overloaded or model-specific keywords
+    tier FlexibleTier.Burstable_B1ms
+    server_version FlexibleVersion.V_16
+    storage_performance_tier Vm.DiskPerformanceTier.P10
 }
 ```

--- a/docs/content/api-overview/resources/postgresql.md
+++ b/docs/content/api-overview/resources/postgresql.md
@@ -12,7 +12,11 @@ It supports features such as firewall, autogrow and version selection.
 Every PostgreSQL Azure server you create will automatically create a SecureString
 parameter for the admin account password.
 
+> There is support for newer "Flexible" as well as the original "Single Instance" server type.
+> Several keywords are overloaded to cater for both server types.
+
 * PostgreSQL server (`Microsoft.DBforPostgreSQL/servers`)
+* PostgreSQL server (`Microsoft.DBforPostgreSQL/flexibleServers`)
 
 #### PostgreSQL Builder keywords
 | Applies To | Keyword | Purpose |
@@ -26,6 +30,7 @@ parameter for the admin account password.
 | Server | enable_storage_autogrow | Enables auto-grow storage |
 | Server | disable_storage_autogrow | Disables auto-grow storage |
 | Server | storage_size (int&lt;Gb>) | Sets the initial size of the storage available |
+| Server | storage_performance_tier (Vm.DiskPerformanceTier) | Sets the storage performance tier of the server. |
 | Server | backup_retention (int&lt;Days>) | Sets the number of days to keep backups |
 | Server | server_version (Version) | Selects the PostgreSQL version of the server  |
 | Server | capacity (int&lt;VCores>) | Sets the number of cores for the server |
@@ -53,6 +58,8 @@ parameter for the admin account password.
 
 #### Example
 
+* Original "Single Instance" model
+
 ```fsharp
 open Farmer
 open Farmer.Builders
@@ -73,11 +80,23 @@ let template = arm {
     add_resource myPostgres
     output "fqdn" myPostgres.FullyQualifiedDomainName
 }
-
-// WARNING:
-// since there is currently no free tier for PostgreSQL, actually deploying this
-// *will* incur spending on your subscription.
-template
-|> Write.quickWrite "postgres-example"
 ```
 
+* "Flexible Server" model
+
+```fsharp
+open Farmer
+open Farmer.Builders
+open Farmer.PostgreSQL
+
+let myPostgres = postgreSQL {
+    name "aserverformultitudes42"
+    admin_username "adminallthethings"
+    storage_size 64<Gb>
+    tier FlexibleTier.Burstable_B1ms
+    storage_performance_tier Vm.DiskPerformanceTier.P10
+    add_database "my_db"
+    enable_azure_firewall
+    storage_autogrow true
+}
+```

--- a/samples/scripts/postgresql.fsx
+++ b/samples/scripts/postgresql.fsx
@@ -1,17 +1,24 @@
-#r "nuget:Farmer"
+#r "nuget: Farmer"
 
 open Farmer
 open Farmer.Builders
 open Farmer.PostgreSQL
 
 let myPostgres = postgreSQL {
-    name "aserverformultitudes42"
+    name "flexibleserver"
     admin_username "adminallthethings"
-    capacity 4<VCores>
-    storage_size 50<Gb>
-    tier GeneralPurpose
-    add_database "my_db"
+    storage_size 64<Gb>
+    storage_performance_tier Vm.DiskPerformanceTier.P10
+    tier FlexibleTier.Burstable_B1ms
     enable_azure_firewall
+    storage_autogrow true
+
+    add_database (
+        postgreSQLDb {
+            name "thedatabase"
+            collation "en_US.utf8"
+        }
+    )
 }
 
 let template = arm {

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -17,7 +17,7 @@ let virtualNetworkRules =
 let servers = ResourceType("Microsoft.DBforPostgreSQL/servers", "2017-12-01")
 
 let flexibleFirewallRules =
-    ResourceType("Microsoft.DBforPostgreSQL/flexibleservers/firewallrules", "2023-06-01-preview")
+    ResourceType("Microsoft.DBforPostgreSQL/flexibleServers/firewallrules", "2023-06-01-preview")
 
 let flexibleDatabases =
     ResourceType("Microsoft.DBforPostgreSQL/flexibleServers/databases", "2023-06-01-preview")

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -25,8 +25,6 @@ let flexibleDatabases =
 let flexibleServers =
     ResourceType("Microsoft.DBforPostgreSQL/flexibleServers", "2023-06-01-preview")
 
-
-
 type PostgreSQLFamily =
     | Gen5
 

--- a/src/Farmer/Arm/DBforPostgreSQL.fs
+++ b/src/Farmer/Arm/DBforPostgreSQL.fs
@@ -16,18 +16,23 @@ let virtualNetworkRules =
 
 let servers = ResourceType("Microsoft.DBforPostgreSQL/servers", "2017-12-01")
 
-[<RequireQualifiedAccess>]
+let flexibleFirewallRules =
+    ResourceType("Microsoft.DBforPostgreSQL/flexibleservers/firewallrules", "2023-06-01-preview")
+
+let flexibleDatabases =
+    ResourceType("Microsoft.DBforPostgreSQL/flexibleServers/databases", "2023-06-01-preview")
+
+let flexibleServers =
+    ResourceType("Microsoft.DBforPostgreSQL/flexibleServers", "2023-06-01-preview")
+
+
+
 type PostgreSQLFamily =
     | Gen5
-
-    override this.ToString() =
-        match this with
-        | Gen5 -> "Gen5"
 
     member this.AsArmValue =
         match this with
         | Gen5 -> "Gen5"
-
 
 module Servers =
     type Database = {
@@ -35,13 +40,18 @@ module Servers =
         Server: ResourceName
         Charset: string
         Collation: string
+        ResourceType: ResourceType
+        ServerType: ResourceType
     } with
 
         interface IArmResource with
-            member this.ResourceId = databases.resourceId (this.Server / this.Name)
+            member this.ResourceId = this.ResourceType.resourceId (this.Server / this.Name)
 
             member this.JsonModel = {|
-                databases.Create(this.Server / this.Name, dependsOn = [ servers.resourceId this.Server ]) with
+                this.ResourceType.Create(
+                    this.Server / this.Name,
+                    dependsOn = [ this.ServerType.resourceId this.Server ]
+                ) with
                     properties = {|
                         charset = this.Charset
                         collation = this.Collation
@@ -54,13 +64,19 @@ module Servers =
         Start: IPAddress
         End: IPAddress
         Location: Location
+        ResourceType: ResourceType
+        ServerType: ResourceType
     } with
 
         interface IArmResource with
-            member this.ResourceId = firewallRules.resourceId (this.Server / this.Name)
+            member this.ResourceId = this.ResourceType.resourceId (this.Server / this.Name)
 
             member this.JsonModel = {|
-                firewallRules.Create(this.Server / this.Name, this.Location, [ servers.resourceId this.Server ]) with
+                this.ResourceType.Create(
+                    this.Server / this.Name,
+                    this.Location,
+                    [ this.ServerType.resourceId this.Server ]
+                ) with
                     properties = {|
                         startIpAddress = string this.Start
                         endIpAddress = string this.End
@@ -94,43 +110,13 @@ type Server = {
     Version: Version
     Capacity: int<VCores>
     StorageSize: int<Mb>
-    Tier: Sku
+    Sku: Sku
     Family: PostgreSQLFamily
     GeoRedundantBackup: FeatureFlag
     StorageAutoGrow: FeatureFlag
     BackupRetention: int<Days>
     Tags: Map<string, string>
 } with
-
-    member this.Sku = {|
-        name = $"{this.Tier.Name}_{this.Family.AsArmValue}_{this.Capacity}"
-        tier = string this.Tier
-        capacity = this.Capacity
-        family = string this.Family
-        size = string this.StorageSize
-    |}
-
-    member this.GetStorageProfile() = {|
-        storageMB = this.StorageSize
-        backupRetentionDays = this.BackupRetention
-        geoRedundantBackup = string this.GeoRedundantBackup
-        storageAutoGrow = string this.StorageAutoGrow
-    |}
-
-    member this.GetProperties() =
-        let version =
-            match this.Version with
-            | VS_9_5 -> "9.5"
-            | VS_9_6 -> "9.6"
-            | VS_10 -> "10"
-            | VS_11 -> "11"
-
-        {|
-            administratorLogin = this.Credentials.Username
-            administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
-            version = version
-            storageProfile = this.GetStorageProfile()
-        |}
 
     interface IParameters with
         member this.SecureParameters = [ this.Credentials.Password ]
@@ -140,6 +126,83 @@ type Server = {
 
         member this.JsonModel = {|
             servers.Create(this.Name, this.Location, tags = (this.Tags |> Map.add "displayName" this.Name.Value)) with
-                sku = this.Sku
-                properties = this.GetProperties()
+                sku = {|
+                    name = $"{this.Sku.Name}_{this.Family.AsArmValue}_{this.Capacity}"
+                    tier = string this.Sku
+                    capacity = this.Capacity
+                    family = string this.Family
+                    size = string this.StorageSize
+                |}
+                properties =
+                    let version =
+                        match this.Version with
+                        | VS_9_5 -> "9.5"
+                        | VS_9_6 -> "9.6"
+                        | VS_10 -> "10"
+                        | VS_11 -> "11"
+
+                    {|
+                        administratorLogin = this.Credentials.Username
+                        administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
+                        version = version
+                        storageProfile = {|
+                            storageMB = this.StorageSize
+                            backupRetentionDays = this.BackupRetention
+                            geoRedundantBackup = string this.GeoRedundantBackup
+                            storageAutoGrow = string this.StorageAutoGrow
+                        |}
+                    |}
+        |}
+
+type FlexibleServer = {
+    Name: ResourceName
+    Location: Location
+    Credentials: {|
+        Username: string
+        Password: SecureParameter
+    |}
+    Version: FlexibleVersion
+    Tier: FlexibleTier
+    Storage: {|
+        Size: int<Gb>
+        AutoGrow: FeatureFlag
+        PerformanceTier: Vm.DiskPerformanceTier option
+    |}
+    Backup: {|
+        Retention: int<Days>
+        GeoRedundancy: FeatureFlag
+    |}
+    Tags: Map<string, string>
+} with
+
+    interface IParameters with
+        member this.SecureParameters = [ this.Credentials.Password ]
+
+    interface IArmResource with
+        member this.ResourceId = flexibleServers.resourceId this.Name
+
+        member this.JsonModel = {|
+            flexibleServers.Create(
+                this.Name,
+                this.Location,
+                tags = (this.Tags |> Map.add "displayName" this.Name.Value)
+            ) with
+                sku = {|
+                    name = this.Tier.VmSize.ArmValue
+                    tier = this.Tier.ArmValue
+                |}
+                properties = {|
+                    administratorLogin = this.Credentials.Username
+                    administratorLoginPassword = this.Credentials.Password.ArmExpression.Eval()
+                    version = this.Version.ArmValue
+                    backup = {|
+                        backupRetentionDays = this.Backup.Retention
+                        geoRedundantBackup = string this.Backup.GeoRedundancy
+                    |}
+                    Storage = {|
+                        StorageSizeGB = this.Storage.Size
+                        AutoGrow = this.Storage.AutoGrow.ArmValue
+                        tier = this.Storage.PerformanceTier |> Option.map _.ArmValue |> Option.toObj
+                    |}
+                |}
         |}

--- a/src/Farmer/Builders/Builders.PostgreSQL.fs
+++ b/src/Farmer/Builders/Builders.PostgreSQL.fs
@@ -303,7 +303,7 @@ let private mapFlexible f v =
 
 [<Literal>]
 let private SingleServerObsoleteMessage =
-    "Single Server is on the retirement path and is scheduled for retirement by March 28, 2025. Please upgrade to Flexible Server. For more information, see https://learn.microsoft.com/en-us/azure/postgresql/single-server/whats-happening-to-postgresql-single-server."
+    "Single Server is on the retirement path and is scheduled for retirement by March 28, 2025. For more information, see https://learn.microsoft.com/en-us/azure/postgresql/single-server/whats-happening-to-postgresql-single-server."
 
 type PostgreSQLBuilder() =
     member _.Yield _ : PostgreSQLConfig = {

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -151,6 +151,7 @@ type EnvVar =
 
 module Mb =
     let toBytes (mb: int<Mb>) = int64 mb * 1024L * 1024L
+    let toGb (mb: int<Mb>) = (mb / 1024<Mb>) * 1<Gb>
 
 module Route =
     type HopType =
@@ -895,6 +896,26 @@ module Vm =
             match this with
             | x -> x.ToString()
 
+    type DiskPerformanceTier =
+        | P1
+        | P2
+        | P3
+        | P4
+        | P6
+        | P10
+        | P15
+        | P20
+        | P30
+        | P40
+        | P50
+        | P60
+        | P70
+        | P80
+
+        member this.ArmValue =
+            match this with
+            | x -> x.ToString()
+
     /// Represents a disk in a VM.
     type DiskInfo = {
         Size: int
@@ -1055,25 +1076,25 @@ module internal Validation =
             Ok()
 
     let startsWith (message, predicate) entity (s: string) =
-        if not (predicate s.[0]) then
+        if not (predicate s[0]) then
             Error $"%s{entity} must start with %s{message}"
         else
             Ok()
 
     let endsWith (message, predicate) entity (s: string) =
-        if not (predicate s.[s.Length - 1]) then
+        if not (predicate s[s.Length - 1]) then
             Error $"%s{entity} must end with %s{message}"
         else
             Ok()
 
     let cannotStartWith (message, predicate) entity (s: string) =
-        if predicate s.[0] then
+        if predicate s[0] then
             Error $"%s{entity} cannot start with %s{message}"
         else
             Ok()
 
     let cannotEndWith (message, predicate) entity (s: string) =
-        if predicate s.[s.Length - 1] then
+        if predicate s[s.Length - 1] then
             Error $"%s{entity} cannot end with %s{message}"
         else
             Ok()
@@ -2090,7 +2111,7 @@ module Sql =
         /// Suffix name for server and database name
         NameSuffix: string
         /// Replication location, different from the original one
-        Location: Farmer.Location
+        Location: Location
         /// Override database Skus
         DbSku: DtuSku option
     }
@@ -2976,11 +2997,102 @@ module PostgreSQL =
             | GeneralPurpose -> "GP"
             | MemoryOptimized -> "MO"
 
+    type FlexibleTier =
+        | Burstable of Vm.VMSize
+        | GeneralPurpose of Vm.VMSize
+        | MemoryOptimized of Vm.VMSize
+
+        member this.VmSize =
+            match this with
+            | Burstable vmSize
+            | GeneralPurpose vmSize
+            | MemoryOptimized vmSize -> vmSize
+
+        member this.ArmValue =
+            match this with
+            | Burstable _ -> "Burstable"
+            | GeneralPurpose _ -> "GeneralPurpose"
+            | MemoryOptimized _ -> "MemoryOptimized"
+
+        static member Burstable_B1ms = Burstable Vm.VMSize.Standard_B1ms
+        static member Burstable_B2s = Burstable Vm.VMSize.Standard_B2s
+        static member Burstable_B2ms = Burstable Vm.VMSize.Standard_B2ms
+        static member Burstable_B4ms = Burstable Vm.VMSize.Standard_B4ms
+        static member Burstable_B8ms = Burstable Vm.VMSize.Standard_B8ms
+        static member Burstable_B12ms = Burstable Vm.VMSize.Standard_B12ms
+        static member Burstable_B16ms = Burstable Vm.VMSize.Standard_B16ms
+        static member Burstable_B20ms = Burstable Vm.VMSize.Standard_B20ms
+        static member GeneralPurpose_D2s_v3 = GeneralPurpose Vm.VMSize.Standard_D2s_v3
+        static member GeneralPurpose_D4s_v3 = GeneralPurpose Vm.VMSize.Standard_D4s_v3
+        static member GeneralPurpose_D8s_v3 = GeneralPurpose Vm.VMSize.Standard_D8s_v3
+        static member GeneralPurpose_D16s_v3 = GeneralPurpose Vm.VMSize.Standard_D16s_v3
+        static member GeneralPurpose_D32s_v3 = GeneralPurpose Vm.VMSize.Standard_D32s_v3
+        static member GeneralPurpose_D48s_v3 = GeneralPurpose Vm.VMSize.Standard_D48s_v3
+        static member GeneralPurpose_D64s_v3 = GeneralPurpose Vm.VMSize.Standard_D64s_v3
+        static member GeneralPurpose_D2ds_v4 = GeneralPurpose Vm.VMSize.Standard_D2ds_v4
+        static member GeneralPurpose_D4ds_v4 = GeneralPurpose Vm.VMSize.Standard_D4ds_v4
+        static member GeneralPurpose_D8ds_v4 = GeneralPurpose Vm.VMSize.Standard_D8ds_v4
+        static member GeneralPurpose_D16ds_v4 = GeneralPurpose Vm.VMSize.Standard_D16ds_v4
+        static member GeneralPurpose_D32ds_v4 = GeneralPurpose Vm.VMSize.Standard_D32ds_v4
+        static member GeneralPurpose_D48ds_v4 = GeneralPurpose Vm.VMSize.Standard_D48ds_v4
+        static member GeneralPurpose_D64ds_v4 = GeneralPurpose Vm.VMSize.Standard_D64ds_v4
+        static member GeneralPurpose_D2ds_v5 = GeneralPurpose Vm.VMSize.Standard_D2ds_v5
+        static member GeneralPurpose_D4ds_v5 = GeneralPurpose Vm.VMSize.Standard_D4ds_v5
+        static member GeneralPurpose_D8ds_v5 = GeneralPurpose Vm.VMSize.Standard_D8ds_v5
+        static member GeneralPurpose_D16ds_v5 = GeneralPurpose Vm.VMSize.Standard_D16ds_v5
+        static member GeneralPurpose_D32ds_v5 = GeneralPurpose Vm.VMSize.Standard_D32ds_v5
+        static member GeneralPurpose_D48ds_v5 = GeneralPurpose Vm.VMSize.Standard_D48ds_v5
+        static member GeneralPurpose_D64ds_v5 = GeneralPurpose Vm.VMSize.Standard_D64ds_v5
+        static member GeneralPurpose_D96ds_v5 = GeneralPurpose Vm.VMSize.Standard_D96ds_v5
+        static member MemoryOptimized_E2s_v3 = MemoryOptimized Vm.VMSize.Standard_E2s_v3
+        static member MemoryOptimized_E4s_v3 = MemoryOptimized Vm.VMSize.Standard_E4s_v3
+        static member MemoryOptimized_E8s_v3 = MemoryOptimized Vm.VMSize.Standard_E8s_v3
+        static member MemoryOptimized_E16s_v3 = MemoryOptimized Vm.VMSize.Standard_E16s_v3
+        static member MemoryOptimized_E32s_v3 = MemoryOptimized Vm.VMSize.Standard_E32s_v3
+        static member MemoryOptimized_E48s_v3 = MemoryOptimized Vm.VMSize.Standard_E48s_v3
+        static member MemoryOptimized_E64s_v3 = MemoryOptimized Vm.VMSize.Standard_E64s_v3
+        static member MemoryOptimized_E2ds_v4 = MemoryOptimized Vm.VMSize.Standard_E2ds_v4
+        static member MemoryOptimized_E4ds_v4 = MemoryOptimized Vm.VMSize.Standard_E4ds_v4
+        static member MemoryOptimized_E8ds_v4 = MemoryOptimized Vm.VMSize.Standard_E8ds_v4
+        static member MemoryOptimized_E16ds_v4 = MemoryOptimized Vm.VMSize.Standard_E16ds_v4
+        static member MemoryOptimized_E20ds_v4 = MemoryOptimized Vm.VMSize.Standard_E20ds_v4
+        static member MemoryOptimized_E32ds_v4 = MemoryOptimized Vm.VMSize.Standard_E32ds_v4
+        static member MemoryOptimized_E48ds_v4 = MemoryOptimized Vm.VMSize.Standard_E48ds_v4
+        static member MemoryOptimized_E64ds_v4 = MemoryOptimized Vm.VMSize.Standard_E64ds_v4
+        static member MemoryOptimized_E2ds_v5 = MemoryOptimized Vm.VMSize.Standard_E2ds_v5
+        static member MemoryOptimized_E4ds_v5 = MemoryOptimized Vm.VMSize.Standard_E4ds_v5
+        static member MemoryOptimized_E8ds_v5 = MemoryOptimized Vm.VMSize.Standard_E8ds_v5
+        static member MemoryOptimized_E16ds_v5 = MemoryOptimized Vm.VMSize.Standard_E16ds_v5
+        static member MemoryOptimized_E20ds_v5 = MemoryOptimized Vm.VMSize.Standard_E20ds_v5
+        static member MemoryOptimized_E32ds_v5 = MemoryOptimized Vm.VMSize.Standard_E32ds_v5
+        static member MemoryOptimized_E48ds_v5 = MemoryOptimized Vm.VMSize.Standard_E48ds_v5
+        static member MemoryOptimized_E64ds_v5 = MemoryOptimized Vm.VMSize.Standard_E64ds_v5
+        static member MemoryOptimized_E96ds_v5 = MemoryOptimized Vm.VMSize.Standard_E96ds_v5
+
     type Version =
         | VS_9_5
         | VS_9_6
         | VS_10
         | VS_11
+
+    type FlexibleVersion =
+        | V_11
+        | V_12
+        | V_13
+        | V_14
+        | V_15
+        | V_16
+        | Custom of string
+
+        member this.ArmValue =
+            match this with
+            | V_11 -> "11"
+            | V_12 -> "12"
+            | V_13 -> "13"
+            | V_14 -> "14"
+            | V_15 -> "15"
+            | V_16 -> "16"
+            | Custom v -> v
 
 module IotHub =
     type Sku =
@@ -3702,28 +3814,28 @@ module AvailabilityTest =
         /// Raw Visual Stuido WebTest XML
         | CustomWebtestXml of string
         /// URL of website that the test will ping
-        | WebsiteUrl of System.Uri
+        | WebsiteUrl of Uri
 
     /// Availability test sites, from where the webtest is run
     type TestSiteLocation =
-        | AvailabilityTestSite of Farmer.Location
+        | AvailabilityTestSite of Location
 
-        static member NorthCentralUS = Farmer.Location "us-il-ch1-azr" |> AvailabilityTestSite
-        static member WestEurope = Farmer.Location "emea-nl-ams-azr" |> AvailabilityTestSite
-        static member SoutheastAsia = Farmer.Location "apac-sg-sin-azr" |> AvailabilityTestSite
-        static member WestUS = Farmer.Location "us-ca-sjc-azr" |> AvailabilityTestSite
-        static member SouthCentralUS = Farmer.Location "us-tx-sn1-azr" |> AvailabilityTestSite
-        static member EastUS = Farmer.Location "us-va-ash-azr" |> AvailabilityTestSite
-        static member EastAsia = Farmer.Location "apac-hk-hkn-azr" |> AvailabilityTestSite
-        static member NorthEurope = Farmer.Location "emea-gb-db3-azr" |> AvailabilityTestSite
-        static member JapanEast = Farmer.Location "apac-jp-kaw-edge" |> AvailabilityTestSite
-        static member AustraliaEast = Farmer.Location "emea-au-syd-edge" |> AvailabilityTestSite
-        static member FranceCentralSouth = Farmer.Location "emea-ch-zrh-edge" |> AvailabilityTestSite
-        static member FranceCentral = Farmer.Location "emea-fr-pra-edge" |> AvailabilityTestSite
-        static member UKSouth = Farmer.Location "emea-ru-msa-edge" |> AvailabilityTestSite
-        static member UKWest = Farmer.Location "emea-se-sto-edge" |> AvailabilityTestSite
-        static member BrazilSouth = Farmer.Location "latam-br-gru-edge" |> AvailabilityTestSite
-        static member CentralUS = Farmer.Location "us-fl-mia-edge" |> AvailabilityTestSite
+        static member NorthCentralUS = Location "us-il-ch1-azr" |> AvailabilityTestSite
+        static member WestEurope = Location "emea-nl-ams-azr" |> AvailabilityTestSite
+        static member SoutheastAsia = Location "apac-sg-sin-azr" |> AvailabilityTestSite
+        static member WestUS = Location "us-ca-sjc-azr" |> AvailabilityTestSite
+        static member SouthCentralUS = Location "us-tx-sn1-azr" |> AvailabilityTestSite
+        static member EastUS = Location "us-va-ash-azr" |> AvailabilityTestSite
+        static member EastAsia = Location "apac-hk-hkn-azr" |> AvailabilityTestSite
+        static member NorthEurope = Location "emea-gb-db3-azr" |> AvailabilityTestSite
+        static member JapanEast = Location "apac-jp-kaw-edge" |> AvailabilityTestSite
+        static member AustraliaEast = Location "emea-au-syd-edge" |> AvailabilityTestSite
+        static member FranceCentralSouth = Location "emea-ch-zrh-edge" |> AvailabilityTestSite
+        static member FranceCentral = Location "emea-fr-pra-edge" |> AvailabilityTestSite
+        static member UKSouth = Location "emea-ru-msa-edge" |> AvailabilityTestSite
+        static member UKWest = Location "emea-se-sto-edge" |> AvailabilityTestSite
+        static member BrazilSouth = Location "latam-br-gru-edge" |> AvailabilityTestSite
+        static member CentralUS = Location "us-fl-mia-edge" |> AvailabilityTestSite
 
 module ContainerApp =
     //type SecretRef = SecretRef of string

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -2986,6 +2986,8 @@ module CosmosDb =
         | Serverless
 
 module PostgreSQL =
+    open Vm
+
     type Sku =
         | Basic
         | GeneralPurpose
@@ -2998,9 +3000,12 @@ module PostgreSQL =
             | MemoryOptimized -> "MO"
 
     type FlexibleTier =
-        | Burstable of Vm.VMSize
-        | GeneralPurpose of Vm.VMSize
-        | MemoryOptimized of Vm.VMSize
+        /// Workloads that don't need the full CPU continuously.
+        | Burstable of VMSize
+        /// Most business workloads that require balanced compute and memory with scalable I/O throughput. Examples include servers for hosting web and mobile apps and other enterprise applications.
+        | GeneralPurpose of VMSize
+        /// High-performance database workloads that require in-memory performance for faster transaction processing and higher concurrency. Examples include servers for processing real-time data and high-performance transactional or analytical apps.
+        | MemoryOptimized of VMSize
 
         member this.VmSize =
             match this with
@@ -3014,60 +3019,114 @@ module PostgreSQL =
             | GeneralPurpose _ -> "GeneralPurpose"
             | MemoryOptimized _ -> "MemoryOptimized"
 
-        static member Burstable_B1ms = Burstable Vm.VMSize.Standard_B1ms
-        static member Burstable_B2s = Burstable Vm.VMSize.Standard_B2s
-        static member Burstable_B2ms = Burstable Vm.VMSize.Standard_B2ms
-        static member Burstable_B4ms = Burstable Vm.VMSize.Standard_B4ms
-        static member Burstable_B8ms = Burstable Vm.VMSize.Standard_B8ms
-        static member Burstable_B12ms = Burstable Vm.VMSize.Standard_B12ms
-        static member Burstable_B16ms = Burstable Vm.VMSize.Standard_B16ms
-        static member Burstable_B20ms = Burstable Vm.VMSize.Standard_B20ms
-        static member GeneralPurpose_D2s_v3 = GeneralPurpose Vm.VMSize.Standard_D2s_v3
-        static member GeneralPurpose_D4s_v3 = GeneralPurpose Vm.VMSize.Standard_D4s_v3
-        static member GeneralPurpose_D8s_v3 = GeneralPurpose Vm.VMSize.Standard_D8s_v3
-        static member GeneralPurpose_D16s_v3 = GeneralPurpose Vm.VMSize.Standard_D16s_v3
-        static member GeneralPurpose_D32s_v3 = GeneralPurpose Vm.VMSize.Standard_D32s_v3
-        static member GeneralPurpose_D48s_v3 = GeneralPurpose Vm.VMSize.Standard_D48s_v3
-        static member GeneralPurpose_D64s_v3 = GeneralPurpose Vm.VMSize.Standard_D64s_v3
-        static member GeneralPurpose_D2ds_v4 = GeneralPurpose Vm.VMSize.Standard_D2ds_v4
-        static member GeneralPurpose_D4ds_v4 = GeneralPurpose Vm.VMSize.Standard_D4ds_v4
-        static member GeneralPurpose_D8ds_v4 = GeneralPurpose Vm.VMSize.Standard_D8ds_v4
-        static member GeneralPurpose_D16ds_v4 = GeneralPurpose Vm.VMSize.Standard_D16ds_v4
-        static member GeneralPurpose_D32ds_v4 = GeneralPurpose Vm.VMSize.Standard_D32ds_v4
-        static member GeneralPurpose_D48ds_v4 = GeneralPurpose Vm.VMSize.Standard_D48ds_v4
-        static member GeneralPurpose_D64ds_v4 = GeneralPurpose Vm.VMSize.Standard_D64ds_v4
-        static member GeneralPurpose_D2ds_v5 = GeneralPurpose Vm.VMSize.Standard_D2ds_v5
-        static member GeneralPurpose_D4ds_v5 = GeneralPurpose Vm.VMSize.Standard_D4ds_v5
-        static member GeneralPurpose_D8ds_v5 = GeneralPurpose Vm.VMSize.Standard_D8ds_v5
-        static member GeneralPurpose_D16ds_v5 = GeneralPurpose Vm.VMSize.Standard_D16ds_v5
-        static member GeneralPurpose_D32ds_v5 = GeneralPurpose Vm.VMSize.Standard_D32ds_v5
-        static member GeneralPurpose_D48ds_v5 = GeneralPurpose Vm.VMSize.Standard_D48ds_v5
-        static member GeneralPurpose_D64ds_v5 = GeneralPurpose Vm.VMSize.Standard_D64ds_v5
-        static member GeneralPurpose_D96ds_v5 = GeneralPurpose Vm.VMSize.Standard_D96ds_v5
-        static member MemoryOptimized_E2s_v3 = MemoryOptimized Vm.VMSize.Standard_E2s_v3
-        static member MemoryOptimized_E4s_v3 = MemoryOptimized Vm.VMSize.Standard_E4s_v3
-        static member MemoryOptimized_E8s_v3 = MemoryOptimized Vm.VMSize.Standard_E8s_v3
-        static member MemoryOptimized_E16s_v3 = MemoryOptimized Vm.VMSize.Standard_E16s_v3
-        static member MemoryOptimized_E32s_v3 = MemoryOptimized Vm.VMSize.Standard_E32s_v3
-        static member MemoryOptimized_E48s_v3 = MemoryOptimized Vm.VMSize.Standard_E48s_v3
-        static member MemoryOptimized_E64s_v3 = MemoryOptimized Vm.VMSize.Standard_E64s_v3
-        static member MemoryOptimized_E2ds_v4 = MemoryOptimized Vm.VMSize.Standard_E2ds_v4
-        static member MemoryOptimized_E4ds_v4 = MemoryOptimized Vm.VMSize.Standard_E4ds_v4
-        static member MemoryOptimized_E8ds_v4 = MemoryOptimized Vm.VMSize.Standard_E8ds_v4
-        static member MemoryOptimized_E16ds_v4 = MemoryOptimized Vm.VMSize.Standard_E16ds_v4
-        static member MemoryOptimized_E20ds_v4 = MemoryOptimized Vm.VMSize.Standard_E20ds_v4
-        static member MemoryOptimized_E32ds_v4 = MemoryOptimized Vm.VMSize.Standard_E32ds_v4
-        static member MemoryOptimized_E48ds_v4 = MemoryOptimized Vm.VMSize.Standard_E48ds_v4
-        static member MemoryOptimized_E64ds_v4 = MemoryOptimized Vm.VMSize.Standard_E64ds_v4
-        static member MemoryOptimized_E2ds_v5 = MemoryOptimized Vm.VMSize.Standard_E2ds_v5
-        static member MemoryOptimized_E4ds_v5 = MemoryOptimized Vm.VMSize.Standard_E4ds_v5
-        static member MemoryOptimized_E8ds_v5 = MemoryOptimized Vm.VMSize.Standard_E8ds_v5
-        static member MemoryOptimized_E16ds_v5 = MemoryOptimized Vm.VMSize.Standard_E16ds_v5
-        static member MemoryOptimized_E20ds_v5 = MemoryOptimized Vm.VMSize.Standard_E20ds_v5
-        static member MemoryOptimized_E32ds_v5 = MemoryOptimized Vm.VMSize.Standard_E32ds_v5
-        static member MemoryOptimized_E48ds_v5 = MemoryOptimized Vm.VMSize.Standard_E48ds_v5
-        static member MemoryOptimized_E64ds_v5 = MemoryOptimized Vm.VMSize.Standard_E64ds_v5
-        static member MemoryOptimized_E96ds_v5 = MemoryOptimized Vm.VMSize.Standard_E96ds_v5
+        /// 1 cores, max 640 IOPs & 2048 MB per core.
+        static member Burstable_B1ms = Burstable Standard_B1ms
+        /// 2 cores, max 1280 IOPs & 2048 MB per core.
+        static member Burstable_B2s = Burstable Standard_B2s
+        /// 2 cores, max 1920 IOPs & 4096 MB per core.
+        static member Burstable_B2ms = Burstable Standard_B2ms
+        /// 4 cores, max 2880 IOPs & 4096 MB per core.
+        static member Burstable_B4ms = Burstable Standard_B4ms
+        /// 8 cores, max 4320 IOPs & 4096 MB per core.
+        static member Burstable_B8ms = Burstable Standard_B8ms
+        /// 12 cores, max 4320 IOPs & 4096 MB per core.
+        static member Burstable_B12ms = Burstable Standard_B12ms
+        /// 16 cores, max 4320 IOPs & 4096 MB per core.
+        static member Burstable_B16ms = Burstable Standard_B16ms
+        /// 20 cores, max 4320 IOPs & 4096 MB per core.
+        static member Burstable_B20ms = Burstable Standard_B20ms
+        /// 2 cores, max 3200 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D2s_v3 = GeneralPurpose Standard_D2s_v3
+        /// 4 cores, max 6400 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D4s_v3 = GeneralPurpose Standard_D4s_v3
+        /// 8 cores, max 12800 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D8s_v3 = GeneralPurpose Standard_D8s_v3
+        /// 16 cores, max 25600 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D16s_v3 = GeneralPurpose Standard_D16s_v3
+        /// 32 cores, max 51200 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D32s_v3 = GeneralPurpose Standard_D32s_v3
+        /// 48 cores, max 76800 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D48s_v3 = GeneralPurpose Standard_D48s_v3
+        /// 64 cores, max 80000 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D64s_v3 = GeneralPurpose Standard_D64s_v3
+        /// 2 cores, max 3200 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D2ds_v4 = GeneralPurpose Standard_D2ds_v4
+        /// 4 cores, max 6400 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D4ds_v4 = GeneralPurpose Standard_D4ds_v4
+        /// 8 cores, max 12800 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D8ds_v4 = GeneralPurpose Standard_D8ds_v4
+        /// 16 cores, max 25600 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D16ds_v4 = GeneralPurpose Standard_D16ds_v4
+        /// 32 cores, max 51200 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D32ds_v4 = GeneralPurpose Standard_D32ds_v4
+        /// 48 cores, max 76800 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D48ds_v4 = GeneralPurpose Standard_D48ds_v4
+        /// 64 cores, max 80000 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D64ds_v4 = GeneralPurpose Standard_D64ds_v4
+        /// 2 cores, max 3750 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D2ds_v5 = GeneralPurpose Standard_D2ds_v5
+        /// 4 cores, max 6400 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D4ds_v5 = GeneralPurpose Standard_D4ds_v5
+        /// 8 cores, max 12800 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D8ds_v5 = GeneralPurpose Standard_D8ds_v5
+        /// 16 cores, max 25600 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D16ds_v5 = GeneralPurpose Standard_D16ds_v5
+        /// 32 cores, max 51200 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D32ds_v5 = GeneralPurpose Standard_D32ds_v5
+        /// 48 cores, max 76800 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D48ds_v5 = GeneralPurpose Standard_D48ds_v5
+        /// 64 cores, max 80000 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D64ds_v5 = GeneralPurpose Standard_D64ds_v5
+        /// 96 cores, max 80000 IOPs & 4096 MB per core.
+        static member GeneralPurpose_D96ds_v5 = GeneralPurpose Standard_D96ds_v5
+        /// 2 cores, max 3200 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E2s_v3 = MemoryOptimized Standard_E2s_v3
+        /// 4 cores, max 6400 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E4s_v3 = MemoryOptimized Standard_E4s_v3
+        /// 8 cores, max 12800 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E8s_v3 = MemoryOptimized Standard_E8s_v3
+        /// 16 cores, max 25600 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E16s_v3 = MemoryOptimized Standard_E16s_v3
+        /// 32 cores, max 32000 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E32s_v3 = MemoryOptimized Standard_E32s_v3
+        /// 48 cores, max 51200 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E48s_v3 = MemoryOptimized Standard_E48s_v3
+        /// 64 cores, max 76800 IOPs & 6912 MB per core.
+        static member MemoryOptimized_E64s_v3 = MemoryOptimized Standard_E64s_v3
+        /// 2 cores, max 3200 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E2ds_v4 = MemoryOptimized Standard_E2ds_v4
+        /// 4 cores, max 6400 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E4ds_v4 = MemoryOptimized Standard_E4ds_v4
+        /// 8 cores, max 12800 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E8ds_v4 = MemoryOptimized Standard_E8ds_v4
+        /// 16 cores, max 25600 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E16ds_v4 = MemoryOptimized Standard_E16ds_v4
+        /// 20 cores, max 32000 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E20ds_v4 = MemoryOptimized Standard_E20ds_v4
+        /// 32 cores, max 51200 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E32ds_v4 = MemoryOptimized Standard_E32ds_v4
+        /// 48 cores, max 76800 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E48ds_v4 = MemoryOptimized Standard_E48ds_v4
+        /// 64 cores, max 80000 IOPs & 6912 MB per core.
+        static member MemoryOptimized_E64ds_v4 = MemoryOptimized Standard_E64ds_v4
+        /// 2 cores, max 3750 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E2ds_v5 = MemoryOptimized Standard_E2ds_v5
+        /// 4 cores, max 6400 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E4ds_v5 = MemoryOptimized Standard_E4ds_v5
+        /// 8 cores, max 12800 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E8ds_v5 = MemoryOptimized Standard_E8ds_v5
+        /// 16 cores, max 25600 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E16ds_v5 = MemoryOptimized Standard_E16ds_v5
+        /// 20 cores, max 32000 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E20ds_v5 = MemoryOptimized Standard_E20ds_v5
+        /// 32 cores, max 51200 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E32ds_v5 = MemoryOptimized Standard_E32ds_v5
+        /// 48 cores, max 76800 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E48ds_v5 = MemoryOptimized Standard_E48ds_v5
+        /// 64 cores, max 80000 IOPs & 8192 MB per core.
+        static member MemoryOptimized_E64ds_v5 = MemoryOptimized Standard_E64ds_v5
+        /// 96 cores, max 80000 IOPs & 7168 MB per core.
+        static member MemoryOptimized_E96ds_v5 = MemoryOptimized Standard_E96ds_v5
 
     type Version =
         | VS_9_5

--- a/src/Farmer/Deploy.fs
+++ b/src/Farmer/Deploy.fs
@@ -248,7 +248,7 @@ module Az =
                 "Deployment failed. Correlation ID: 3c51a527-c6e2-42a9-acee-7d9c796a626f. "
                     .Length
 
-            match Serialization.ofJson<AzureError> error.[skip..] with
+            match Serialization.ofJson<AzureError> error[skip..] with
             | {
                   Error = {
                               Code = "RoleAssignmentExists"

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -1,196 +1,196 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- General -->
-    <AssemblyName>Farmer</AssemblyName>
-    <Version>1.8.13</Version>
-    <Description>Farmer makes authoring ARM templates easy!</Description>
-    <Copyright>Copyright 2019-2024 Compositional IT Ltd.</Copyright>
-    <Company>Compositional IT</Company>
-    <Authors>Isaac Abraham and contributors</Authors>
+    <PropertyGroup>
+        <!-- General -->
+        <AssemblyName>Farmer</AssemblyName>
+        <Version>1.8.13</Version>
+        <Description>Farmer makes authoring ARM templates easy!</Description>
+        <Copyright>Copyright 2019-2024 Compositional IT Ltd.</Copyright>
+        <Company>Compositional IT</Company>
+        <Authors>Isaac Abraham and contributors</Authors>
 
-    <!-- Build settings -->
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <DebugType>portable</DebugType>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <!-- Build settings -->
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <DebugType>portable</DebugType>
+        <OutputType>Library</OutputType>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <!-- NuGet Pack settings -->
-    <PackageId>Farmer</PackageId>
-    <PackageIcon>Icon.jpg</PackageIcon>
-    <PackageTags>azure;resource-manager;template;dsl;fsharp;infrastructure-as-code</PackageTags>
-    <PackageReleaseNotes>https://raw.githubusercontent.com/CompositionalIT/farmer/master/RELEASE_NOTES.md</PackageReleaseNotes>
-    <PackageProjectUrl>https://compositionalit.github.io/farmer</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>readme.md</PackageReadmeFile>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/CompositionalIT/farmer</RepositoryUrl>
+        <!-- NuGet Pack settings -->
+        <PackageId>Farmer</PackageId>
+        <PackageIcon>Icon.jpg</PackageIcon>
+        <PackageTags>azure;resource-manager;template;dsl;fsharp;infrastructure-as-code</PackageTags>
+        <PackageReleaseNotes>https://raw.githubusercontent.com/CompositionalIT/farmer/master/RELEASE_NOTES.md</PackageReleaseNotes>
+        <PackageProjectUrl>https://compositionalit.github.io/farmer</PackageProjectUrl>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/CompositionalIT/farmer</RepositoryUrl>
 
-    <!-- SourceLink settings -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-  </PropertyGroup>
+        <!-- SourceLink settings -->
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    </PropertyGroup>
 
-  <!-- Normalize paths to sources in symbols when built in Azure Pipelines -->
-  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
+    <!-- Normalize paths to sources in symbols when built in Azure Pipelines -->
+    <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" Version="5" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="../../Icon.jpg">
-      <Pack>true</Pack>
-      <PackagePath>$(PackageIconUrl)</PackagePath>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="5.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="System.Text.Json" Version="5" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="../../Icon.jpg">
+            <Pack>true</Pack>
+            <PackagePath>$(PackageIconUrl)</PackagePath>
+        </None>
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="../../LICENSE" Pack="true" PackagePath="" />
-    <None Include="../../readme.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="../../LICENSE" Pack="true" PackagePath="" />
+        <None Include="../../readme.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="Result.fs" />
-    <Compile Include="Types.fs" />
-    <Compile Include="Common.fs" />
-    <Compile Include="DiagnosticLogCategories.fs" />
+    <ItemGroup>
+        <Compile Include="Result.fs" />
+        <Compile Include="Types.fs" />
+        <Compile Include="Common.fs" />
+        <Compile Include="DiagnosticLogCategories.fs" />
 
-    <Compile Include="Writer.fs" />
-    <Compile Include="Deploy.fs" />
-    <Compile Include="Arm\ActionGroup.fs" />
-    <Compile Include="Arm\AutomationAccount.fs" />
-    <Compile Include="Arm\AutoscaleSettings.fs" />
-    <Compile Include="Arm\ResourceGroup.fs" />
+        <Compile Include="Writer.fs" />
+        <Compile Include="Deploy.fs" />
+        <Compile Include="Arm\ActionGroup.fs" />
+        <Compile Include="Arm\AutomationAccount.fs" />
+        <Compile Include="Arm\AutoscaleSettings.fs" />
+        <Compile Include="Arm\ResourceGroup.fs" />
 
-    <Compile Include="Arm/DiagnosticSetting.fs" />
-    <Compile Include="Arm/ManagedIdentity.fs" />
-    <Compile Include="Arm/LogAnalytics.fs" />
-    <Compile Include="Arm\Alert.fs" />
-    <Compile Include="Arm/Storage.fs" />
-    <Compile Include="Arm/Cache.fs" />
-    <Compile Include="Arm/Cdn.fs" />
-    <Compile Include="Arm/CognitiveServices.fs" />
-    <Compile Include="Arm/CommunicationServices.fs" />
-    <Compile Include="Arm/BingSearch.fs" />
-    <Compile Include="Arm/Dns.fs" />
-    <Compile Include="Arm\AVS.fs" />
-    <Compile Include="Arm\Network.fs" />
-    <Compile Include="Arm/Bastion.fs" />
-    <Compile Include="Arm/Compute.fs" />
-    <Compile Include="Arm/ContainerInstance.fs" />
-    <Compile Include="Arm/ContainerRegistry.fs" />
-    <Compile Include="Arm/ContainerService.fs" />
-    <Compile Include="Arm/DataLakeStore.fs" />
-    <Compile Include="Arm/DBforPostgreSQL.fs" />
-    <Compile Include="Arm/Devices.fs" />
-    <Compile Include="Arm/Disk.fs" />
-    <Compile Include="Arm/DocumentDb.fs" />
-    <Compile Include="Arm/EventHub.fs" />
-    <Compile Include="Arm/Gallery.fs" />
-    <Compile Include="Arm/ImageTemplate.fs" />
-    <Compile Include="Arm/Insights.fs" />
-    <Compile Include="Arm\AvailabilityTest.fs" />
-    <Compile Include="Arm/KeyVault.fs" />
-    <Compile Include="Arm\LoadBalancer.fs" />
-    <Compile Include="Arm\PrivateLinkService.fs" />
-    <Compile Include="Arm/RoleAssignment.fs" />
-    <Compile Include="Arm/Search.fs" />
-    <Compile Include="Arm/ServiceBus.fs" />
-    <Compile Include="Arm/Sql.fs" />
-    <Compile Include="Arm/App.fs" />
-    <Compile Include="Arm/Web.fs" />
-    <Compile Include="Arm/Maps.fs" />
-    <Compile Include="Arm/SignalR.fs" />
-    <Compile Include="Arm/EventGrid.fs" />
-    <Compile Include="Arm/NetworkSecurityGroup.fs" />
-    <Compile Include="Arm/DeploymentScript.fs" />
-    <Compile Include="Arm/Databricks.fs" />
-    <Compile Include="Arm/VirtualWan.fs" />
-    <Compile Include="Arm/TrafficManager.fs" />
-    <Compile Include="Arm/AzureFirewall.fs" />
-    <Compile Include="Arm/ApplicationGateway.fs" />
-    <Compile Include="Arm/VirtualHub.fs" />
-    <Compile Include="Arm\Dashboard.fs" />
-    <Compile Include="Arm/LogicApps.fs" />
-    <Compile Include="Arm/OperationsManagement.fs" />
-    <Compile Include="Arm\Webhook.fs" />
-    <Compile Include="Arm\B2cTenant.fs" />
-    <Compile Include="IdentityExtensions.fs" />
-    <Compile Include="Builders/Extensions.fs" />
-    <Compile Include="Builders\Builders.ActionGroup.fs" />
-    <Compile Include="Builders\Builders.AutoscaleSettings.fs" />
-    <Compile Include="Builders\Builders.B2cTenant.fs" />
-    <Compile Include="Builders/Builders.UserAssignedIdentity.fs" />
-    <Compile Include="Builders/Builders.ResourceGroup.fs" />
-    <Compile Include="Builders/Builders.LogAnalytics.fs" />
-    <Compile Include="Builders/Builders.Helpers.fs" />
-    <Compile Include="Builders\Builders.Alert.fs" />
-    <Compile Include="Builders/Builders.PostgreSQL.fs" />
-    <Compile Include="Builders/Builders.Cdn.fs" />
-    <Compile Include="Builders\Builders.Storage.fs" />
-    <Compile Include="Builders/Builders.AppInsights.fs" />
-    <Compile Include="Builders\Builders.ServiceBus.fs" />
-    <Compile Include="Builders\Builders.ContainerApps.fs" />
-    <Compile Include="Builders/Builders.ContainerGroups.fs" />
-    <Compile Include="Builders/Builders.ContainerService.fs" />
-    <Compile Include="Builders/Builders.DataLake.fs" />
-    <Compile Include="Builders/Builders.DeploymentScript.fs" />
-    <Compile Include="Builders/Builders.Disk.fs" />
-    <Compile Include="Builders/Builders.Dns.fs" />
-    <Compile Include="Builders\Builders.DnsResolver.fs" />
-    <Compile Include="Builders/Builders.Gallery.fs" />
-    <Compile Include="Builders/Builders.ImageTemplate.fs" />
-    <Compile Include="Builders/Builders.Redis.fs" />
-    <Compile Include="Builders/Builders.KeyVault.fs" />
-    <Compile Include="Builders/Builders.Bastion.fs" />
-    <Compile Include="Builders\Builders.NatGateway.fs" />
-    <Compile Include="Builders\Builders.NetworkSecurityGroup.fs" />
-    <Compile Include="Builders/Builders.VirtualNetwork.fs" />
-    <Compile Include="Builders\Builders.LoadBalancer.fs" />
-    <Compile Include="Builders/Builders.Vm.fs" />
-    <Compile Include="Builders/Builders.VmScaleSet.fs" />
-    <Compile Include="Builders/Builders.ServicePlan.fs" />
-    <Compile Include="Builders\Builders.AvailabilityTest.fs" />
-    <Compile Include="Builders/Builders.WebApp.fs" />
-    <Compile Include="Builders/Builders.Functions.fs" />
-    <Compile Include="Builders/Builders.Sql.fs" />
-    <Compile Include="Builders/Builders.Search.fs" />
-    <Compile Include="Builders/Builders.Cosmos.fs" />
-    <Compile Include="Builders/Builders.EventHub.fs" />
-    <Compile Include="Builders/Builders.ExpressRoute.fs" />
-    <Compile Include="Builders/Builders.CognitiveServices.fs" />
-    <Compile Include="Builders/Builders.CommunicationServices.fs" />
-    <Compile Include="Builders/Builders.BingSearch.fs" />
-    <Compile Include="Builders/Builders.ContainerRegistry.fs" />
-    <Compile Include="Builders/Builders.IotHub.fs" />
-    <Compile Include="Builders/Builders.Maps.fs" />
-    <Compile Include="Builders/Builders.SignalR.fs" />
-    <Compile Include="Builders/Builders.VirtualNetworkGateway.fs" />
-    <Compile Include="Builders/Builders.EventGrid.fs" />
-    <Compile Include="Builders/Builders.StaticWebApp.fs" />
-    <Compile Include="Builders/Builders.Databricks.fs" />
-    <Compile Include="Builders/Builders.DiagnosticSetting.fs" />
-    <Compile Include="Builders/Builders.VirtualWan.fs" />
-    <Compile Include="Builders/Builders.TrafficManager.fs" />
-    <Compile Include="Builders/Builders.VirtualHub.fs" />
-    <Compile Include="Builders/Builders.AzureFirewall.fs" />
-    <Compile Include="Builders\Builders.Dashboard.fs" />
-    <Compile Include="Builders/Builders.ApplicationGateway.fs" />
-    <Compile Include="Builders/Builders.LogicApps.fs" />
-    <Compile Include="Builders/Builders.OperationsManagement.fs" />
-    <Compile Include="Builders\Builders.PrivateLink.fs" />
-    <Compile Include="Builders\Builders.PrivateEndpoint.fs" />
-    <Compile Include="Builders\Builders.RouteTable.fs" />
-    <Compile Include="Builders\Builders.HostGroup.fs" />
-    <Compile Include="Builders\Builders.NetworkInterface.fs" />
-    <Compile Include="Builders\Builders.RouteServer.fs" />
-    <Compile Include="Aliases.fs" />
-  </ItemGroup>
+        <Compile Include="Arm/DiagnosticSetting.fs" />
+        <Compile Include="Arm/ManagedIdentity.fs" />
+        <Compile Include="Arm/LogAnalytics.fs" />
+        <Compile Include="Arm\Alert.fs" />
+        <Compile Include="Arm/Storage.fs" />
+        <Compile Include="Arm/Cache.fs" />
+        <Compile Include="Arm/Cdn.fs" />
+        <Compile Include="Arm/CognitiveServices.fs" />
+        <Compile Include="Arm/CommunicationServices.fs" />
+        <Compile Include="Arm/BingSearch.fs" />
+        <Compile Include="Arm/Dns.fs" />
+        <Compile Include="Arm\AVS.fs" />
+        <Compile Include="Arm\Network.fs" />
+        <Compile Include="Arm/Bastion.fs" />
+        <Compile Include="Arm/Compute.fs" />
+        <Compile Include="Arm/ContainerInstance.fs" />
+        <Compile Include="Arm/ContainerRegistry.fs" />
+        <Compile Include="Arm/ContainerService.fs" />
+        <Compile Include="Arm/DataLakeStore.fs" />
+        <Compile Include="Arm/DBforPostgreSQL.fs" />
+        <Compile Include="Arm/Devices.fs" />
+        <Compile Include="Arm/Disk.fs" />
+        <Compile Include="Arm/DocumentDb.fs" />
+        <Compile Include="Arm/EventHub.fs" />
+        <Compile Include="Arm/Gallery.fs" />
+        <Compile Include="Arm/ImageTemplate.fs" />
+        <Compile Include="Arm/Insights.fs" />
+        <Compile Include="Arm\AvailabilityTest.fs" />
+        <Compile Include="Arm/KeyVault.fs" />
+        <Compile Include="Arm\LoadBalancer.fs" />
+        <Compile Include="Arm\PrivateLinkService.fs" />
+        <Compile Include="Arm/RoleAssignment.fs" />
+        <Compile Include="Arm/Search.fs" />
+        <Compile Include="Arm/ServiceBus.fs" />
+        <Compile Include="Arm/Sql.fs" />
+        <Compile Include="Arm/App.fs" />
+        <Compile Include="Arm/Web.fs" />
+        <Compile Include="Arm/Maps.fs" />
+        <Compile Include="Arm/SignalR.fs" />
+        <Compile Include="Arm/EventGrid.fs" />
+        <Compile Include="Arm/NetworkSecurityGroup.fs" />
+        <Compile Include="Arm/DeploymentScript.fs" />
+        <Compile Include="Arm/Databricks.fs" />
+        <Compile Include="Arm/VirtualWan.fs" />
+        <Compile Include="Arm/TrafficManager.fs" />
+        <Compile Include="Arm/AzureFirewall.fs" />
+        <Compile Include="Arm/ApplicationGateway.fs" />
+        <Compile Include="Arm/VirtualHub.fs" />
+        <Compile Include="Arm\Dashboard.fs" />
+        <Compile Include="Arm/LogicApps.fs" />
+        <Compile Include="Arm/OperationsManagement.fs" />
+        <Compile Include="Arm\Webhook.fs" />
+        <Compile Include="Arm\B2cTenant.fs" />
+        <Compile Include="IdentityExtensions.fs" />
+        <Compile Include="Builders/Extensions.fs" />
+        <Compile Include="Builders\Builders.ActionGroup.fs" />
+        <Compile Include="Builders\Builders.AutoscaleSettings.fs" />
+        <Compile Include="Builders\Builders.B2cTenant.fs" />
+        <Compile Include="Builders/Builders.UserAssignedIdentity.fs" />
+        <Compile Include="Builders/Builders.ResourceGroup.fs" />
+        <Compile Include="Builders/Builders.LogAnalytics.fs" />
+        <Compile Include="Builders/Builders.Helpers.fs" />
+        <Compile Include="Builders\Builders.Alert.fs" />
+        <Compile Include="Builders/Builders.PostgreSQL.fs" />
+        <Compile Include="Builders/Builders.Cdn.fs" />
+        <Compile Include="Builders\Builders.Storage.fs" />
+        <Compile Include="Builders/Builders.AppInsights.fs" />
+        <Compile Include="Builders\Builders.ServiceBus.fs" />
+        <Compile Include="Builders\Builders.ContainerApps.fs" />
+        <Compile Include="Builders/Builders.ContainerGroups.fs" />
+        <Compile Include="Builders/Builders.ContainerService.fs" />
+        <Compile Include="Builders/Builders.DataLake.fs" />
+        <Compile Include="Builders/Builders.DeploymentScript.fs" />
+        <Compile Include="Builders/Builders.Disk.fs" />
+        <Compile Include="Builders/Builders.Dns.fs" />
+        <Compile Include="Builders\Builders.DnsResolver.fs" />
+        <Compile Include="Builders/Builders.Gallery.fs" />
+        <Compile Include="Builders/Builders.ImageTemplate.fs" />
+        <Compile Include="Builders/Builders.Redis.fs" />
+        <Compile Include="Builders/Builders.KeyVault.fs" />
+        <Compile Include="Builders/Builders.Bastion.fs" />
+        <Compile Include="Builders\Builders.NatGateway.fs" />
+        <Compile Include="Builders\Builders.NetworkSecurityGroup.fs" />
+        <Compile Include="Builders/Builders.VirtualNetwork.fs" />
+        <Compile Include="Builders\Builders.LoadBalancer.fs" />
+        <Compile Include="Builders/Builders.Vm.fs" />
+        <Compile Include="Builders/Builders.VmScaleSet.fs" />
+        <Compile Include="Builders/Builders.ServicePlan.fs" />
+        <Compile Include="Builders\Builders.AvailabilityTest.fs" />
+        <Compile Include="Builders/Builders.WebApp.fs" />
+        <Compile Include="Builders/Builders.Functions.fs" />
+        <Compile Include="Builders/Builders.Sql.fs" />
+        <Compile Include="Builders/Builders.Search.fs" />
+        <Compile Include="Builders/Builders.Cosmos.fs" />
+        <Compile Include="Builders/Builders.EventHub.fs" />
+        <Compile Include="Builders/Builders.ExpressRoute.fs" />
+        <Compile Include="Builders/Builders.CognitiveServices.fs" />
+        <Compile Include="Builders/Builders.CommunicationServices.fs" />
+        <Compile Include="Builders/Builders.BingSearch.fs" />
+        <Compile Include="Builders/Builders.ContainerRegistry.fs" />
+        <Compile Include="Builders/Builders.IotHub.fs" />
+        <Compile Include="Builders/Builders.Maps.fs" />
+        <Compile Include="Builders/Builders.SignalR.fs" />
+        <Compile Include="Builders/Builders.VirtualNetworkGateway.fs" />
+        <Compile Include="Builders/Builders.EventGrid.fs" />
+        <Compile Include="Builders/Builders.StaticWebApp.fs" />
+        <Compile Include="Builders/Builders.Databricks.fs" />
+        <Compile Include="Builders/Builders.DiagnosticSetting.fs" />
+        <Compile Include="Builders/Builders.VirtualWan.fs" />
+        <Compile Include="Builders/Builders.TrafficManager.fs" />
+        <Compile Include="Builders/Builders.VirtualHub.fs" />
+        <Compile Include="Builders/Builders.AzureFirewall.fs" />
+        <Compile Include="Builders\Builders.Dashboard.fs" />
+        <Compile Include="Builders/Builders.ApplicationGateway.fs" />
+        <Compile Include="Builders/Builders.LogicApps.fs" />
+        <Compile Include="Builders/Builders.OperationsManagement.fs" />
+        <Compile Include="Builders\Builders.PrivateLink.fs" />
+        <Compile Include="Builders\Builders.PrivateEndpoint.fs" />
+        <Compile Include="Builders\Builders.RouteTable.fs" />
+        <Compile Include="Builders\Builders.HostGroup.fs" />
+        <Compile Include="Builders\Builders.NetworkInterface.fs" />
+        <Compile Include="Builders\Builders.RouteServer.fs" />
+        <Compile Include="Aliases.fs" />
+    </ItemGroup>
 </Project>

--- a/src/Farmer/Result.fs
+++ b/src/Farmer/Result.fs
@@ -36,7 +36,7 @@ module Result =
             | Error result -> failures.Add result
 
         if failures.Count > 0 then
-            Error failures.[0]
+            Error failures[0]
         else
             Ok(successes.ToArray())
 

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -1,7 +1,6 @@
 namespace Farmer
 
 open System
-open Farmer
 
 /// Common generic functions to support internals
 [<AutoOpen>]
@@ -118,7 +117,7 @@ type ResourceType with
         match name.Value.Split('/') with
         | [||]
         | [| _ |] -> ResourceId.create (this, name)
-        | parts -> ResourceId.create (this, (ResourceName parts.[0]), (Array.map ResourceName parts.[1..]))
+        | parts -> ResourceId.create (this, (ResourceName parts[0]), (Array.map ResourceName parts[1..]))
 
     member this.resourceId name = this.resourceId (ResourceName name)
 
@@ -489,9 +488,9 @@ module internal DeterministicGuid =
     open System.Text
 
     let private swapBytes (guid: byte array, left, right) =
-        let temp = guid.[left]
-        guid.[left] <- guid.[right]
-        guid.[right] <- temp
+        let temp = guid[left]
+        guid[left] <- guid[right]
+        guid[right] <- temp
 
     let private swapByteOrder guid =
         swapBytes (guid, 0, 3)
@@ -519,8 +518,8 @@ module internal DeterministicGuid =
         let newGuid = Array.zeroCreate<byte> 16
         Array.Copy(hash, 0, newGuid, 0, 16)
 
-        newGuid.[6] <- ((newGuid.[6] &&& 0x0Fuy) ||| (5uy <<< 4))
-        newGuid.[8] <- ((newGuid.[8] &&& 0x3Fuy) ||| 0x80uy)
+        newGuid[6] <- ((newGuid[6] &&& 0x0Fuy) ||| (5uy <<< 4))
+        newGuid[8] <- ((newGuid[8] &&& 0x3Fuy) ||| 0x80uy)
 
         swapByteOrder newGuid
         Guid newGuid

--- a/src/Tests/PostgreSQL.fs
+++ b/src/Tests/PostgreSQL.fs
@@ -1,12 +1,14 @@
 module PostgreSQL
 
+#nowarn "0044" // disable obsolete warning as error - needed
+
 open System
 
 open Expecto
 open Farmer
-open Farmer.PostgreSQL
-open Farmer.Builders
 open Farmer.Arm
+open Farmer.Builders
+open Farmer.PostgreSQL
 
 type PostgresSku = {
     name: string
@@ -29,7 +31,6 @@ type Properties = {
     version: string
     storageProfile: StorageProfile
 }
-
 
 type PostgresTemplate = {
     name: string

--- a/src/Tests/PostgreSQL.fs
+++ b/src/Tests/PostgreSQL.fs
@@ -148,13 +148,13 @@ let tests =
 
             let expectedDbRes = {
                 name = "testdb/my_db"
-                apiVersion = "2017-12-01"
-                ``type`` = "Microsoft.DBforPostgreSQL/servers/databases"
+                apiVersion = "2023-06-01-preview"
+                ``type`` = "Microsoft.DBforPostgreSQL/flexibleServers/databases"
                 properties = {|
                     collation = "de_DE"
                     charset = "ASCII"
                 |}
-                dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
+                dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', 'testdb')]" |]
             }
 
             Expect.equal actual expectedDbRes "database resource"
@@ -177,9 +177,9 @@ let tests =
 
             let expectedFwRuleRes: FirewallResource = {
                 name = "testdb/allow-azure-services"
-                ``type`` = "Microsoft.DBforPostgreSQL/servers/firewallrules"
-                apiVersion = "2017-12-01"
-                dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
+                ``type`` = "Microsoft.DBforPostgreSQL/flexibleServers/firewallrules"
+                apiVersion = "2023-06-01-preview"
+                dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/flexibleServers', 'testdb')]" |]
                 location = "northeurope"
                 properties = {|
                     startIpAddress = "0.0.0.0"
@@ -190,18 +190,13 @@ let tests =
             Expect.equal actual expectedFwRuleRes "Firewall is incorrect"
         }
 
-        test "Vnet rule are correctly set" {
-            let subscriptionId = "sid-subid"
-            let resourceGroup = "rg-abc"
-            let vnetName = "vnetid"
-            let subnetName = "default"
-
+        test "Vnet rule is correctly set" {
             let networkResourceId = {
                 Type = subnets
-                ResourceGroup = Some resourceGroup
-                Subscription = Some subscriptionId
-                Name = ResourceName vnetName
-                Segments = [ ResourceName subnetName ]
+                ResourceGroup = Some "rg-abc"
+                Subscription = Some "sid-subid"
+                Name = ResourceName "vnetid"
+                Segments = [ ResourceName "default" ]
             }
 
             let networkResourceIdString = networkResourceId.Eval()
@@ -210,6 +205,7 @@ let tests =
             let actual = postgreSQL {
                 name "testdb"
                 admin_username "myadminuser"
+                tier Basic
                 add_vnet_rule vnetRuleName networkResourceId
             }
 
@@ -218,11 +214,11 @@ let tests =
                 |> toTemplate Location.NorthEurope
                 |> Writer.toJson
                 |> Serialization.ofJson<TypedArmTemplate<VnetResource>>
-                |> fun r -> r.Resources
-                |> Seq.find (fun r -> r.name = $"testdb/%s{vnetRuleName}")
+                |> _.Resources
+                |> Seq.find (fun r -> r.name = $"testdb/{vnetRuleName}")
 
             let expectedVnetRuleResult: VnetResource = {
-                name = $"testdb/%s{vnetRuleName}"
+                name = $"testdb/{vnetRuleName}"
                 ``type`` = "Microsoft.DBforPostgreSQL/servers/virtualNetworkRules"
                 apiVersion = "2017-12-01"
                 dependsOn = [| "[resourceId('Microsoft.DBforPostgreSQL/servers', 'testdb')]" |]
@@ -270,6 +266,7 @@ let tests =
             let actual = postgreSQL {
                 name "testdb"
                 admin_username "myadminuser"
+                tier Basic
                 add_vnet_rules [ vnetRuleName1, networkResourceId1; vnetRuleName2, networkResourceId2 ]
             }
 
@@ -278,7 +275,7 @@ let tests =
                 |> toTemplate Location.NorthEurope
                 |> Writer.toJson
                 |> Serialization.ofJson<TypedArmTemplate<VnetResource>>
-                |> fun r -> r.Resources
+                |> _.Resources
 
             let actual1 = actual |> Seq.find (fun r -> r.name = $"testdb/%s{vnetRuleName1}")
             let actual2 = actual |> Seq.find (fun r -> r.name = $"testdb/%s{vnetRuleName2}")
@@ -500,5 +497,48 @@ let tests =
                 actual.dependsOn
                 "[resourceId('Microsoft.DBforPostgreSQL/servers', 'pgserver')]"
                 "Depends on is wrong"
+        }
+
+        test "Flexible Server properties are set correctly" {
+            let actual = postgreSQL {
+                name "pgserver"
+                add_database "db"
+                admin_username "theadmin"
+                tier FlexibleTier.Burstable_B4ms
+                storage_size 64<Gb>
+                storage_performance_tier Vm.DiskPerformanceTier.P6
+                server_version V_16
+            }
+
+            let actual =
+                actual
+                |> toTemplate Location.NorthEurope
+                |> Writer.toJson
+                |> Serialization.ofJson<
+                    TypedArmTemplate<
+                        {|
+                            sku: {| name: string; tier: string |}
+                            properties:
+                                {|
+                                    version: string
+                                    Storage:
+                                        {|
+                                            StorageSizeGb: int
+                                            tier: string
+                                            AutoGrow: string
+                                        |}
+                                |}
+                        |}
+                     >
+                    >
+                |> _.Resources
+                |> Seq.head
+
+            Expect.equal actual.sku.name "Standard_B4ms" "Incorrect SKU name"
+            Expect.equal actual.sku.tier "Burstable" "Incorrect SKU tier"
+            Expect.equal actual.properties.Storage.StorageSizeGb 64 "Incorrect storage size"
+            Expect.equal actual.properties.Storage.tier "P6" "Incorrect storage performance tier"
+            Expect.equal actual.properties.Storage.AutoGrow "Enabled" "Incorrect storage autogrow"
+            Expect.equal actual.properties.version "16" "Incorrect server version"
         }
     ]

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -1,115 +1,115 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <GenerateProgramFile>false</GenerateProgramFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <GenerateProgramFile>false</GenerateProgramFile>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="ActionGroup.fs" />
-    <Compile Include="ServicePlan.fs" />
-    <Content Include="test-data\*.json" CopyToOutputDirectory="PreserveNewest" />
-    <Compile Include="Helpers.fs" />
-    <Compile Include="AppGateway.fs" />
-    <Compile Include="AppInsights.fs" />
-    <Compile Include="Alerts.fs" />
-    <Compile Include="AutoscaleSettings.fs" />
-    <Compile Include="AvailabilityTests.fs" />
-    <Compile Include="AzureFirewall.fs" />
-    <Compile Include="B2cTenant.fs" />
-    <Compile Include="DiagnosticSettings.fs" />
-    <Compile Include="Disk.fs" />
-    <Compile Include="Common.fs" />
-    <Compile Include="Functions.fs" />
-    <Compile Include="LogicApps.fs" />
-    <Compile Include="LogAnalytics.fs" />
-    <Compile Include="Bastion.fs" />
-    <Compile Include="CommunicationServices.fs" />
-    <Compile Include="BingSearch.fs" />
-    <Compile Include="Cdn.fs" />
-    <Compile Include="ContainerApps.fs" />
-    <Compile Include="ContainerGroup.fs" />
-    <Compile Include="ContainerService.fs" />
-    <Compile Include="CognitiveServices.fs" />
-    <Compile Include="Dns.fs" />
-    <Compile Include="DnsResolver.fs" />
-    <Compile Include="ExpressRoute.fs" />
-    <Compile Include="EventHub.fs" />
-    <Compile Include="Gallery.fs" />
-    <Compile Include="ImageTemplate.fs" />
-    <Compile Include="Network.fs" />
-    <Compile Include="LoadBalancer.fs" />
-    <Compile Include="NetworkSecurityGroup.fs" />
-    <Compile Include="OperationsManagement.fs" />
-    <Compile Include="PrivateLink.fs" />
-    <Compile Include="ResourceGroup.fs" />
-    <Compile Include="Storage.fs" />
-    <Compile Include="ServiceBus.fs" />
-    <Compile Include="IotHub.fs" />
-    <Compile Include="Template.fs" />
-    <Compile Include="AzCli.fs" />
-    <Compile Include="Cosmos.fs" />
-    <Compile Include="KeyVault.fs" />
-    <Compile Include="VirtualMachine.fs" />
-    <Compile Include="VmScaleSet.fs" />
-    <Compile Include="ContainerRegistry.fs" />
-    <Compile Include="PostgreSQL.fs" />
-    <Compile Include="Maps.fs" />
-    <Compile Include="Sql.fs" />
-    <Compile Include="SignalR.fs" />
-    <Compile Include="EventGrid.fs" />
-    <Compile Include="WebApp.fs" />
-    <Compile Include="StaticWebApp.fs" />
-    <Compile Include="VirtualNetworkGateway.fs" />
-    <Compile Include="Identity.fs" />
-    <Compile Include="DeploymentScript.fs" />
-    <Compile Include="Databricks.fs" />
-    <Compile Include="VirtualWan.fs" />
-    <Compile Include="VirtualHub.fs" />
-    <Compile Include="JsonRegression.fs" />
-    <Compile Include="Types.fs" />
-    <Compile Include="TrafficManager.fs" />
-    <Compile Include="Dashboards.fs" />
-    <Compile Include="RoleAssignment.fs" />
-    <Compile Include="DedicatedHosts.fs" />
-    <Compile Include="AllTests.fs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="ActionGroup.fs" />
+        <Compile Include="ServicePlan.fs" />
+        <Content Include="test-data\*.json" CopyToOutputDirectory="PreserveNewest" />
+        <Compile Include="Helpers.fs" />
+        <Compile Include="AppGateway.fs" />
+        <Compile Include="AppInsights.fs" />
+        <Compile Include="Alerts.fs" />
+        <Compile Include="AutoscaleSettings.fs" />
+        <Compile Include="AvailabilityTests.fs" />
+        <Compile Include="AzureFirewall.fs" />
+        <Compile Include="B2cTenant.fs" />
+        <Compile Include="DiagnosticSettings.fs" />
+        <Compile Include="Disk.fs" />
+        <Compile Include="Common.fs" />
+        <Compile Include="Functions.fs" />
+        <Compile Include="LogicApps.fs" />
+        <Compile Include="LogAnalytics.fs" />
+        <Compile Include="Bastion.fs" />
+        <Compile Include="CommunicationServices.fs" />
+        <Compile Include="BingSearch.fs" />
+        <Compile Include="Cdn.fs" />
+        <Compile Include="ContainerApps.fs" />
+        <Compile Include="ContainerGroup.fs" />
+        <Compile Include="ContainerService.fs" />
+        <Compile Include="CognitiveServices.fs" />
+        <Compile Include="Dns.fs" />
+        <Compile Include="DnsResolver.fs" />
+        <Compile Include="ExpressRoute.fs" />
+        <Compile Include="EventHub.fs" />
+        <Compile Include="Gallery.fs" />
+        <Compile Include="ImageTemplate.fs" />
+        <Compile Include="Network.fs" />
+        <Compile Include="LoadBalancer.fs" />
+        <Compile Include="NetworkSecurityGroup.fs" />
+        <Compile Include="OperationsManagement.fs" />
+        <Compile Include="PrivateLink.fs" />
+        <Compile Include="ResourceGroup.fs" />
+        <Compile Include="Storage.fs" />
+        <Compile Include="ServiceBus.fs" />
+        <Compile Include="IotHub.fs" />
+        <Compile Include="Template.fs" />
+        <Compile Include="AzCli.fs" />
+        <Compile Include="Cosmos.fs" />
+        <Compile Include="KeyVault.fs" />
+        <Compile Include="VirtualMachine.fs" />
+        <Compile Include="VmScaleSet.fs" />
+        <Compile Include="ContainerRegistry.fs" />
+        <Compile Include="PostgreSQL.fs" />
+        <Compile Include="Maps.fs" />
+        <Compile Include="Sql.fs" />
+        <Compile Include="SignalR.fs" />
+        <Compile Include="EventGrid.fs" />
+        <Compile Include="WebApp.fs" />
+        <Compile Include="StaticWebApp.fs" />
+        <Compile Include="VirtualNetworkGateway.fs" />
+        <Compile Include="Identity.fs" />
+        <Compile Include="DeploymentScript.fs" />
+        <Compile Include="Databricks.fs" />
+        <Compile Include="VirtualWan.fs" />
+        <Compile Include="VirtualHub.fs" />
+        <Compile Include="JsonRegression.fs" />
+        <Compile Include="Types.fs" />
+        <Compile Include="TrafficManager.fs" />
+        <Compile Include="Dashboards.fs" />
+        <Compile Include="RoleAssignment.fs" />
+        <Compile Include="DedicatedHosts.fs" />
+        <Compile Include="AllTests.fs" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="expecto" Version="9.0.4" />
-    <PackageReference Include="DiffPlex" Version="1.7.1" />
-    <PackageReference Include="Microsoft.Azure.Management.Cdn" Version="6.1.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Azure.Management.CognitiveServices" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Compute" Version="35.2.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ContainerService" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Management.DeviceProvisioningServices" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="2.10.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.Logic" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Maps" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Monitor" Version="0.25.3-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.Network" Version="19.20.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.OperationalInsights" Version="0.21.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.10.1-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.SignalR" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Azure.Management.Sql" Version="1.43.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage" Version="21.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.TrafficManager" Version="2.5.3" />
-    <PackageReference Include="Microsoft.Azure.Management.WebSites" Version="3.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.13.3" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="expecto" Version="9.0.4" />
+        <PackageReference Include="DiffPlex" Version="1.7.1" />
+        <PackageReference Include="Microsoft.Azure.Management.Cdn" Version="6.1.0" />
+        <PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Azure.Management.CognitiveServices" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Azure.Management.Compute" Version="35.2.0" />
+        <PackageReference Include="Microsoft.Azure.Management.ContainerInstance" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Azure.Management.ContainerService" Version="1.1.0" />
+        <PackageReference Include="Microsoft.Azure.Management.DeviceProvisioningServices" Version="1.0.0" />
+        <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="2.10.0-preview" />
+        <PackageReference Include="Microsoft.Azure.Management.Logic" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Azure.Management.Maps" Version="1.0.2" />
+        <PackageReference Include="Microsoft.Azure.Management.Monitor" Version="0.25.3-preview" />
+        <PackageReference Include="Microsoft.Azure.Management.Network" Version="19.20.0-preview" />
+        <PackageReference Include="Microsoft.Azure.Management.OperationalInsights" Version="0.21.0-preview" />
+        <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.10.1-preview" />
+        <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Azure.Management.SignalR" Version="1.0.1" />
+        <PackageReference Include="Microsoft.Azure.Management.Sql" Version="1.43.0-preview" />
+        <PackageReference Include="Microsoft.Azure.Management.Storage" Version="21.0.0" />
+        <PackageReference Include="Microsoft.Azure.Management.TrafficManager" Version="2.5.3" />
+        <PackageReference Include="Microsoft.Azure.Management.WebSites" Version="3.1.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.13.3" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Farmer\Farmer.fsproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Farmer\Farmer.fsproj" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR closes #1123 

The changes in this PR are as follows:

* Adds support for Flexible Servers, databases and firewalls.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders
open Farmer.PostgreSQL

let myPostgres = postgreSQL {
    name "aserverformultitudes42"
    admin_username "adminallthethings"
    storage_size 64<Gb>
    add_database "my_db"
    enable_azure_firewall
    storage_autogrow true

    // overloaded or model-specific keywords
    tier FlexibleTier.Burstable_B1ms
    server_version FlexibleVersion.V_16
    storage_performance_tier Vm.DiskPerformanceTier.P10
}
```

The main potential concern for this PR is that it adds support for the new Flexible server but allows the old Single Server model to still work. I propose we mark the old one as obsolete and at some point in the future completely decomission it. This will also simplify the codebase.