### PR TITLE
Rollback FSharp.Core and System.Text.Json to minimal 5.0.0 versions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 Release Notes
 =============
-## vNext
+
+## 9.0.0
 * PostgreSQL: Support for Flexible Servers.
 
 ## 1.8.13

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <!-- General -->
         <AssemblyName>Farmer</AssemblyName>
-        <Version>1.8.13</Version>
+        <Version>9.0.0</Version>
         <Description>Farmer makes authoring ARM templates easy!</Description>
         <Copyright>Copyright 2019-2024 Compositional IT Ltd.</Copyright>
         <Company>Compositional IT</Company>
@@ -40,9 +40,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="8.0.200" />
+        <PackageReference Update="FSharp.Core" Version="5.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
+        <PackageReference Include="System.Text.Json" Version="5.0.0" />
     </ItemGroup>
     <ItemGroup>
         <None Include="../../Icon.jpg">


### PR DESCRIPTION
This PR closes #1128 

The changes in this PR are as follows:

* Rolls back FSharp.Core dependency to 5.0.0 since that's the minimal version required by Farmer. Consumers of Farmer can upgrade to whatever newer version of FSharp.Core suites them.
* Rolls back System.Text.Json dependency to 5.0.0 since that's the minimal version required. The runtime will generally include a newer one anyway.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Dependency changes only, nothing to change in tests or docs.