### PR TITLE
Managed Clusters (AKS): Support for workload identity, OIDC issuer, image cleaner, and Defender.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.9.1
 * Managed Clusters (AKS): Support for workload identity, OIDC issuer, image cleaner, and Defender.
+* Managed Clusters (AKS): Default to use MSI for the service principal profile to align with CLI and Portal.
 * User Assigned Identities: Support for `depends_on`.
 
 ## 1.9.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 1.9.1
+* Managed Clusters (AKS): Support for workload identity, OIDC issuer, image cleaner, and Defender.
+* User Assigned Identities: Support for `depends_on`.
+
 ## 1.9.0
 * PostgreSQL: Support for Flexible Servers.
 * Virtual Machines: Includes Ubuntu 24.04 LTS images.

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -13,39 +13,48 @@ The AKS Cluster builder is used to create AKS clusters.
 #### AKS Builder Keywords
 The AKS builder (`aks`) constructs AKS clusters.
 
-| Keyword | Purpose |
-|-|-|
-| name | Sets the name of the AKS cluster. |
-| dns_prefix | Sets the DNS prefix of the AKS cluster. |
-| enable_private_cluster | Restricts the cluster's Kubernetes API to only be accessible from private networks. |
-| enable_rbac | Enable Kubernetes Role-Based Access Control. |
-| add_agent_pools | Adds agent pools to the AKS cluster. |
-| add_agent_pool | Adds an agent pool to the AKS cluster. |
-| add_identity | Adds a managed identity to the the AKS cluster. |
-| system_identity | Activates the system identity of the AKS cluster. |
-| kubelet_identity | Assigns a user assigned identity to the kubelet user that pulls container images. |
-| network_profile | Sets the network profile for the AKS cluster. |
-| linux_profile | Sets the linux profile for the AKS cluster. |
-| service_principal_client_id | Sets the client id of the service principal for the AKS cluster. |
-| service_principal_use_msi | Enables the AKS cluster to use the managed identity service principal instead of an external client secret. |
-| windows_username | Sets the windows admin username for the AKS cluster. |
-| add_api_server_authorized_ip_ranges | Adds IP address CIDR ranges to be allowed Kubernetes API access. |
-| addon | A list with the configuration of all addons on the cluster (AciConnectorLinux, HttpApplicationRouting, KubeDashboard, IngressApplicationGateway, OmsAgent). |
+| Keyword                             | Purpose                                                                                                                                                     |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name                                | Sets the name of the AKS cluster.                                                                                                                           |
+| dns_prefix                          | Sets the DNS prefix of the AKS cluster.                                                                                                                     |
+| enable_defender                     | Enables Defender for the containers running in the cluster.                                                                                                 |
+| enable_image_cleaner                | Enables a service to periodically purge images that are no longer used.                                                                                     |
+| enable_private_cluster              | Restricts the cluster's Kubernetes API to only be accessible from private networks.                                                                         |
+| enable_rbac                         | Enable Kubernetes Role-Based Access Control.                                                                                                                |
+| enable_workload_identity            | Enables workload identity to assign a pod to a managed identity. Requires OIDC, so enables that as well.                                                    |
+| oidc_issuer                         | Enables or disables the OIDC issuer service for issuing tokens for federated identity.                                                                      |
+| add_agent_pools                     | Adds agent pools to the AKS cluster.                                                                                                                        |
+| add_agent_pool                      | Adds an agent pool to the AKS cluster.                                                                                                                      |
+| add_identity                        | Adds a managed identity to the the AKS cluster.                                                                                                             |
+| system_identity                     | Activates the system identity of the AKS cluster.                                                                                                           |
+| kubelet_identity                    | Assigns a user assigned identity to the kubelet user that pulls container images.                                                                           |
+| network_profile                     | Sets the network profile for the AKS cluster.                                                                                                               |
+| linux_profile                       | Sets the linux profile for the AKS cluster.                                                                                                                 |
+| service_principal_client_id         | Sets the client id of the service principal for the AKS cluster.                                                                                            |
+| service_principal_use_msi           | Enables the AKS cluster to use the managed identity service principal instead of an external client secret.                                                 |
+| windows_username                    | Sets the windows admin username for the AKS cluster.                                                                                                        |
+| add_api_server_authorized_ip_ranges | Adds IP address CIDR ranges to be allowed Kubernetes API access.                                                                                            |
+| addon                               | A list with the configuration of all addons on the cluster (AciConnectorLinux, HttpApplicationRouting, KubeDashboard, IngressApplicationGateway, OmsAgent). |
+
+##### Configuration Members
+
+* `OidcIssuerUrl` - the configuration built by the `aks` builder uses this property to provide an ARM expression to reference the OIDC Issuer URL on the managed cluster, if enabled.
 
 #### Agent Pool Builder keywords
 The Agent Pool builder (`agentPool`) constructs agent pools in the AKS cluster.
 
