### PR TITLE
Attaching a containerGroup to a vnet no longer requires a profile

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@ Release Notes
 
 ## 1.9.2
 * Container Apps: Fix to container registry credential to not emit a secret for a managed identity.
+* ContainerGroup followup to #ff78f202dc - expand DNS config validation for profile-less vnet.
 
 ## 1.9.1
 * Managed Clusters (AKS): Support for workload identity, OIDC issuer, image cleaner, and Defender.

--- a/src/Farmer/Builders/Builders.ContainerGroups.fs
+++ b/src/Farmer/Builders/Builders.ContainerGroups.fs
@@ -155,7 +155,11 @@ type ContainerGroupConfig = {
                 ]
                 Diagnostics = this.Diagnostics
                 DnsConfig =
-                    if this.DnsConfig.IsSome && this.NetworkProfile.IsNone then
+                    if
+                        this.DnsConfig.IsSome
+                        && this.NetworkProfile.IsNone
+                        && this.VirtualNetwork.IsNone
+                    then
                         raiseFarmer "DNS configuration can only be set when attached to a virtual network."
                     else
                         this.DnsConfig


### PR DESCRIPTION
This PR updates the condition for deploying ACI with a custom DNS config to account for new profile-less subnet option.

The changes in this PR are as follows:

* Allow DNS if either Network Profile or a VNet are specified.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
Seems straight-forward?

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

in  a `containerGroup` CE, specifying this combination of options:

```fsharp
        subnet subnet
        link_to_vnet vnetName
        dns_search_domains [domain]
```
should not throw "DNS configuration can only be set when attached to a virtual network."