### PR TITLE
Add support for Immutable Storage on container

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = false
 [*.{fs,fsx}]
 fsharp_multiline_bracket_style = stroustrup
 fsharp_newline_before_multiline_computation_expression = false
+
+[*.json]
+indent_size = 2

--- a/Farmer.sln
+++ b/Farmer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29201.188
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35417.141
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Farmer", "src\Farmer\Farmer.fsproj", "{CB0287CC-AD12-427C-866B-5F236C29B0A2}"
 EndProject
@@ -44,8 +44,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{C399
 		samples\scripts\sqlserver.fsx = samples\scripts\sqlserver.fsx
 		samples\scripts\storage.fsx = samples\scripts\storage.fsx
 		samples\scripts\template.json = samples\scripts\template.json
-		samples\scripts\vm.fsx = samples\scripts\vm.fsx
 		samples\scripts\vm-spot-instance.fsx = samples\scripts\vm-spot-instance.fsx
+		samples\scripts\vm.fsx = samples\scripts\vm.fsx
 		samples\scripts\vnet-gateway.fsx = samples\scripts\vnet-gateway.fsx
 		samples\scripts\vnet-hub-and-spoke.fsx = samples\scripts\vnet-hub-and-spoke.fsx
 		samples\scripts\vnet.fsx = samples\scripts\vnet.fsx

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+## 1.9.13
+* Storage: Add BLOB `immutableStorageWithVersioning`
+* Storage: Add BLOB `encryption.requireInfrastructureEncryption`
+* Storage: Add BLOB container immutability policies support
+
 ## 1.9.12
 * AKS Cluster: Add link_to_kubelet_identity
 * VMSS overprovisioning controls

--- a/docs/content/api-overview/resources/storage-account.md
+++ b/docs/content/api-overview/resources/storage-account.md
@@ -83,6 +83,12 @@ let storage = storageAccount {
     add_public_container "mypubliccontainer"
     add_private_container "myprivatecontainer"
     add_blob_container "myblobcontainer"
+    add_blob_container
+        "myblobcontainerwithimmutabilitypolicies"
+        (blobContainerImmutabilityPolicies {
+            allow_protected_append_writes AllAppendAllowed
+            immutability_period_since_creation (365<Days> * 5)
+        })
     add_file_share "share1"
     add_file_share_with_quota "share2" 1024<Gb>
     add_queue "myqueue"

--- a/samples/scripts/loadbalancer.fsx
+++ b/samples/scripts/loadbalancer.fsx
@@ -18,7 +18,7 @@ let (lb: LoadBalancer) = {
         {|
             Name = ResourceName "LoadBalancerFrontend"
             AddressVersion = Network.AddressVersion.IPv4
-            PublicIp = Some (publicIPAddresses.resourceId "lb-test-pip")
+            PublicIp = Some(publicIPAddresses.resourceId "lb-test-pip")
             PrivateIpAllocationMethod = PrivateIpAddress.DynamicPrivateIp
             Subnet = None
         |}

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -175,8 +175,8 @@ type StorageAccount = {
                     | Blobs _ -> "BlobStorage"
                     | Files _ -> "FileStorage"
                     | BlockBlobs _ -> "BlockBlobStorage"
-                extendedLocation = "" // TODO:
-                identity = "" // TODO: user assigned identityt
+                extendedLocation = None // TODO:
+                identity = None // TODO: user assigned identity
                 properties = {|
                     accessTier =
                         match this.Sku with
@@ -206,9 +206,9 @@ type StorageAccount = {
                             defaultAction = networkRuleSet.DefaultAction.ArmValue
                         |})
                         |> Option.defaultValue Unchecked.defaultof<_>
-                    allowBlobPublicAccess = this.DisableBlobPublicAccess.BooleanValue()
-                    allowSharedKeyAccess = this.DisableSharedKeyAccess.BooleanValue()
-                    defaultToOAuthAuthentication = this.DefaultToOAuthAuthentication.BooleanValue()
+                    allowBlobPublicAccess = this.DisableBlobPublicAccess.AsInvertedBoolean()
+                    allowSharedKeyAccess = this.DisableSharedKeyAccess.AsInvertedBoolean()
+                    defaultToOAuthAuthentication = this.DefaultToOAuthAuthentication.AsBoolean()
                     dnsEndpointType = this.DnsZoneType |> Option.toObj
                     encryption =
                         this.RequireInfrastructureEncryption
@@ -231,8 +231,8 @@ type StorageAccount = {
                         |})
                     isHnsEnabled = this.EnableHierarchicalNamespace |> Option.toNullable
                     minimumTlsVersion = this.MinTlsVersion.ArmValue()
-                    publicNetworkAccess = this.DisablePublicNetworkAccess.ArmValue()
-                    supportsHttpsTrafficOnly = this.SupportsHttpsTrafficOnly.BooleanValue()
+                    publicNetworkAccess = this.DisablePublicNetworkAccess.ArmInvertedValue()
+                    supportsHttpsTrafficOnly = this.SupportsHttpsTrafficOnly.AsBoolean()
                 |}
         |}
 

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -366,6 +366,7 @@ module BlobServices =
         Name: StorageResourceName
         StorageAccount: ResourceName
         Accessibility: StorageContainerAccess
+        Metadata: Metadata option
     } with
 
         member this.ResourceName = this.StorageAccount / "default" / this.Name.ResourceName
@@ -377,6 +378,7 @@ module BlobServices =
                 containers.Create(this.ResourceName, dependsOn = [ storageAccounts.resourceId this.StorageAccount ]) with
                     properties = {|
                         publicAccess = this.Accessibility.ArmValue
+                        metadata = this.Metadata |> Option.defaultValue Unchecked.defaultof<_>
                     |}
             |}
 

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -175,8 +175,8 @@ type StorageAccount = {
                     | Blobs _ -> "BlobStorage"
                     | Files _ -> "FileStorage"
                     | BlockBlobs _ -> "BlockBlobStorage"
-                extendedLocation = None // TODO:
-                identity = None // TODO: user assigned identity
+                extendedLocation = None
+                identity = None
                 properties = {|
                     accessTier =
                         match this.Sku with

--- a/src/Farmer/Arm/Storage.fs
+++ b/src/Farmer/Arm/Storage.fs
@@ -127,11 +127,12 @@ type StorageAccount = {
     ImmutableStorageWithVersioning:
         {|
             Enable: bool option
-            ImmutabilityPolicy: {|
-                AllowProtectedAppendWrites: bool option
-                ImmutabilityPeriodSinceCreation: int<Days> option
-                State: ImmutabilityPolicyState option
-            |} option
+            ImmutabilityPolicy:
+                {|
+                    AllowProtectedAppendWrites: bool option
+                    ImmutabilityPeriodSinceCreation: int<Days> option
+                    State: ImmutabilityPolicyState option
+                |} option
         |} option
     MinTlsVersion: TlsVersion option
     NetworkAcls: NetworkRuleSet option
@@ -205,30 +206,33 @@ type StorageAccount = {
                             defaultAction = networkRuleSet.DefaultAction.ArmValue
                         |})
                         |> Option.defaultValue Unchecked.defaultof<_>
-                    allowBlobPublicAccess = this.DisableBlobPublicAccess.BooleanValue ()
-                    allowSharedKeyAccess = this.DisableSharedKeyAccess.BooleanValue ()
-                    defaultToOAuthAuthentication = this.DefaultToOAuthAuthentication.BooleanValue ()
+                    allowBlobPublicAccess = this.DisableBlobPublicAccess.BooleanValue()
+                    allowSharedKeyAccess = this.DisableSharedKeyAccess.BooleanValue()
+                    defaultToOAuthAuthentication = this.DefaultToOAuthAuthentication.BooleanValue()
                     dnsEndpointType = this.DnsZoneType |> Option.toObj
-                    encryption = {|
-                        requireInfrastructureEncryption = this.RequireInfrastructureEncryption |> Option.toNullable
-                    |}
+                    encryption =
+                        this.RequireInfrastructureEncryption
+                        |> Option.map (fun b -> {|
+                            requireInfrastructureEncryption = b
+                        |})
                     immutableStorageWithVersioning =
                         this.ImmutableStorageWithVersioning
                         |> Option.map (fun immutableStorage -> {|
                             enable = immutableStorage.Enable |> Option.toNullable
                             policy =
                                 immutableStorage.ImmutabilityPolicy
-                                |> Option.map (fun immutableStorage ->
-                                    {|
-                                        allowProtectedAppendWrites = immutableStorage.AllowProtectedAppendWrites |> Option.toNullable
-                                        immutabilityPeriodSinceCreationInDays = immutableStorage.ImmutabilityPeriodSinceCreation |> Option.toNullable
-                                        state = immutableStorage.State |> Option.map _.ArmValue |> Option.toObj
-                                    |})
+                                |> Option.map (fun immutableStorage -> {|
+                                    allowProtectedAppendWrites =
+                                        immutableStorage.AllowProtectedAppendWrites |> Option.toNullable
+                                    immutabilityPeriodSinceCreationInDays =
+                                        immutableStorage.ImmutabilityPeriodSinceCreation |> Option.toNullable
+                                    state = immutableStorage.State |> Option.map _.ArmValue |> Option.toObj
+                                |})
                         |})
                     isHnsEnabled = this.EnableHierarchicalNamespace |> Option.toNullable
-                    minimumTlsVersion = this.MinTlsVersion.ArmValue ()
-                    publicNetworkAccess = this.DisablePublicNetworkAccess.ArmValue ()
-                    supportsHttpsTrafficOnly = this.SupportsHttpsTrafficOnly.BooleanValue ()
+                    minimumTlsVersion = this.MinTlsVersion.ArmValue()
+                    publicNetworkAccess = this.DisablePublicNetworkAccess.ArmValue()
+                    supportsHttpsTrafficOnly = this.SupportsHttpsTrafficOnly.BooleanValue()
                 |}
         |}
 
