### PR TITLE
Fix container-apps.md formatting

### DIFF
--- a/docs/content/api-overview/resources/container-apps.md
+++ b/docs/content/api-overview/resources/container-apps.md
@@ -91,6 +91,7 @@ The Container builder (`container`) is used to define one or more containers for
 
 #### Dapr Component Builder
 The Dapr Component builder (`daprComponent`) is used to define one or more dapr components for a container environment.
+
 | Keyword | Purpose |
 |-|-|
 | name | Sets the name of the dapr component. |


### PR DESCRIPTION
Adds a line break before a table to (hopefully) fix the docs site (untested).

![docs page showing plaintext markdown table syntax rather than a rendered table](https://github.com/user-attachments/assets/36b5a8d2-6bf8-44be-b109-06870017c76c)