-| Keyword | Purpose |
-|-|-|
-| name | Sets the name of the agent pool. |
-| count | Sets the count of VM's in the agent pool. |
-| user_mode | Sets the agent pool to user mode. |
-| disk_size | Sets the disk size for the VM's in the agent pool. |
-| max_pods | Sets the maximum number of pods in the agent pool. |
-| os_type | Sets the OS type of the VM's in the agent pool. |
-| subnet | Sets the name of a virtual network subnet where this AKS cluster should be attached. |
-| vm_size | Sets the size of the VM's in the agent pool. |
-| vnet | Sets the name of a virtual network in the same region where this AKS cluster should be attached. |
+| Keyword     | Purpose                                                                                          |
+|-------------|--------------------------------------------------------------------------------------------------|
+| name        | Sets the name of the agent pool.                                                                 |
+| count       | Sets the count of VM's in the agent pool.                                                        |
+| user_mode   | Sets the agent pool to user mode.                                                                |
+| disk_size   | Sets the disk size for the VM's in the agent pool.                                               |
+| enable_fips | Uses a FIPS compliant OS image for VM's in the agent pool.                                       |
+| max_pods    | Sets the maximum number of pods in the agent pool.                                               |
+| os_type     | Sets the OS type of the VM's in the agent pool.                                                  |
+| subnet      | Sets the name of a virtual network subnet where this AKS cluster should be attached.             |
+| vm_size     | Sets the size of the VM's in the agent pool.                                                     |
+| vnet        | Sets the name of a virtual network in the same region where this AKS cluster should be attached. |
 
 #### Kubenet Builder
 The Kubenet builder (`kubenetNetworkProfile`) creates Kubenet network profiles on the AKS cluster.
@@ -66,7 +75,7 @@ The CNI builder (`azureCniNetworkProfile`) creates Azure CNI network profiles on
 
 #### Basic Example
 