@@ -370,10 +374,7 @@ module BlobServices =
             member this.ResourceId = containers.resourceId this.ResourceName
 
             member this.JsonModel = {|
-                containers.Create(
-                    this.ResourceName,
-                    dependsOn = [ storageAccounts.resourceId this.StorageAccount ]
-                ) with
+                containers.Create(this.ResourceName, dependsOn = [ storageAccounts.resourceId this.StorageAccount ]) with
                     properties = {|
                         publicAccess = this.Accessibility.ArmValue
                     |}
@@ -402,13 +403,13 @@ type AllowProtectedAppendWrites =
 type AllowProtectedAppendWritesExtensions =
 
     [<Extension>]
-    static member AllowProtectedAppendWrites (this: AllowProtectedAppendWrites option) =
+    static member AllowProtectedAppendWrites(this: AllowProtectedAppendWrites option) =
         match this with
         | Some value -> value.AllowProtectedAppendWrites
         | None -> Nullable()
 
     [<Extension>]
-    static member AllowProtectedAppendWritesAll (this: AllowProtectedAppendWrites option) =
+    static member AllowProtectedAppendWritesAll(this: AllowProtectedAppendWrites option) =
         match this with
         | Some value -> value.AllowProtectedAppendWritesAll
         | None -> Nullable()
@@ -425,20 +426,25 @@ module BlobContainers =
 
         member _.Name = ResourceName "default"
 
-        member this.ResourceName = this.StorageAccount / "default" / this.Container.ResourceName / this.Name
+        member this.ResourceName =
+            this.StorageAccount / "default" / this.Container.ResourceName / this.Name
 
         interface IArmResource with
             member this.ResourceId = immutabilityPolicies.resourceId this.ResourceName
+
             member this.JsonModel = {|
                 immutabilityPolicies.Create(
                     this.ResourceName,
-                    dependsOn = [ containers.resourceId (this.StorageAccount / "default" / this.Container.ResourceName) ]
+                    dependsOn = [
+                        containers.resourceId (this.StorageAccount / "default" / this.Container.ResourceName)
+                    ]
                 ) with
                     properties = {|
-                        immutabilityPeriodSinceCreationInDays = this.ImmutabilityPeriodSinceCreation |> Option.toNullable
+                        immutabilityPeriodSinceCreationInDays =
+                            this.ImmutabilityPeriodSinceCreation |> Option.toNullable
                         // The 'allowProtectedAppendWrites' and 'allowProtectedAppendWritesAll' properties are mutually exclusive
-                        allowProtectedAppendWrites = this.AllowProtectedAppendWrites.AllowProtectedAppendWrites ()
-                        allowProtectedAppendWritesAll = this.AllowProtectedAppendWrites.AllowProtectedAppendWritesAll ()
+                        allowProtectedAppendWrites = this.AllowProtectedAppendWrites.AllowProtectedAppendWrites()
+                        allowProtectedAppendWritesAll = this.AllowProtectedAppendWrites.AllowProtectedAppendWritesAll()
                     |}
             |}
 

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -11,6 +11,7 @@ open Farmer.Arm.Storage
 open Farmer.Arm.KeyVault
 open Farmer.Arm.KeyVault.Vaults
 open System
+open System.Globalization
 open Farmer.Arm
 
 type FunctionsRuntime =
@@ -320,7 +321,7 @@ type FunctionsConfig = {
                     | Linux ->
                         match this.VersionedRuntime with
                         | DotNet, Some version ->
-                            match Double.TryParse(version) with
+                            match Double.TryParse(version, NumberStyles.Any, CultureInfo.InvariantCulture) with
                             | true, versionNo when versionNo < 4.0 -> Some $"DOTNETCORE|{version}"
                             | _ -> Some $"DOTNET|{version}"
                         | DotNetIsolated, Some version -> Some $"DOTNET-ISOLATED|{version}"

--- a/src/Farmer/Builders/Builders.Functions.fs
+++ b/src/Farmer/Builders/Builders.Functions.fs
@@ -386,6 +386,8 @@ type FunctionsConfig = {
                 DisableBlobPublicAccess = None
                 DisableSharedKeyAccess = None
                 DefaultToOAuthAuthentication = None
+                ImmutableStorageWithVersioning = None
+                RequireInfrastructureEncryption = None
               }
             | _ -> ()
 

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -286,9 +286,9 @@ type StorageAccountBuilder() =
                 Containers =
                     let containers =
                         names
-                        |> List.ofSeq
-                        |> List.map (fun name ->
+                        |> Seq.map (fun name ->
                             ((StorageResourceName.Create name).OkValue, access, immutabilityPolicies))
+                        |> Seq.toList
 
                     state.Containers @ containers
         }

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -173,7 +173,7 @@ and StorageAccountConfig = {
                 DisableSharedKeyAccess = this.DisableSharedKeyAccess
                 DnsZoneType = this.DnsZoneType
                 EnableHierarchicalNamespace = this.EnableDataLake
-                ImmutableStorageWithVersioning = None // TODO: Implement
+                ImmutableStorageWithVersioning = None // TODO: Implement on the `StorageAccountConfig` type
                 MinTlsVersion = this.MinTlsVersion
                 NetworkAcls = this.NetworkAcls
                 RequireInfrastructureEncryption = this.RequireInfrastructureEncryption
@@ -957,7 +957,7 @@ type StorageBlobContainerBuilder() =
 
     /// Sets the name of the storage account.
     [<CustomOperation "metadata">]
-    member _.Name(state: StorageBlobContainerConfig, metadata: (string * string) list) =
+    member _.Metadata(state: StorageBlobContainerConfig, metadata: (string * string) list) =
         let m = metadata |> Map.ofList
         { state with Metadata = Some(m) }
 

--- a/src/Farmer/Builders/Builders.Storage.fs
+++ b/src/Farmer/Builders/Builders.Storage.fs
@@ -155,15 +155,15 @@ type StorageAccountConfig = {
                     StorageAccount = this.Name.ResourceName
                     Accessibility = access
                 }
+
                 match immutabilityPolicies with
                 | None -> ()
-                | Some immutabilityPolicies ->
-                    {
-                        StorageAccount = this.Name.ResourceName
-                        Container = name
-                        AllowProtectedAppendWrites = immutabilityPolicies.AllowProtectedAppendWrites
-                        ImmutabilityPeriodSinceCreation = immutabilityPolicies.ImmutabilityPeriodSinceCreation
-                    }
+                | Some immutabilityPolicies -> {
+                    StorageAccount = this.Name.ResourceName
+                    Container = name
+                    AllowProtectedAppendWrites = immutabilityPolicies.AllowProtectedAppendWrites
+                    ImmutabilityPeriodSinceCreation = immutabilityPolicies.ImmutabilityPeriodSinceCreation
+                  }
             for (name, shareQuota) in this.FileShares do
                 {
                     Name = name
@@ -278,18 +278,24 @@ type StorageAccountBuilder() =
 
         state
 
-    static member private AddContainers(state, access, names: string seq, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig) = {
-        state with
-            Containers =
-                let containers =
-                    names
-                    |> List.ofSeq
-                    |> List.map (fun name -> ((StorageResourceName.Create name).OkValue, access, immutabilityPolicies))
+    static member private AddContainers
+        (state, access, names: string seq, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig)
+        =
+        {
+            state with
+                Containers =
+                    let containers =
+                        names
+                        |> List.ofSeq
+                        |> List.map (fun name ->
+                            ((StorageResourceName.Create name).OkValue, access, immutabilityPolicies))
 
-                state.Containers @ containers
-    }
+                    state.Containers @ containers
+        }
 
-    static member private AddContainer(state, access, name: string, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig) =
+    static member private AddContainer
+        (state, access, name: string, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig)
+        =
         StorageAccountBuilder.AddContainers(state, access, [ name ], ?immutabilityPolicies = immutabilityPolicies)
 
     static member private AddFileShares(state: StorageAccountConfig, names: string seq, quota) = {
@@ -321,32 +327,44 @@ type StorageAccountBuilder() =
 
     /// Adds private container.
     [<CustomOperation "add_private_container">]
-    member _.AddPrivateContainer(state: StorageAccountConfig, name, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig) =
+    member _.AddPrivateContainer
+        (state: StorageAccountConfig, name, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig)
+        =
         StorageAccountBuilder.AddContainer(state, Private, name, ?immutabilityPolicies = immutabilityPolicies)
 
     /// Adds private containers.
     [<CustomOperation "add_private_containers">]
-    member _.AddPrivateContainers(state: StorageAccountConfig, names, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig) =
+    member _.AddPrivateContainers
+        (state: StorageAccountConfig, names, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig)
+        =
         StorageAccountBuilder.AddContainers(state, Private, names, ?immutabilityPolicies = immutabilityPolicies)
 
     /// Adds container with anonymous read access for blobs and containers.
     [<CustomOperation "add_public_container">]
-    member _.AddPublicContainer(state: StorageAccountConfig, name, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig) =
+    member _.AddPublicContainer
+        (state: StorageAccountConfig, name, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig)
+        =
         StorageAccountBuilder.AddContainer(state, Container, name, ?immutabilityPolicies = immutabilityPolicies)
 
     /// Adds containers with anonymous read access for blobs and containers.
     [<CustomOperation "add_public_containers">]
-    member _.AddPublicContainers(state: StorageAccountConfig, names, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig) =
+    member _.AddPublicContainers
+        (state: StorageAccountConfig, names, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig)
+        =
         StorageAccountBuilder.AddContainers(state, Container, names, ?immutabilityPolicies = immutabilityPolicies)
 
     /// Adds container with anonymous read access for blobs only.
     [<CustomOperation "add_blob_container">]
-    member _.AddBlobContainer(state: StorageAccountConfig, name, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig) =
+    member _.AddBlobContainer
+        (state: StorageAccountConfig, name, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig)
+        =
         StorageAccountBuilder.AddContainer(state, Blob, name, ?immutabilityPolicies = immutabilityPolicies)
 
     /// Adds containers with anonymous read access for blobs only.
     [<CustomOperation "add_blob_containers">]
-    member _.AddBlobContainers(state: StorageAccountConfig, names, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig) =
+    member _.AddBlobContainers
+        (state: StorageAccountConfig, names, ?immutabilityPolicies: BlobContainerImmutabilityPoliciesConfig)
+        =
         StorageAccountBuilder.AddContainers(state, Blob, names, ?immutabilityPolicies = immutabilityPolicies)
 
     /// Adds a file share with no quota.
@@ -806,6 +824,7 @@ type StorageQueueBuilder() =
     member _.Run(state: StorageQueueConfig) : StorageQueueConfig =
         if state.Name.ResourceName = ResourceName.Empty then
             raiseFarmer "No Storage Account name has been set."
+
         state
 
     /// Sets the name of the storage queue.

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -276,6 +276,8 @@ type VmConfig = {
                     DisableBlobPublicAccess = None
                     DisableSharedKeyAccess = None
                     DefaultToOAuthAuthentication = None
+                    ImmutableStorageWithVersioning = None
+                    RequireInfrastructureEncryption = None
                   }
                 | Some _
                 | None -> ()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -71,6 +71,21 @@ module LocationExtensions =
         static member NorwayWest = Location "NorwayWest"
         static member NorwayEast = Location "NorwayEast"
         static member Global = Location "global"
+        static member SpainCentral = Location "SpainCentral"
+        static member ItalyNorth = Location "ItalyNorth"
+        static member PolandCentral = Location "PolandCentral"
+        static member MexicoCentral = Location "MexicoCentral"
+        static member IsraelCentral = Location "IsraelCentral"
+        static member QatarCentral = Location "QatarCentral"
+        static member ChileCentral = Location "ChileCentral"
+        static member NewZealandNorth = Location "NewZealandNorth"
+        static member MalaysiaCentral = Location "MalaysiaCentral"
+        static member IndonesiaCentral = Location "IndonesiaCentral"
+        static member TaiwanNorth = Location "TaiwanNorth"
+        static member AustriaCentral = Location "AustriaCentral"
+        static member GreeceCentral = Location "GreeceCentral"
+        static member DenmarkCentral = Location "DenmarkCentral"
+        static member SwedenCentral = Location "SwedenCentral"
 
         static member ResourceGroup =
             LocationExpression(ArmExpression.create "resourceGroup().location")

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1556,6 +1556,12 @@ module Storage =
         | Container
         | Blob
 
+        member this.ArmValue =
+            match this with
+            | Private -> "None"
+            | Container -> "Container"
+            | Blob -> "Blob"
+
     /// The type of action to take when defining a lifecycle policy.
     type LifecyclePolicyAction =
         | CoolAfter of int<Days>

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1549,6 +1549,12 @@ module Storage =
         /// General Purpose V2 Standard RAGZRS with no default access tier.
         static member Standard_RAGZRS = GeneralPurpose(V2(RAGZRS, None))
 
+    /// <summary>
+    /// The type of access allowed for a storage container.
+    /// </summary>
+    /// <remarks>
+    /// Default is Private.
+    /// </remarks>
     type StorageContainerAccess =
         | Private
         | Container

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1,6 +1,7 @@
-﻿namespace Farmer
+namespace Farmer
 
 open System
+open System.Runtime.CompilerServices
 
 type NonEmptyList<'T> =
     private
@@ -140,6 +141,16 @@ type TlsVersion =
         | Tls10 -> "1.0"
         | Tls11 -> "1.1"
         | Tls12 -> "1.2"
+
+[<AbstractClass; Sealed; Extension>]
+type TlsVersionExtensions =
+
+    [<Extension>]
+    static member ArmValue (version: TlsVersion option) =
+        version
+        |> Option.map (fun v -> v.ArmValue)
+        |> Option.toObj
+
 
 /// Represents an environment variable that can be set, typically on Docker container services.
 type EnvVar =
@@ -1437,6 +1448,11 @@ module Storage =
     type DefaultAccessTier =
         | Hot
         | Cool
+
+        member this.ArmValue =
+            match this with
+            | Hot -> "Hot"
+            | Cool -> "Cool"
 
     type StoragePerformance =
         | Standard

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -161,10 +161,8 @@ type TlsVersion =
 type TlsVersionExtensions =
 
     [<Extension>]
-    static member ArmValue (version: TlsVersion option) =
-        version
-        |> Option.map (fun v -> v.ArmValue)
-        |> Option.toObj
+    static member ArmValue(version: TlsVersion option) =
+        version |> Option.map (fun v -> v.ArmValue) |> Option.toObj
 
 
 /// Represents an environment variable that can be set, typically on Docker container services.

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -435,22 +435,16 @@ type FeatureFlag =
 type FeatureFlagExtensions =
 
     [<Extension>]
-    static member AsBoolean (featureFlag : FeatureFlag option) =
-        featureFlag
-        |> Option.map (fun f -> f.AsBoolean)
-        |> Option.toNullable
+    static member AsBoolean(featureFlag: FeatureFlag option) =
+        featureFlag |> Option.map (fun f -> f.AsBoolean) |> Option.toNullable
 
     [<Extension>]
-    static member BooleanValue (featureFlag : FeatureFlag option) =
-        featureFlag
-        |> Option.map (fun f -> f.BooleanValue)
-        |> Option.toObj
+    static member BooleanValue(featureFlag: FeatureFlag option) =
+        featureFlag |> Option.map (fun f -> f.BooleanValue) |> Option.toObj
 
     [<Extension>]
-    static member ArmValue (featureFlag : FeatureFlag option) =
-        featureFlag
-        |> Option.map (fun f -> f.ArmValue)
-        |> Option.toObj
+    static member ArmValue(featureFlag: FeatureFlag option) =
+        featureFlag |> Option.map (fun f -> f.ArmValue) |> Option.toObj
 
 module FeatureFlag =
     let ofBool enabled = if enabled then Enabled else Disabled

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -421,15 +421,20 @@ type FeatureFlag =
         | Enabled -> true
         | Disabled -> false
 
-    member this.BooleanValue =
+    member this.AsInvertedBoolean =
         match this with
-        | Enabled -> "true"
-        | Disabled -> "false"
+        | Enabled -> false
+        | Disabled -> true
 
     member this.ArmValue =
         match this with
         | Enabled -> "Enabled"
         | Disabled -> "Disabled"
+
+    member this.ArmInvertedValue =
+        match this with
+        | Enabled -> "Disabled"
+        | Disabled -> "Enabled"
 
 [<AbstractClass; Sealed; Extension>]
 type FeatureFlagExtensions =
@@ -439,12 +444,16 @@ type FeatureFlagExtensions =
         featureFlag |> Option.map (fun f -> f.AsBoolean) |> Option.toNullable
 
     [<Extension>]
-    static member BooleanValue(featureFlag: FeatureFlag option) =
-        featureFlag |> Option.map (fun f -> f.BooleanValue) |> Option.toObj
+    static member AsInvertedBoolean(featureFlag: FeatureFlag option) =
+        featureFlag |> Option.map (fun f -> f.AsInvertedBoolean) |> Option.toNullable
 
     [<Extension>]
     static member ArmValue(featureFlag: FeatureFlag option) =
         featureFlag |> Option.map (fun f -> f.ArmValue) |> Option.toObj
+
+    [<Extension>]
+    static member ArmInvertedValue(featureFlag: FeatureFlag option) =
+        featureFlag |> Option.map (fun f -> f.ArmInvertedValue) |> Option.toObj
 
 module FeatureFlag =
     let ofBool enabled = if enabled then Enabled else Disabled

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -1,6 +1,7 @@
 namespace Farmer
 
 open System
+open System.Runtime.CompilerServices
 
 /// Common generic functions to support internals
 [<AutoOpen>]
@@ -420,10 +421,36 @@ type FeatureFlag =
         | Enabled -> true
         | Disabled -> false
 
+    member this.BooleanValue =
+        match this with
+        | Enabled -> "true"
+        | Disabled -> "false"
+
     member this.ArmValue =
         match this with
         | Enabled -> "Enabled"
         | Disabled -> "Disabled"
+
+[<AbstractClass; Sealed; Extension>]
+type FeatureFlagExtensions =
+
+    [<Extension>]
+    static member AsBoolean (featureFlag : FeatureFlag option) =
+        featureFlag
+        |> Option.map (fun f -> f.AsBoolean)
+        |> Option.toNullable
+
+    [<Extension>]
+    static member BooleanValue (featureFlag : FeatureFlag option) =
+        featureFlag
+        |> Option.map (fun f -> f.BooleanValue)
+        |> Option.toObj
+
+    [<Extension>]
+    static member ArmValue (featureFlag : FeatureFlag option) =
+        featureFlag
+        |> Option.map (fun f -> f.ArmValue)
+        |> Option.toObj
 
 module FeatureFlag =
     let ofBool enabled = if enabled then Enabled else Disabled

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -441,19 +441,19 @@ type FeatureFlagExtensions =
 
     [<Extension>]
     static member AsBoolean(featureFlag: FeatureFlag option) =
-        featureFlag |> Option.map (fun f -> f.AsBoolean) |> Option.toNullable
+        featureFlag |> Option.map _.AsBoolean |> Option.toNullable
 
     [<Extension>]
     static member AsInvertedBoolean(featureFlag: FeatureFlag option) =
-        featureFlag |> Option.map (fun f -> f.AsInvertedBoolean) |> Option.toNullable
+        featureFlag |> Option.map _.AsInvertedBoolean |> Option.toNullable
 
     [<Extension>]
     static member ArmValue(featureFlag: FeatureFlag option) =
-        featureFlag |> Option.map (fun f -> f.ArmValue) |> Option.toObj
+        featureFlag |> Option.map _.ArmValue |> Option.toObj
 
     [<Extension>]
     static member ArmInvertedValue(featureFlag: FeatureFlag option) =
-        featureFlag |> Option.map (fun f -> f.ArmInvertedValue) |> Option.toObj
+        featureFlag |> Option.map _.ArmInvertedValue |> Option.toObj
 
 module FeatureFlag =
     let ofBool enabled = if enabled then Enabled else Disabled

--- a/src/Tests/JsonRegression.fs
+++ b/src/Tests/JsonRegression.fs
@@ -329,7 +329,7 @@ let tests =
         test "Can parse JSON into an ARM template" {
             let json =
                 """    {
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2023-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -456,7 +456,7 @@ let tests =
 
             Expect.equal
                 builder.WebsitePrimaryEndpoint.Value
-                "reference(resourceId('Microsoft.Storage/storageAccounts', 'foo'), '2022-05-01').primaryEndpoints.web"
+                "reference(resourceId('Microsoft.Storage/storageAccounts', 'foo'), '2023-05-01').primaryEndpoints.web"
                 "Zone names are not fixed and should be related to a storage account name"
         }
         test "Creates different SKU kinds correctly" {
@@ -736,8 +736,10 @@ let tests =
             let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
             Expect.equal
-                (jobj.SelectToken("resources[0].properties.supportsHttpsTrafficOnly").ToString())
-                "false"
+                (jobj
+                    .SelectToken("resources[0].properties.supportsHttpsTrafficOnly")
+                    .ToObject<bool>())
+                false
                 "https traffic only should be disabled"
         }
 
@@ -754,8 +756,10 @@ let tests =
             let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
             Expect.equal
-                (jobj.SelectToken("resources[0].properties.supportsHttpsTrafficOnly").ToString())
-                "true"
+                (jobj
+                    .SelectToken("resources[0].properties.supportsHttpsTrafficOnly")
+                    .ToObject<bool>())
+                true
                 "https traffic only should be enabled"
         }
 
@@ -863,8 +867,10 @@ let tests =
             let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
             Expect.equal
-                (jobj.SelectToken("resources[0].properties.allowBlobPublicAccess").ToString())
-                "false"
+                (jobj
+                    .SelectToken("resources[0].properties.allowBlobPublicAccess")
+                    .ToObject<bool>())
+                false
                 "blob public access should be disabled"
         }
 
@@ -882,8 +888,10 @@ let tests =
             let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
             Expect.equal
-                (jobj.SelectToken("resources[0].properties.allowBlobPublicAccess").ToString())
-                "true"
+                (jobj
+                    .SelectToken("resources[0].properties.allowBlobPublicAccess")
+                    .ToObject<bool>())
+                true
                 "blob public access should be enabled"
         }
 
@@ -900,8 +908,10 @@ let tests =
             let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
             Expect.equal
-                (jobj.SelectToken("resources[0].properties.allowSharedKeyAccess").ToString())
-                "false"
+                (jobj
+                    .SelectToken("resources[0].properties.allowSharedKeyAccess")
+                    .ToObject<bool>())
+                false
                 "shared key access should be disabled"
         }
 
@@ -919,8 +929,10 @@ let tests =
             let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
 
             Expect.equal
-                (jobj.SelectToken("resources[0].properties.allowSharedKeyAccess").ToString())
-                "true"
+                (jobj
+                    .SelectToken("resources[0].properties.allowSharedKeyAccess")
+                    .ToObject<bool>())
+                true
                 "shared key access should be enabled"
         }
 
@@ -939,8 +951,8 @@ let tests =
             Expect.equal
                 (jobj
                     .SelectToken("resources[0].properties.defaultToOAuthAuthentication")
-                    .ToString())
-                "true"
+                    .ToObject<bool>())
+                true
                 "default to OAuth should be enabled"
         }
 
@@ -960,8 +972,8 @@ let tests =
             Expect.equal
                 (jobj
                     .SelectToken("resources[0].properties.defaultToOAuthAuthentication")
-                    .ToString())
-                "false"
+                    .ToObject<bool>())
+                false
                 "default to OAuth should be disabled"
         }
     ]

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -101,76 +101,6 @@ let tests =
             resource.Validate()
             Expect.isFalse resource.IsHnsEnabled.Value "Hierarchical namespace should be false"
         }
-        test "Creates containers correctly" {
-            let resources: BlobContainer list =
-                let account = storageAccount {
-                    name "storage"
-                    add_blob_container "blob"
-                    add_private_container "private"
-                    add_public_container "public"
-                    add_blob_containers [ "blob1"; "blob2" ]
-                    add_private_containers [ "private1"; "private2" ]
-                    add_public_containers [ "public1"; "public2" ]
-                }
-
-                [
-                    for i in 1..9 do
-                        account |> getResourceAtIndex client.SerializationSettings i
-                ]
-
-            Expect.equal resources.[0].Name "storage/default/blob" "blob name is wrong"
-            Expect.equal resources.[0].PublicAccess.Value PublicAccess.Blob "blob access is wrong"
-            Expect.equal resources.[1].Name "storage/default/private" "private name is wrong"
-            Expect.equal resources.[1].PublicAccess.Value PublicAccess.None "private access is wrong"
-            Expect.equal resources.[2].Name "storage/default/public" "public name is wrong"
-            Expect.equal resources.[2].PublicAccess.Value PublicAccess.Container "container access is wrong"
-            Expect.equal resources.[3].Name "storage/default/blob1" "blob1 name is wrong"
-            Expect.equal resources.[3].PublicAccess.Value PublicAccess.Blob "blob1 access is wrong"
-            Expect.equal resources.[4].Name "storage/default/blob2" "blob2 name is wrong"
-            Expect.equal resources.[4].PublicAccess.Value PublicAccess.Blob "blob2 access is wrong"
-            Expect.equal resources.[5].Name "storage/default/private1" "private1 name is wrong"
-            Expect.equal resources.[5].PublicAccess.Value PublicAccess.None "private1 access is wrong"
-            Expect.equal resources.[6].Name "storage/default/private2" "private2 name is wrong"
-            Expect.equal resources.[6].PublicAccess.Value PublicAccess.None "private2 access is wrong"
-            Expect.equal resources.[7].Name "storage/default/public1" "public1 name is wrong"
-            Expect.equal resources.[7].PublicAccess.Value PublicAccess.Container "public1 access is wrong"
-            Expect.equal resources.[8].Name "storage/default/public2" "public2 name is wrong"
-            Expect.equal resources.[8].PublicAccess.Value PublicAccess.Container "public2 access is wrong"
-        }
-        test "Creates containers with immutability policies" {
-            let policy = blobContainerImmutabilityPolicies {
-                allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed
-                immutability_period_since_creation 5<Days>
-            }
-            let resource =
-                let account = storageAccount {
-                    name "storage"
-                    add_blob_container "blob" policy
-                    add_private_container "private" policy
-                    add_public_container "public" policy
-                    add_blob_containers [ "blob1"; "blob2" ] policy
-                    add_private_containers [ "private1"; "private2" ] policy
-                    add_public_containers [ "public1"; "public2" ] policy
-                }
-
-                arm { add_resource account }
-
-            let jsn = resource.Template |> Writer.toJson
-            let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
-
-            let check i (container: Newtonsoft.Json.Linq.JObject, policy: Newtonsoft.Json.Linq.JObject) =
-                Expect.equal (policy.SelectToken("name").ToObject<string>()) (container.SelectToken("name").ToObject<string>() + "/default") $"policy %d{i} name is wrong"
-                let properties = policy.SelectToken("properties")
-                Expect.equal (properties.SelectToken("immutabilityPeriodSinceCreationInDays").ToObject<int>()) 5 $"policy %d{i} immutability period is wrong"
-                Expect.equal (properties.SelectToken("allowProtectedAppendWritesAll").ToObject<bool>()) true $"policy %d{i} allowProtectedAppendWrites is wrong"
-
-            jobj.SelectTokens("resources[*]")
-            |> Seq.skip 1
-            |> Seq.cast<Newtonsoft.Json.Linq.JObject>
-            |> Seq.chunkBySize 2
-            |> Seq.map (fun items -> (items[0], items[1]))
-            |> Seq.iteri check
-        }
         test "Creates file shares correctly" {
             let resources: FileShare list =
                 let account = storageAccount {
@@ -213,46 +143,297 @@ let tests =
             Expect.equal resources.[1].Name "storage/default/table2" "table name for 'table2' is wrong"
             Expect.equal resources.[2].Name "storage/default/table3" "table name for 'table3' is wrong"
         }
-        testList "Blob Immutability Policies Tests" [
+        testList "Blob Container Immutability Policies Tests" [
             let getPolicy (policyConfig: Builders.Storage.BlobContainerImmutabilityPoliciesConfig) =
                 let account = storageAccount {
                     name "storage"
                     add_blob_container "blob" policyConfig
                 }
+
                 let resource = arm { add_resource account }
-                resource.Template.Resources.OfType<Arm.Storage.BlobContainers.ImmutabilityPolicies>() |> Seq.last
+
+                resource.Template.Resources.OfType<Arm.Storage.BlobContainers.ImmutabilityPolicies>()
+                |> Seq.last
 
             test "Sets NoAppendAllowed correctly" {
                 let policy = blobContainerImmutabilityPolicies {
                     allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.NoAppendAllowed
                 }
+
                 let policy = getPolicy policy
-                Expect.equal policy.ImmutabilityPeriodSinceCreation None "ImmutabilityPeriodSinceCreation not set correctly"
-                Expect.equal policy.AllowProtectedAppendWrites (Some Arm.Storage.AllowProtectedAppendWrites.NoAppendAllowed) "NoAppendAllowed not set correctly"
+
+                Expect.equal
+                    policy.ImmutabilityPeriodSinceCreation
+                    None
+                    "ImmutabilityPeriodSinceCreation not set correctly"
+
+                Expect.equal
+                    policy.AllowProtectedAppendWrites
+                    (Some Arm.Storage.AllowProtectedAppendWrites.NoAppendAllowed)
+                    "NoAppendAllowed not set correctly"
             }
+
             test "Sets AppendBlobOnlyAppendAllowed correctly" {
                 let policy = blobContainerImmutabilityPolicies {
                     allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.AppendBlobOnlyAppendAllowed
                 }
+
                 let policy = getPolicy policy
-                Expect.equal policy.ImmutabilityPeriodSinceCreation None "ImmutabilityPeriodSinceCreation not set correctly"
-                Expect.equal policy.AllowProtectedAppendWrites (Some Arm.Storage.AllowProtectedAppendWrites.AppendBlobOnlyAppendAllowed) "AppendBlobOnlyAppendAllowed not set correctly"
+
+                Expect.equal
+                    policy.ImmutabilityPeriodSinceCreation
+                    None
+                    "ImmutabilityPeriodSinceCreation not set correctly"
+
+                Expect.equal
+                    policy.AllowProtectedAppendWrites
+                    (Some Arm.Storage.AllowProtectedAppendWrites.AppendBlobOnlyAppendAllowed)
+                    "AppendBlobOnlyAppendAllowed not set correctly"
             }
+
             test "Sets AllAppendAllowed correctly" {
                 let policy = blobContainerImmutabilityPolicies {
                     allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed
                 }
+
                 let policy = getPolicy policy
-                Expect.equal policy.ImmutabilityPeriodSinceCreation None "ImmutabilityPeriodSinceCreation not set correctly"
-                Expect.equal policy.AllowProtectedAppendWrites (Some Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed) "AllAppendAllowed not set correctly"
+
+                Expect.equal
+                    policy.ImmutabilityPeriodSinceCreation
+                    None
+                    "ImmutabilityPeriodSinceCreation not set correctly"
+
+                Expect.equal
+                    policy.AllowProtectedAppendWrites
+                    (Some Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed)
+                    "AllAppendAllowed not set correctly"
             }
+
             test "Sets creation period correctly" {
+                let policy = blobContainerImmutabilityPolicies { immutability_period_since_creation 5<Days> }
+                let policy = getPolicy policy
+
+                Expect.equal
+                    policy.ImmutabilityPeriodSinceCreation
+                    (Some 5<Days>)
+                    "ImmutabilityPeriodSinceCreation not set correctly"
+
+                Expect.equal policy.AllowProtectedAppendWrites None "AllowProtectedAppendWrites not set correctly"
+            }
+        ]
+        testList "Blob Container Tests" [
+            test "Creates containers correctly" {
+                let resources: BlobContainer list =
+                    let container = storageBlobContainer {
+                        name "frombuilder"
+                        metadata [ "environment", "dev"; "source", "image" ]
+                    }
+
+                    let account = storageAccount {
+                        name "storage"
+                        add_blob_container "blob"
+                        add_private_container "private"
+                        add_public_container "public"
+                        add_blob_containers [ "blob1"; "blob2" ]
+                        add_private_containers [ "private1"; "private2" ]
+                        add_public_containers [ "public1"; "public2" ]
+                        add_blob_container container
+                    }
+
+                    [
+                        for i in 1..10 do
+                            account |> getResourceAtIndex client.SerializationSettings i
+                    ]
+
+                Expect.equal resources.[0].Name "storage/default/blob" "blob name is wrong"
+                Expect.equal resources.[0].PublicAccess.Value PublicAccess.Blob "blob access is wrong"
+                Expect.equal resources.[1].Name "storage/default/private" "private name is wrong"
+                Expect.equal resources.[1].PublicAccess.Value PublicAccess.None "private access is wrong"
+                Expect.equal resources.[2].Name "storage/default/public" "public name is wrong"
+                Expect.equal resources.[2].PublicAccess.Value PublicAccess.Container "container access is wrong"
+                Expect.equal resources.[3].Name "storage/default/blob1" "blob1 name is wrong"
+                Expect.equal resources.[3].PublicAccess.Value PublicAccess.Blob "blob1 access is wrong"
+                Expect.equal resources.[4].Name "storage/default/blob2" "blob2 name is wrong"
+                Expect.equal resources.[4].PublicAccess.Value PublicAccess.Blob "blob2 access is wrong"
+                Expect.equal resources.[5].Name "storage/default/private1" "private1 name is wrong"
+                Expect.equal resources.[5].PublicAccess.Value PublicAccess.None "private1 access is wrong"
+                Expect.equal resources.[6].Name "storage/default/private2" "private2 name is wrong"
+                Expect.equal resources.[6].PublicAccess.Value PublicAccess.None "private2 access is wrong"
+                Expect.equal resources.[7].Name "storage/default/public1" "public1 name is wrong"
+                Expect.equal resources.[7].PublicAccess.Value PublicAccess.Container "public1 access is wrong"
+                Expect.equal resources.[8].Name "storage/default/public2" "public2 name is wrong"
+                Expect.equal resources.[8].PublicAccess.Value PublicAccess.Container "public2 access is wrong"
+                Expect.equal resources.[9].Name "storage/default/frombuilder" "frombuilder name is wrong"
+                Expect.equal resources.[9].PublicAccess.Value PublicAccess.None "frombuilder access is wrong"
+            }
+            test "Creates containers with immutability policies" {
                 let policy = blobContainerImmutabilityPolicies {
+                    allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed
                     immutability_period_since_creation 5<Days>
                 }
-                let policy = getPolicy policy
-                Expect.equal policy.ImmutabilityPeriodSinceCreation (Some 5<Days>) "ImmutabilityPeriodSinceCreation not set correctly"
-                Expect.equal policy.AllowProtectedAppendWrites None "AllowProtectedAppendWrites not set correctly"
+
+                let resource =
+                    let account = storageAccount {
+                        name "storage"
+
+                        add_blob_container (
+                            storageBlobContainer {
+                                name "blobfrombuilder"
+                                immutability_policies policy
+                            }
+                        )
+
+                        add_blob_container "blob" policy
+                        add_private_container "private" policy
+                        add_public_container "public" policy
+
+                        add_blob_containers [
+                            (storageBlobContainer {
+                                name "blobfrombuilder1"
+                                immutability_policies policy
+                            })
+                            (storageBlobContainer {
+                                name "blobfrombuilder2"
+                                immutability_policies policy
+                            })
+                        ]
+
+                        add_blob_containers [ "blob1"; "blob2" ] policy
+                        add_private_containers [ "private1"; "private2" ] policy
+                        add_public_containers [ "public1"; "public2" ] policy
+                    }
+
+                    arm { add_resource account }
+
+                let jsn = resource.Template |> Writer.toJson
+                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+
+                let check i (container: Newtonsoft.Json.Linq.JObject, policy: Newtonsoft.Json.Linq.JObject) =
+                    Expect.equal
+                        (policy.SelectToken("name").ToObject<string>())
+                        (container.SelectToken("name").ToObject<string>() + "/default")
+                        $"policy %d{i} name is wrong"
+
+                    let properties = policy.SelectToken("properties")
+
+                    Expect.equal
+                        (properties.SelectToken("immutabilityPeriodSinceCreationInDays").ToObject<int>())
+                        5
+                        $"policy %d{i} immutability period is wrong"
+
+                    Expect.equal
+                        (properties.SelectToken("allowProtectedAppendWritesAll").ToObject<bool>())
+                        true
+                        $"policy %d{i} allowProtectedAppendWrites is wrong"
+
+                jobj.SelectTokens("resources[*]")
+                |> Seq.skip 1
+                |> Seq.cast<Newtonsoft.Json.Linq.JObject>
+                |> Seq.chunkBySize 2
+                |> Seq.map (fun items -> (items[0], items[1]))
+                |> Seq.iteri check
+            }
+            test "Metadata is added correctly to single container" {
+                let resource: BlobContainer =
+                    let account = storageAccount {
+                        name "storage"
+
+                        add_blob_container (
+                            storageBlobContainer {
+                                name "container1"
+                                metadata [ "environment", "dev"; "project", "farmer" ]
+                            }
+                        )
+                    }
+
+                    account |> getResourceAtIndex client.SerializationSettings 1
+
+                Expect.equal resource.Name "storage/default/container1" "container name for 'container1' is wrong"
+
+                Expect.containsAll
+                    resource.Metadata
+                    (seq [ ("environment", "dev"); ("project", "farmer") ] |> dict)
+                    "Metadata not set correctly"
+            }
+            test "Metadata is added correctly to multiple containers" {
+                let resources: BlobContainer list =
+                    let account = storageAccount {
+                        name "storage"
+
+                        add_blob_containers [
+                            storageBlobContainer {
+                                name "container1"
+                                metadata [ "environment", "dev"; "project", "farmer" ]
+                            }
+                            storageBlobContainer {
+                                name "container2"
+                                metadata [ "environment", "test"; "project", "barnyard" ]
+                            }
+                        ]
+
+                        add_blob_containers [
+                            storageBlobContainer { name "container3" }
+                            storageBlobContainer { name "container4" }
+                        ] [ "environment", "test"; "project", "barnyard" ]
+                    }
+
+                    [
+                        for i in 1..2 do
+                            account |> getResourceAtIndex client.SerializationSettings i
+                    ]
+
+                Expect.equal resources.[0].Name "storage/default/container1" "container name for 'container1' is wrong"
+                Expect.equal resources.[1].Name "storage/default/container2" "container name for 'container2' is wrong"
+
+                let container1Metadata = seq [ ("environment", "dev"); ("project", "farmer") ]
+                let container2Metadata = seq [ ("environment", "test"); ("project", "barnyard") ]
+
+                Expect.containsAll
+                    resources.[0].Metadata
+                    (container1Metadata |> dict)
+                    "Metadata not set correctly for container1"
+
+                Expect.containsAll
+                    resources.[1].Metadata
+                    (container2Metadata |> dict)
+                    "Metadata not set correctly for container2"
+            }
+            test "Metadata is added correctly to multiple containers when same for all" {
+                let resources: BlobContainer list =
+                    let account = storageAccount {
+                        name "storage"
+
+                        add_blob_containers [
+                            storageBlobContainer {
+                                name "container1"
+                                metadata [ "environment", "dev"; "project", "farmer" ]
+                            }
+                            storageBlobContainer {
+                                name "container2"
+                                metadata [ "environment", "dev"; "project", "farmer" ]
+                            }
+                        ]
+                    }
+
+                    [
+                        for i in 1..2 do
+                            account |> getResourceAtIndex client.SerializationSettings i
+                    ]
+
+                Expect.equal resources.[0].Name "storage/default/container1" "container name for 'container1' is wrong"
+                Expect.equal resources.[1].Name "storage/default/container2" "container name for 'container2' is wrong"
+
+                let containerMetadata = seq [ ("environment", "dev"); ("project", "farmer") ]
+
+                Expect.containsAll
+                    resources.[0].Metadata
+                    (containerMetadata |> dict)
+                    "Metadata not set correctly for container1"
+
+                Expect.containsAll
+                    resources.[1].Metadata
+                    (containerMetadata |> dict)
+                    "Metadata not set correctly for container2"
             }
         ]
         testList "Storage Queue Tests" [
@@ -797,7 +978,7 @@ let tests =
 
                 arm { add_resource account } |> getStorageResource
 
-            Expect.equal resource.MinimumTlsVersion "TLS1_2" "Min TLS version is wrong"
+            Expect.equal resource.MinimumTlsVersion "1.2" "Min TLS version is wrong"
         }
 
         test "Test Disable HTTPS Traffic only" {

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -985,7 +985,13 @@ let tests =
                 let policy = storageAccountImmutabilityPolicy { allow_protected_append_writes }
                 Expect.equal policy.AllowProtectedAppendWrites (Some true) "Immutability policy should be enabled"
             }
-            let check isPolicyEnabled allowWrites (state: StorageImmutabilityPolicyState) period (account: Newtonsoft.Json.Linq.JObject) =
+            let check
+                isPolicyEnabled
+                allowWrites
+                (state: StorageImmutabilityPolicyState)
+                period
+                (account: Newtonsoft.Json.Linq.JObject)
+                =
                 let properties = account.SelectToken("properties")
 
                 let immutableStorageWithVersioning =

--- a/src/Tests/Storage.fs
+++ b/src/Tests/Storage.fs
@@ -5,6 +5,7 @@ open Farmer
 open Farmer.Builders
 open Farmer.Network
 open Farmer.Storage
+open Farmer.Arm.Storage
 open Microsoft.Azure.Management.Storage
 open Microsoft.Azure.Management.Storage.Models
 open Microsoft.Rest
@@ -143,84 +144,6 @@ let tests =
             Expect.equal resources.[1].Name "storage/default/table2" "table name for 'table2' is wrong"
             Expect.equal resources.[2].Name "storage/default/table3" "table name for 'table3' is wrong"
         }
-        testList "Blob Container Immutability Policies Tests" [
-            let getPolicy (policyConfig: Builders.Storage.BlobContainerImmutabilityPoliciesConfig) =
-                let account = storageAccount {
-                    name "storage"
-                    add_blob_container "blob" policyConfig
-                }
-
-                let resource = arm { add_resource account }
-
-                resource.Template.Resources.OfType<Arm.Storage.BlobContainers.ImmutabilityPolicies>()
-                |> Seq.last
-
-            test "Sets NoAppendAllowed correctly" {
-                let policy = blobContainerImmutabilityPolicies {
-                    allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.NoAppendAllowed
-                }
-
-                let policy = getPolicy policy
-
-                Expect.equal
-                    policy.ImmutabilityPeriodSinceCreation
-                    None
-                    "ImmutabilityPeriodSinceCreation not set correctly"
-
-                Expect.equal
-                    policy.AllowProtectedAppendWrites
-                    (Some Arm.Storage.AllowProtectedAppendWrites.NoAppendAllowed)
-                    "NoAppendAllowed not set correctly"
-            }
-
-            test "Sets AppendBlobOnlyAppendAllowed correctly" {
-                let policy = blobContainerImmutabilityPolicies {
-                    allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.AppendBlobOnlyAppendAllowed
-                }
-
-                let policy = getPolicy policy
-
-                Expect.equal
-                    policy.ImmutabilityPeriodSinceCreation
-                    None
-                    "ImmutabilityPeriodSinceCreation not set correctly"
-
-                Expect.equal
-                    policy.AllowProtectedAppendWrites
-                    (Some Arm.Storage.AllowProtectedAppendWrites.AppendBlobOnlyAppendAllowed)
-                    "AppendBlobOnlyAppendAllowed not set correctly"
-            }
-
-            test "Sets AllAppendAllowed correctly" {
-                let policy = blobContainerImmutabilityPolicies {
-                    allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed
-                }
-
-                let policy = getPolicy policy
-
-                Expect.equal
-                    policy.ImmutabilityPeriodSinceCreation
-                    None
-                    "ImmutabilityPeriodSinceCreation not set correctly"
-
-                Expect.equal
-                    policy.AllowProtectedAppendWrites
-                    (Some Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed)
-                    "AllAppendAllowed not set correctly"
-            }
-
-            test "Sets creation period correctly" {
-                let policy = blobContainerImmutabilityPolicies { immutability_period_since_creation 5<Days> }
-                let policy = getPolicy policy
-
-                Expect.equal
-                    policy.ImmutabilityPeriodSinceCreation
-                    (Some 5<Days>)
-                    "ImmutabilityPeriodSinceCreation not set correctly"
-
-                Expect.equal policy.AllowProtectedAppendWrites None "AllowProtectedAppendWrites not set correctly"
-            }
-        ]
         testList "Blob Container Tests" [
             test "Creates containers correctly" {
                 let resources: BlobContainer list =
@@ -434,6 +357,84 @@ let tests =
                     resources.[1].Metadata
                     (containerMetadata |> dict)
                     "Metadata not set correctly for container2"
+            }
+        ]
+        testList "Blob Container Immutability Policies Tests" [
+            let getPolicy (policyConfig: Builders.Storage.BlobContainerImmutabilityPoliciesConfig) =
+                let account = storageAccount {
+                    name "storage"
+                    add_blob_container "blob" policyConfig
+                }
+
+                let resource = arm { add_resource account }
+
+                resource.Template.Resources.OfType<Arm.Storage.BlobContainers.ImmutabilityPolicies>()
+                |> Seq.last
+
+            test "Sets NoAppendAllowed correctly" {
+                let policy = blobContainerImmutabilityPolicies {
+                    allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.NoAppendAllowed
+                }
+
+                let policy = getPolicy policy
+
+                Expect.equal
+                    policy.ImmutabilityPeriodSinceCreation
+                    None
+                    "ImmutabilityPeriodSinceCreation not set correctly"
+
+                Expect.equal
+                    policy.AllowProtectedAppendWrites
+                    (Some Arm.Storage.AllowProtectedAppendWrites.NoAppendAllowed)
+                    "NoAppendAllowed not set correctly"
+            }
+
+            test "Sets AppendBlobOnlyAppendAllowed correctly" {
+                let policy = blobContainerImmutabilityPolicies {
+                    allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.AppendBlobOnlyAppendAllowed
+                }
+
+                let policy = getPolicy policy
+
+                Expect.equal
+                    policy.ImmutabilityPeriodSinceCreation
+                    None
+                    "ImmutabilityPeriodSinceCreation not set correctly"
+
+                Expect.equal
+                    policy.AllowProtectedAppendWrites
+                    (Some Arm.Storage.AllowProtectedAppendWrites.AppendBlobOnlyAppendAllowed)
+                    "AppendBlobOnlyAppendAllowed not set correctly"
+            }
+
+            test "Sets AllAppendAllowed correctly" {
+                let policy = blobContainerImmutabilityPolicies {
+                    allow_protected_append_writes Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed
+                }
+
+                let policy = getPolicy policy
+
+                Expect.equal
+                    policy.ImmutabilityPeriodSinceCreation
+                    None
+                    "ImmutabilityPeriodSinceCreation not set correctly"
+
+                Expect.equal
+                    policy.AllowProtectedAppendWrites
+                    (Some Arm.Storage.AllowProtectedAppendWrites.AllAppendAllowed)
+                    "AllAppendAllowed not set correctly"
+            }
+
+            test "Sets creation period correctly" {
+                let policy = blobContainerImmutabilityPolicies { immutability_period_since_creation 5<Days> }
+                let policy = getPolicy policy
+
+                Expect.equal
+                    policy.ImmutabilityPeriodSinceCreation
+                    (Some 5<Days>)
+                    "ImmutabilityPeriodSinceCreation not set correctly"
+
+                Expect.equal policy.AllowProtectedAppendWrites None "AllowProtectedAppendWrites not set correctly"
             }
         ]
         testList "Storage Queue Tests" [
@@ -957,6 +958,118 @@ let tests =
             Expect.isTrue containerDeleteRetentionPolicy.enabled ""
             Expect.equal containerDeleteRetentionPolicy.days 11 ""
         }
+        testList "Immutability policy tests" [
+            test "Immutability policy enables correctly" {
+                let account = storageAccount {
+                    name "storage"
+                    enable_immutable_storage_with_versioning
+                }
+
+                let value =
+                    Expect.wantSome account.ImmutableStorageWithVersioning "Immutability policy should be set"
+
+                Expect.equal value.Enable (Some Enabled) "Immutability policy should be enabled"
+            }
+            test "Immutability policy disables correctly" {
+                let account = storageAccount {
+                    name "storage"
+                    disable_immutable_storage_with_versioning
+                }
+
+                let value =
+                    Expect.wantSome account.ImmutableStorageWithVersioning "Immutability policy should be set"
+
+                Expect.equal value.Enable (Some Disabled) "Immutability policy should be disabled"
+            }
+            test "Immutable policy is enabled if no value specified" {
+                let policy = storageAccountImmutabilityPolicy { allow_protected_append_writes }
+                Expect.equal policy.AllowProtectedAppendWrites (Some true) "Immutability policy should be enabled"
+            }
+            let check isPolicyEnabled allowWrites (state: StorageImmutabilityPolicyState) period (account: Newtonsoft.Json.Linq.JObject) =
+                let properties = account.SelectToken("properties")
+
+                let immutableStorageWithVersioning =
+                    properties.SelectToken("immutableStorageWithVersioning")
+
+                Expect.equal
+                    (immutableStorageWithVersioning.SelectToken("enable").ToObject<bool>())
+                    isPolicyEnabled
+                    $"enable policy is wrong"
+
+                let policy = immutableStorageWithVersioning.SelectToken("policy")
+
+                Expect.equal
+                    (policy.SelectToken("immutabilityPeriodSinceCreationInDays").ToObject<int>())
+                    period
+                    $"policy immutability period is wrong"
+
+                Expect.equal
+                    (policy.SelectToken("allowProtectedAppendWrites").ToObject<bool>())
+                    allowWrites
+                    $"policy allowProtectedAppendWrites is wrong"
+
+                Expect.equal (policy.SelectToken("state").ToObject<string>()) state.ArmValue $"policy state is wrong"
+
+            test "Immutability policy enables and sets correctly" {
+                let policy = storageAccountImmutabilityPolicy {
+                    allow_protected_append_writes true
+                    immutability_period_since_creation 5<Days>
+                    state StorageImmutabilityPolicyState.Disabled
+                }
+
+                let account = storageAccount {
+                    name "storage"
+                    enable_immutable_storage_with_versioning policy
+                }
+
+                let value =
+                    Expect.wantSome account.ImmutableStorageWithVersioning "Immutability policy should be set"
+
+                let actualPolicy =
+                    Expect.wantSome value.ImmutabilityPolicy "Immutability policy should be set"
+
+                Expect.equal actualPolicy policy "Immutability policy should be set"
+
+                let resource = arm { add_resource account }
+                let jsn = resource.Template |> Writer.toJson
+                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+
+                jobj.SelectTokens("resources[*]")
+                |> Seq.cast<Newtonsoft.Json.Linq.JObject>
+                |> Seq.head
+                |> check true true StorageImmutabilityPolicyState.Disabled 5
+            }
+
+            test "Immutability policy disables and sets correctly" {
+                let policy = storageAccountImmutabilityPolicy {
+                    allow_protected_append_writes false
+                    immutability_period_since_creation 0<Days>
+                    state StorageImmutabilityPolicyState.Unlocked
+                }
+
+                let account = storageAccount {
+                    name "storage"
+                    disable_immutable_storage_with_versioning policy
+                }
+
+                let value =
+                    Expect.wantSome account.ImmutableStorageWithVersioning "Immutability policy should be set"
+
+                let actualPolicy =
+                    Expect.wantSome value.ImmutabilityPolicy "Immutability policy should be set"
+
+                Expect.equal actualPolicy policy "Immutability policy should be set"
+
+                let resource = arm { add_resource account }
+                let jsn = resource.Template |> Writer.toJson
+                let jobj = jsn |> Newtonsoft.Json.Linq.JObject.Parse
+
+                jobj.SelectTokens("resources[*]")
+                |> Seq.cast<Newtonsoft.Json.Linq.JObject>
+                |> Seq.head
+                |> check false false StorageImmutabilityPolicyState.Unlocked 0
+            }
+        ]
 
         test "Versioning" {
             let account = storageAccount {

--- a/src/Tests/VirtualMachine.fs
+++ b/src/Tests/VirtualMachine.fs
@@ -57,7 +57,7 @@ let tests =
 
             Expect.equal
                 resource.DiagnosticsProfile.BootDiagnostics.StorageUri
-                "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2022-05-01').primaryEndpoints.blob]"
+                "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2023-05-01').primaryEndpoints.blob]"
                 "Incorrect diagnostics storage Uri"
         }
 

--- a/src/Tests/test-data/diagnostics.json
+++ b/src/Tests/test-data/diagnostics.json
@@ -5,7 +5,7 @@
   "parameters": {},
   "resources": [
     {
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",

--- a/src/Tests/test-data/event-grid.json
+++ b/src/Tests/test-data/event-grid.json
@@ -5,7 +5,7 @@
   "parameters": {},
   "resources": [
     {
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
@@ -18,7 +18,7 @@
       "type": "Microsoft.Storage/storageAccounts"
     },
     {
-      "apiVersion": "2018-03-01-preview",
+      "apiVersion": "2023-05-01",
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', 'isaacgriddevprac')]"
       ],

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -83,7 +83,7 @@
       "type": "Microsoft.Sql/servers/elasticPools"
     },
     {
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
@@ -223,7 +223,7 @@
       "type": "Microsoft.Web/serverfarms"
     },
     {
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",
@@ -410,12 +410,12 @@
         "isHttpAllowed": true,
         "isHttpsAllowed": true,
         "optimizationType": "GeneralWebDelivery",
-        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2022-05-01').primaryEndpoints.web, 'https://', ''), '/', '')]",
+        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2023-05-01').primaryEndpoints.web, 'https://', ''), '/', '')]",
         "origins": [
           {
             "name": "origin",
             "properties": {
-              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2022-05-01').primaryEndpoints.web, 'https://', ''), '/', '')]"
+              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', 'farmerstorage1979'), '2023-05-01').primaryEndpoints.web, 'https://', ''), '/', '')]"
             }
           }
         ],
@@ -781,7 +781,7 @@
       "type": "Microsoft.Web/serverfarms"
     },
     {
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -20,7 +20,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2022-05-01').primaryEndpoints.blob]"
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', 'isaacsvmstorage'), '2023-05-01').primaryEndpoints.blob]"
           }
         },
         "hardwareProfile": {
@@ -143,7 +143,7 @@
       "type": "Microsoft.Network/publicIPAddresses"
     },
     {
-      "apiVersion": "2022-05-01",
+      "apiVersion": "2023-05-01",
       "dependsOn": [],
       "kind": "StorageV2",
       "location": "northeurope",


### PR DESCRIPTION
Implemented:
* `ImmutableStorageWithVersioning`
* `RequireInfrastructureEncryption`This PR closes #

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Tested my code** end-to-end against a live Azure subscription.
* [X] **Updated the documentation** in the docs folder for the affected changes.
* [X] **Written unit tests** against the modified code that I have made.
* [X] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [X] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
Which test would you recommend to modify or implement?

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let storage = storageAccount {
    name "wormtest222"
    sku Farmer.Storage.Sku.Standard_GRS
    disable_blob_public_access
    add_private_container
        "container"
        (blobContainerImmutabilityPolicies {
            allow_protected_append_writes AllAppendAllowed
            immutability_period_since_creation (365<Days> * 5)
        })
}

```
