### PR TITLE
Deployments: Default to resource group location rather than West Europe.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.9.3
+* Deployments: Default to resource group location rather than West Europe.
+
 ## 1.9.2
 * Container Apps: Fix to container registry credential to not emit a secret for a managed identity.
 * Container Groups: followup to #ff78f202dc - expand DNS config validation for profile-less vnet.

--- a/src/Farmer/Builders/Builders.ResourceGroup.fs
+++ b/src/Farmer/Builders/Builders.ResourceGroup.fs
@@ -139,7 +139,7 @@ type DeploymentBuilder() =
         Resources = List.empty
         ParameterValues = List.empty
         SubscriptionId = None
-        Location = Location.WestEurope
+        Location = Location.ResourceGroup
         Mode = Incremental
         Tags = Map.empty
     }

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -71,6 +71,9 @@ module LocationExtensions =
         static member NorwayEast = Location "NorwayEast"
         static member Global = Location "global"
 
+        static member ResourceGroup =
+            LocationExpression(ArmExpression.create "resourceGroup().location")
+
 [<AutoOpen>]
 module DataLocationExtensions =
     type DataLocation with

--- a/src/Tests/LogAnalytics.fs
+++ b/src/Tests/LogAnalytics.fs
@@ -33,7 +33,7 @@ let tests =
 
             let workspace = asAzureResource config
 
-            Expect.equal workspace.Location "westeurope" "Incorrect Location"
+            Expect.equal workspace.Location "[resourceGroup().location]" "Incorrect Location"
             Expect.equal workspace.Name "myFarmer" "Incorrect Name"
             Expect.equal workspace.PublicNetworkAccessForIngestion "Enabled" "Incorrect IngestionSupport"
             Expect.equal workspace.PublicNetworkAccessForQuery "Enabled" "QuerySupport"

--- a/src/Tests/Types.fs
+++ b/src/Tests/Types.fs
@@ -2,12 +2,32 @@ module Types
 
 open Expecto
 open Farmer
+open Farmer.Builders
 open System
+open Newtonsoft.Json.Linq
 
 let tests =
     testList "Type Tests" [
         test "Creates deterministic GUID correctly" {
             let actual = DeterministicGuid.create "hello"
             Expect.equal (Guid.Parse "4fbe461c-3438-55c4-941e-d1c2013210c5") actual "Incorrect GUID"
+        }
+        test "Location.ResourceGroup emits correct ARM expression" {
+            Expect.equal
+                Location.ResourceGroup.ArmValue
+                "[resourceGroup().location]"
+                "Incorrect expression emitted for Location.ResourceGroup"
+        }
+        ftest "Default location for 'arm' builder uses resourceGroup location" {
+            let deployment =
+                let dummyResource = storageAccount { name "mystorageaccount74785" }
+                arm { add_resource dummyResource }
+
+            let jobj = deployment.Template |> Writer.toJson |> JToken.Parse
+
+            Expect.equal
+                (jobj.SelectToken "resources[?(@.name=='mystorageaccount74785')].location")
+                (JValue "[resourceGroup().location]")
+                "Default location on resource should be resource group."
         }
     ]


### PR DESCRIPTION
This PR improves the default behavior when no location is specified, improving upon the issue in #682, although not quite fixing it yet. 

The changes in this PR are as follows:

* Deployments: Default to resource group location rather than West Europe.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.