-The simplest cluster uses a system assigned managed identity and 
+The simplest cluster uses a system assigned managed identity and
 default settings for the node pool (size of 3).
 
 ```fsharp

--- a/src/Farmer/Arm/ManagedIdentity.fs
+++ b/src/Farmer/Arm/ManagedIdentity.fs
@@ -12,6 +12,7 @@ let federatedIdentityCredentials =
 
 type UserAssignedIdentity = {
     Name: ResourceName
+    Dependencies: ResourceId Set
     Location: Location
     Tags: Map<string, string>
 } with
@@ -20,7 +21,7 @@ type UserAssignedIdentity = {
         member this.ResourceId = userAssignedIdentities.resourceId this.Name
 
         member this.JsonModel =
-            userAssignedIdentities.Create(this.Name, this.Location, [], this.Tags)
+            userAssignedIdentities.Create(this.Name, this.Location, this.Dependencies, this.Tags)
 
 /// A federated identity credential from an OpenId Connect issuer.
 type FederatedIdentityCredential = {

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -388,7 +388,7 @@ type AksBuilder() =
         NetworkProfile = None
         OidcIssuerProfile = None
         SecurityProfile = None
-        ServicePrincipalClientID = ""
+        ServicePrincipalClientID = "msi"
         WindowsProfileAdminUserName = None
     }
 

--- a/src/Farmer/Builders/Builders.DeploymentScript.fs
+++ b/src/Farmer/Builders/Builders.DeploymentScript.fs
@@ -44,6 +44,7 @@ type DeploymentScriptConfig = {
             if this.CustomIdentity.IsNone then
                 {
                     Name = generatedIdentityId.Name
+                    Dependencies = Set.empty
                     Location = location
                     Tags = Map.empty
                 }

--- a/src/Farmer/Builders/Builders.UserAssignedIdentity.fs
+++ b/src/Farmer/Builders/Builders.UserAssignedIdentity.fs
@@ -107,6 +107,7 @@ let federatedIdentityCredential = FederatedIdentityCredentialBuilder()
 
 type UserAssignedIdentityConfig = {
     Name: ResourceName
+    Dependencies: ResourceId Set
     FederatedIdentityCredentials: FederatedIdentityCredentialConfig list
     Tags: Map<string, string>
 } with
@@ -117,6 +118,7 @@ type UserAssignedIdentityConfig = {
         member this.BuildResources location = [
             {
                 UserAssignedIdentity.Name = this.Name
+                Dependencies = this.Dependencies
                 Location = location
                 Tags = this.Tags
             }
@@ -147,6 +149,7 @@ type UserAssignedIdentityConfig = {
 type UserAssignedIdentityBuilder() =
     member _.Yield _ = {
         Name = ResourceName.Empty
+        Dependencies = Set.empty
         FederatedIdentityCredentials = []
         Tags = Map.empty
     }
@@ -164,7 +167,13 @@ type UserAssignedIdentityBuilder() =
             state with
                 FederatedIdentityCredentials = state.FederatedIdentityCredentials @ creds
         }
-    /// Adds tags to the user assigned identity.
+
+    interface IDependable<UserAssignedIdentityConfig> with
+        member _.Add state newDeps = {
+            state with
+                Dependencies = state.Dependencies + newDeps
+        }
+
     interface ITaggable<UserAssignedIdentityConfig> with
         member _.Add state tags = {
             state with

--- a/src/Tests/test-data/aks-with-acr.json
+++ b/src/Tests/test-data/aks-with-acr.json
@@ -34,7 +34,7 @@
       "type": "Microsoft.ContainerRegistry/registries"
     },
     {
-      "apiVersion": "2021-03-01",
+      "apiVersion": "2024-02-01",
       "dependsOn": [
         "[resourceId('Microsoft.ContainerRegistry/registries', 'farmercontainerregistry1234')]",
         "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'clusterIdentity')]",


### PR DESCRIPTION
The changes in this PR are as follows:

* Managed Clusters (AKS): Support for workload identity, OIDC issuer, image cleaner, and Defender.
* Managed Clusters (AKS): Default to use MSI for the service principal profile to align with CLI and Portal.
* User Assigned Identities: Support for `depends_on`.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let aksWithWorkloadIdentity = aks {
    name "k8s-cluster"
    dns_prefix "test82j9e"

    add_agent_pools [
        agentPool {
            name "linuxPool"
            count 3
            enable_fips
        }
    ]

    enable_workload_identity
    enable_image_cleaner
}

// Create a User Assigned Identity that can be used for applications that run under a Kubernetes service account named `app1service` in the namespace `app1`. This is done by adding a federated identity credential using the OIDC issuer URL from the AKS cluster.
let aksWorkloadIdentityApp1 =
    userAssignedIdentity {
        name "app1-msi"
        depends_on aksWithWorkloadIdentity
        add_federated_identity_credentials [
            federatedIdentityCredential{
                name "aks-workload-fic"
                issuer (aksWithWorkloadIdentity.OidcIssuerUrl.Eval())
                audience EntraIdAudience
                subject "system:serviceaccount:app1:app1service"
            }
        ]
    }

arm {
    location Location.EastUS
    add_resource aksWithWorkloadIdentity
    add_resource aksWorkloadIdentityApp1
}
```
