### PR TITLE
Sql auth enhancements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 Release Notes
 =============
 ## vNext
+* SQL Azure: Clean up Entra ID authentication support.
 * Az: Update `ad` commands to work with latest (breaking) structure.
 
 ## 1.9.2

--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -11,28 +11,26 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 * SQL Azure server (`Microsoft.Sql/servers`)
 
 #### SQL Server Builder Keywords
-| Keyword | Purpose                                                                                                                         |
+| Keyword | Purpose |
 |-|---------------------------------------------------------------------------------------------------------------------------------|
-| name | Sets the name of the SQL server.                                                                                                |
-| active_directory_admin | Sets Active Directory admin of the server                                                                               |
-| add_firewall_rule | Adds a custom firewall rule given a name, start and end IP address range.                                                       |
-| add_firewall_rules | As add_firewall_rule but a list of rules                                                                                        |
-| enable_azure_firewall | Adds a firewall rule that enables access to other Azure services.                                                               |
-| admin_username | Sets the admin username of the server.                                                                                          |
-| elastic_pool_name | Sets the name of the elastic pool, if required. If not set, Farmer will generate a name for you.                                |
-| elastic_pool_sku | Sets the sku of the elastic pool, if required. If not set, Farmer will default to Basic 50.                                     |
-| elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database.                                              |
-| elastic_pool_capacity | Sets the optional disk size in MB for the elastic pool for each database.                                                       |
-| min_tls_version | Sets the minium TLS version for the SQL server                                                                                  |
+| name | Sets the name of the SQL server. |
+| active_directory_admin | Sets Active Directory admin of the server |
+| add_firewall_rule | Adds a custom firewall rule given a name, start and end IP address range. |
+| add_firewall_rules | As add_firewall_rule but a list of rules |
+| enable_azure_firewall | Adds a firewall rule that enables access to other Azure services. |
+| admin_username | Sets the admin username of the server. The password is supplied as a secret parameter at runtime. |
+| entra_id_admin | Activates Entra ID authentication using the supplied login named, associated objectId and principal type of the administrator account. |
+| entra_id_admin_user | Activates Entra ID authentication for the User Principal Type using the supplied user's login name. The ObjectId will be retrieved automatically from Azure at runtime. |
+| entra_id_admin_group | Activates Entra ID authentication for the Group Principal Type using the supplied group's login name. The ObjectId will be retrieved automatically from Azure at runtime. |
+| elastic_pool_name | Sets the name of the elastic pool, if required. If not set, Farmer will generate a name for you. |
+| elastic_pool_sku | Sets the sku of the elastic pool, if required. If not set, Farmer will default to Basic 50. |
+| elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database. |
+| elastic_pool_capacity | Sets the optional disk size in MB for the elastic pool for each database. |
+| min_tls_version | Sets the minium TLS version for the SQL server |
 | geo_replicate | Geo-replicate all the databases in this server to another location, having NameSuffix after original server and database names. |
 
-#### ActiveDirectoryAdminSettings Members
-| Member | Purpose                                                                    |
-|-|----------------------------------------------------------------------------|
-| Login | Display name of AD admin                                                   |
-| Sid | AD object id of AD admin (user or group)                                   |
-| PrincipalType | ActiveDirectoryPrincipalType User or Group                                 |
-| AdOnlyAuth | Disables SQL authentication. False value required admin_username to be set |
+> You can set at least one of SQL user / pass (using `admin_username`) or Entra ID login (using one of the `entra_id_admin` variants).
+> Setting both will leave both activated; setting only Entra ID will automatically explicitly deactivate user / pass authentication.
 
 #### SQL Server Configuration Members
 | Member | Purpose |
@@ -111,7 +109,7 @@ let activeDirectoryAdmin: ActiveDirectoryAdminSettings =
         AdOnlyAuth = false  // when false, admin_username is required
                             // when true admin_username is ignored
     }
-                        
+
 let myDatabases = sqlServer {
     name "my_server"
     active_directory_admin (Some(activeDirectoryAdmin))

--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -14,14 +14,13 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 | Keyword | Purpose |
 |-|---------------------------------------------------------------------------------------------------------------------------------|
 | name | Sets the name of the SQL server. |
-| active_directory_admin | Sets Active Directory admin of the server |
 | add_firewall_rule | Adds a custom firewall rule given a name, start and end IP address range. |
 | add_firewall_rules | As add_firewall_rule but a list of rules |
 | enable_azure_firewall | Adds a firewall rule that enables access to other Azure services. |
-| admin_username | Sets the admin username of the server. The password is supplied as a secret parameter at runtime. |
-| entra_id_admin | Activates Entra ID authentication using the supplied login named, associated objectId and principal type of the administrator account. |
-| entra_id_admin_user | Activates Entra ID authentication for the User Principal Type using the supplied user's login name. The ObjectId will be retrieved automatically from Azure at runtime. |
-| entra_id_admin_group | Activates Entra ID authentication for the Group Principal Type using the supplied group's login name. The ObjectId will be retrieved automatically from Azure at runtime. |
+| admin_username | Sets the admin username of the server. The password is supplied as a secret parameter at runtime. Optional if you use any of the `entra_id_admin` keywords. |
+| entra_id_admin | Activates Entra ID authentication using the supplied login named, associated objectId and principal type of the administrator account. Optional if you use `admin_username`. |
+| entra_id_admin_user | Activates Entra ID authentication for the User Principal Type using the supplied user's login name. The ObjectId will be retrieved automatically from Azure at runtime. Optional if you use `admin_username`. |
+| entra_id_admin_group | Activates Entra ID authentication for the Group Principal Type using the supplied group's login name. The ObjectId will be retrieved automatically from Azure at runtime. Optional if you use `admin_username`. |
 | elastic_pool_name | Sets the name of the elastic pool, if required. If not set, Farmer will generate a name for you. |
 | elastic_pool_sku | Sets the sku of the elastic pool, if required. If not set, Farmer will default to Basic 50. |
 | elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database. |

--- a/docs/content/api-overview/resources/sql.md
+++ b/docs/content/api-overview/resources/sql.md
@@ -19,8 +19,8 @@ The SQL Azure module contains two builders - `sqlServer`, used to create SQL Azu
 | enable_azure_firewall | Adds a firewall rule that enables access to other Azure services. |
 | admin_username | Sets the admin username of the server. The password is supplied as a secret parameter at runtime. Optional if you use any of the `entra_id_admin` keywords. |
 | entra_id_admin | Activates Entra ID authentication using the supplied login named, associated objectId and principal type of the administrator account. Optional if you use `admin_username`. |
-| entra_id_admin_user | Activates Entra ID authentication for the User Principal Type using the supplied user's login name. The ObjectId will be retrieved automatically from Azure at runtime. Optional if you use `admin_username`. |
-| entra_id_admin_group | Activates Entra ID authentication for the Group Principal Type using the supplied group's login name. The ObjectId will be retrieved automatically from Azure at runtime. Optional if you use `admin_username`. |
+| entra_id_admin_user | Activates Entra ID authentication for the User Principal Type using the supplied user's login name. You can determine the ObjectId using `Farmer.Builders.AccessPolicy.findUsers`. Optional if you use `admin_username`. |
+| entra_id_admin_group | Activates Entra ID authentication for the Group Principal Type using the supplied group's login name. You can determine the ObjectId using `Farmer.Builders.AccessPolicy.findGroups`. Optional if you use `admin_username`. |
 | elastic_pool_name | Sets the name of the elastic pool, if required. If not set, Farmer will generate a name for you. |
 | elastic_pool_sku | Sets the sku of the elastic pool, if required. If not set, Farmer will default to Basic 50. |
 | elastic_pool_database_min_max | Sets the optional minimum and maximum DTUs for the elastic pool for each database. |

--- a/samples/SampleApp/SampleApp.fsproj
+++ b/samples/SampleApp/SampleApp.fsproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.0" />
-    <ProjectReference Include="..\..\src\Farmer\Farmer.fsproj"/>
-    <Compile Include="Program.fs" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Farmer\Farmer.fsproj"/>
+        <Compile Include="Program.fs" />
+    </ItemGroup>
 
 </Project>

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -2,11 +2,11 @@
 module Farmer.Builders.SqlAzure
 
 open Farmer
+open Farmer.Arm
+open Farmer.Arm.Sql.Servers
+open Farmer.Arm.Sql.Servers.Databases
 open Farmer.Sql
-open Farmer.Arm.Sql
 open System.Net
-open Servers
-open Databases
 
 type SqlAzureDbConfig = {
     Name: ResourceName
@@ -18,11 +18,7 @@ type SqlAzureDbConfig = {
 
 type SqlAzureConfig = {
     Name: SqlAccountName
-    AdministratorCredentials: {|
-        UserName: string
-        Password: SecureParameter
-    |}
-    ActiveDirectoryAdmin: ActiveDirectoryAdminSettings option
+    Credentials: SqlCredentials option
     MinTlsVersion: TlsVersion option
     FirewallRules:
         {|
@@ -43,16 +39,23 @@ type SqlAzureConfig = {
 
     /// Gets a basic .NET connection string using the administrator username / password.
     member this.ConnectionString(database: SqlAzureDbConfig) =
-        let expr =
-            ArmExpression.concat [
-                ArmExpression.literal
-                    $"Server=tcp:{this.Name.ResourceName.Value}.database.windows.net,1433;Initial Catalog={database.Name.Value};Persist Security Info=False;User ID={this.AdministratorCredentials.UserName};Password="
-                this.AdministratorCredentials.Password.ArmExpression
-                ArmExpression.literal
-                    ";MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
-            ]
+        match this.Credentials with
+        | Some(SqlOnly sqlCredentials)
+        | Some(SqlAndEntra(sqlCredentials, _)) ->
+            let expr =
+                ArmExpression.concat [
+                    ArmExpression.literal
+                        $"Server=tcp:{this.Name.ResourceName.Value}.database.windows.net,1433;Initial Catalog={database.Name.Value};Persist Security Info=False;User ID={sqlCredentials.Username};Password="
+                    sqlCredentials.Password.ArmExpression
+                    ArmExpression.literal
+                        ";MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+                ]
 
-        expr.WithOwner(databases.resourceId (this.Name.ResourceName, database.Name))
+            expr.WithOwner(databases.resourceId (this.Name.ResourceName, database.Name))
+        | Some(EntraOnly _) ->
+            raiseFarmer
+                "Cannot create a connection string for a database that is using Azure Active Directory authentication."
+        | None -> raiseFarmer "Cannot create a connection string for a database that does not have any credentials set."
 
     member this.ConnectionString databaseName =
         this.Databases
@@ -78,13 +81,9 @@ type SqlAzureConfig = {
                 ServerName = this.Name
                 Location = location
                 Credentials =
-                    match this.ActiveDirectoryAdmin with
-                    | AdOnlyAuth _ -> Unchecked.defaultof<_>
-                    | _ -> {|
-                        Username = this.AdministratorCredentials.UserName
-                        Password = this.AdministratorCredentials.Password
-                      |}
-                ActiveDirectoryAdmin = this.ActiveDirectoryAdmin
+                    match this.Credentials with
+                    | Some credentials -> credentials
+                    | None -> raiseFarmer "No credentials have been set for the SQL Server instance."
                 MinTlsVersion = this.MinTlsVersion
                 Tags = this.Tags
             }
@@ -145,11 +144,10 @@ type SqlAzureConfig = {
                     {
                         ServerName = replicaServerName
                         Location = replica.Location
-                        Credentials = {|
-                            Username = this.AdministratorCredentials.UserName
-                            Password = this.AdministratorCredentials.Password
-                        |}
-                        ActiveDirectoryAdmin = this.ActiveDirectoryAdmin
+                        Credentials =
+                            match this.Credentials with
+                            | Some credentials -> credentials
+                            | None -> raiseFarmer "No credentials have been set for the SQL Server instance."
                         MinTlsVersion = this.MinTlsVersion
                         Tags = this.Tags
                     }
@@ -172,13 +170,11 @@ type SqlAzureConfig = {
                             apiVersion = "2021-02-01-preview"
                             location = replica.Location.ArmValue
                             dependsOn = [
-                                Farmer.ResourceId
-                                    .create(Farmer.Arm.Sql.servers, replicaServerName.ResourceName)
-                                    .Eval()
+                                Farmer.ResourceId.create(servers, replicaServerName.ResourceName).Eval()
                                 primaryDatabaseFullId
                             ]
                             name = $"{replicaServerName.ResourceName.Value}/{database.Name.Value + replica.NameSuffix}"
-                            ``type`` = Farmer.Arm.Sql.databases.Type
+                            ``type`` = databases.Type
                             sku = {|
                                 name = fst geoSku
                                 tier = snd geoSku
@@ -271,11 +267,7 @@ type SqlServerBuilder() =
 
     member _.Yield _ = {
         Name = SqlAccountName.Empty
-        AdministratorCredentials = {|
-            UserName = ""
-            Password = SecureParameter ""
-        |}
-        ActiveDirectoryAdmin = None
+        Credentials = None
         ElasticPoolSettings = {|
             Name = None
             Sku = PoolSku.Basic50
@@ -293,26 +285,10 @@ type SqlServerBuilder() =
         if state.Name.ResourceName = ResourceName.Empty then
             raiseFarmer "No SQL Server account name has been set."
 
-        let getStateWithAdminCredentials () =
-            if System.String.IsNullOrWhiteSpace state.AdministratorCredentials.UserName then
-                raiseFarmer
-                    $"You must specify the admin_username for SQL Server instance {state.Name.ResourceName.Value}"
+        if state.Credentials.IsNone then
+            raiseFarmer "No credentials have been set for the SQL Server instance."
 
-            {
-                state with
-                    AdministratorCredentials = {|
-                        state.AdministratorCredentials with
-                            Password = SecureParameter state.PasswordParameter
-                    |}
-            }
-
-        match state.ActiveDirectoryAdmin with
-        | AdOnlyAuth _ -> {
-            state with
-                AdministratorCredentials = Unchecked.defaultof<_>
-          }
-        | MixedModeAuth _ -> getStateWithAdminCredentials ()
-        | SqlOnlyAuth -> getStateWithAdminCredentials ()
+        state
 
     /// Sets the name of the SQL server.
     [<CustomOperation "name">]
@@ -404,15 +380,24 @@ type SqlServerBuilder() =
     member this.UseAzureFirewall(state: SqlAzureConfig) =
         this.AddFirewallRule(state, "allow-azure-services", "0.0.0.0", "0.0.0.0")
 
-    /// Sets the admin username of the server (note: the password is supplied as a securestring parameter to the generated ARM template).
+    /// Sets the admin username of the server (note: the password is supplied as a securestring parameter to the generated ARM template) using SQL authentication.
+    /// If you have already set the Entra ID credentials, they will be preserved as a hybrid setup.
     [<CustomOperation "admin_username">]
-    member _.AdminUsername(state: SqlAzureConfig, username) = {
-        state with
-            AdministratorCredentials = {|
-                state.AdministratorCredentials with
-                    UserName = username
-            |}
-    }
+    member _.AdminUsername(state: SqlAzureConfig, username) =
+        let sqlCredentials = {
+            Username = username
+            Password = SecureParameter state.PasswordParameter
+        }
+
+        {
+            state with
+                Credentials =
+                    match state.Credentials with
+                    | None
+                    | Some(SqlOnly _) -> Some(SqlOnly sqlCredentials)
+                    | Some(SqlAndEntra(_, entraCredentials))
+                    | Some(EntraOnly entraCredentials) -> Some(SqlAndEntra(sqlCredentials, entraCredentials))
+        }
 
     /// Set minimum TLS version
     [<CustomOperation "min_tls_version">]
@@ -423,16 +408,54 @@ type SqlServerBuilder() =
 
     /// Geo-replicate all the databases in this server to another location, having NameSuffix after original server and database names.
     [<CustomOperation "geo_replicate">]
-    member _.SetGeoReplication(state: SqlAzureConfig, replicaSettings) = {
+    member _.SetGeoReplication(state, replicaSettings) = {
         state with
             GeoReplicaServer = Some replicaSettings
     }
 
-    /// Sets the active directory admin and optionally turns on AD only auth.
+    /// Activates Entra ID authentication using the supplied credentials for the administrator account. Farmer determines the Object ID / SID using `ad user list`.
+    /// If you have already set the SQL admin credentials, they will be preserved as a hybrid setup.
+    [<CustomOperation "entra_id_admin">]
+    member this.SetEntraIdAuthenticationUser(state: SqlAzureConfig, login) =
+        match AccessPolicy.findUsers [ login ] |> Array.toList with
+        | [] -> raiseFarmer $"Login {login} not found in the directory."
+        | user :: _ ->
+            this.SetEntraIdAuthentication(
+                state,
+                SqlServerBuilder.CreateCredentials(login, user.Id.Value, PrincipalType.User)
+            )
+
+    /// Activates Entra ID authentication using the supplied credentials for the administrator account. Farmer determines the Object ID / SID using `ad user list`.
+    /// If you have already set the SQL admin credentials, they will be preserved as a hybrid setup.
+    [<CustomOperation "entra_id_admin_group">]
+    member this.SetEntraIdAuthenticationGroup(state: SqlAzureConfig, login) =
+        match AccessPolicy.findGroups [ login ] |> Array.toList with
+        | [] -> raiseFarmer $"Login {login} not found in the directory."
+        | user :: _ ->
+            this.SetEntraIdAuthentication(
+                state,
+                SqlServerBuilder.CreateCredentials(login, user.Id.Value, PrincipalType.Group)
+            )
+
+    /// Activates Entra ID authentication using the supplied credentials for the administrator account, with the object id / sid and principal type manually supplied by you.
+    /// If you have already set the SQL admin credentials, they will be preserved as a hybrid setup.
+    static member private CreateCredentials(login, objectId, principalType) = {
+        Login = login
+        Sid = ObjectId objectId
+        PrincipalType = principalType
+    }
+
+    /// Activates Entra ID authentication using the supplied credentials for the administrator account.
+    /// If you have already set the SQL admin credentials, they will be preserved as a hybrid setup.
     [<CustomOperation "active_directory_admin">]
-    member _.SetActiveDirectoryAdmin(state: SqlAzureConfig, activeDirectoryAdminSettings) = {
+    member _.SetEntraIdAuthentication(state: SqlAzureConfig, entraCredentials) = {
         state with
-            ActiveDirectoryAdmin = activeDirectoryAdminSettings
+            Credentials =
+                match state.Credentials with
+                | None
+                | Some(EntraOnly _) -> Some(EntraOnly entraCredentials)
+                | Some(SqlAndEntra(sqlCredentials, _))
+                | Some(SqlOnly sqlCredentials) -> Some(SqlAndEntra(sqlCredentials, entraCredentials))
     }
 
     interface ITaggable<SqlAzureConfig> with

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -417,18 +417,14 @@ type SqlServerBuilder() =
     /// Activates Entra ID authentication using the supplied Entra username (i.e. email address) for the administrator account. Farmer determines the Object ID / SID using `ad user list`.
     /// If you have set the SQL admin credentials, they will be preserved as a hybrid setup.
     [<CustomOperation "entra_id_admin_user">]
-    member this.SetEntraIdAuthenticationUser(state: SqlAzureConfig, login) =
-        match AccessPolicy.findUsers [ login ] |> Array.toList with
-        | [] -> raiseFarmer $"Login {login} not found in the directory."
-        | user :: _ -> this.SetEntraIdAuthentication(state, login, user.Id, PrincipalType.User)
+    member this.SetEntraIdAuthenticationUser(state: SqlAzureConfig, login, sid) =
+        this.SetEntraIdAuthentication(state, login, sid, PrincipalType.User)
 
     /// Activates Entra ID authentication using the supplied Entra groupname for the administrator account. Farmer determines the Object ID / SID using `ad user list`.
     /// If you have set the SQL admin credentials, they will be preserved as a hybrid setup.
     [<CustomOperation "entra_id_admin_group">]
-    member this.SetEntraIdAuthenticationGroup(state: SqlAzureConfig, login) =
-        match AccessPolicy.findGroups [ login ] |> Array.toList with
-        | [] -> raiseFarmer $"Login {login} not found in the directory."
-        | group :: _ -> this.SetEntraIdAuthentication(state, login, group.Id, PrincipalType.Group)
+    member this.SetEntraIdAuthenticationGroup(state: SqlAzureConfig, login, sid) =
+        this.SetEntraIdAuthentication(state, login, sid, PrincipalType.Group)
 
     /// Activates Entra ID authentication using the supplied login named, associated objectId and principal type of the administrator account.
     /// If you have set the SQL admin credentials, they will be preserved as a hybrid setup.

--- a/src/Farmer/Builders/Builders.Sql.fs
+++ b/src/Farmer/Builders/Builders.Sql.fs
@@ -420,7 +420,7 @@ type SqlServerBuilder() =
     member this.SetEntraIdAuthenticationUser(state: SqlAzureConfig, login) =
         match AccessPolicy.findUsers [ login ] |> Array.toList with
         | [] -> raiseFarmer $"Login {login} not found in the directory."
-        | user :: _ -> this.SetEntraIdAuthentication(state, login, user.Id.Value.ToString(), PrincipalType.User)
+        | user :: _ -> this.SetEntraIdAuthentication(state, login, user.Id, PrincipalType.User)
 
     /// Activates Entra ID authentication using the supplied Entra groupname for the administrator account. Farmer determines the Object ID / SID using `ad user list`.
     /// If you have set the SQL admin credentials, they will be preserved as a hybrid setup.
@@ -428,15 +428,15 @@ type SqlServerBuilder() =
     member this.SetEntraIdAuthenticationGroup(state: SqlAzureConfig, login) =
         match AccessPolicy.findGroups [ login ] |> Array.toList with
         | [] -> raiseFarmer $"Login {login} not found in the directory."
-        | group :: _ -> this.SetEntraIdAuthentication(state, login, group.Id.Value.ToString(), PrincipalType.Group)
+        | group :: _ -> this.SetEntraIdAuthentication(state, login, group.Id, PrincipalType.Group)
 
-    /// Activates Entra ID authentication using the supplied credentials for the administrator account.
+    /// Activates Entra ID authentication using the supplied login named, associated objectId and principal type of the administrator account.
     /// If you have set the SQL admin credentials, they will be preserved as a hybrid setup.
     [<CustomOperation "entra_id_admin">]
-    member _.SetEntraIdAuthentication(state: SqlAzureConfig, login, objectId: string, principalType) =
+    member _.SetEntraIdAuthentication(state: SqlAzureConfig, login, objectId: ObjectId, principalType) =
         let entraCredentials = {
             Login = login
-            Sid = objectId |> Guid.Parse |> ObjectId
+            Sid = objectId
             PrincipalType = principalType
         }
 

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -132,6 +132,12 @@ type TlsVersion =
     | Tls11
     | Tls12
 
+    member this.ArmValue =
+        match this with
+        | Tls10 -> "1.0"
+        | Tls11 -> "1.1"
+        | Tls12 -> "1.2"
+
 /// Represents an environment variable that can be set, typically on Docker container services.
 type EnvVar =
     /// Use for non-secret environment variables. These will be stored in cleartext in the ARM template.

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -438,7 +438,12 @@ type PrincipalId =
         match this with
         | PrincipalId e -> e
 
-type ObjectId = ObjectId of Guid
+type ObjectId =
+    | ObjectId of Guid
+
+    member this.Value =
+        match this with
+        | ObjectId id -> id
 
 /// Represents a secret to be captured either via an ARM expression or a secure parameter.
 type SecretValue =

--- a/src/Tests/KeyVault.fs
+++ b/src/Tests/KeyVault.fs
@@ -48,6 +48,7 @@ let tests =
             let p = AccessPolicy.create (ObjectId Guid.Empty)
             Expect.equal (set [ Secret.Get; Secret.List ]) p.Permissions.Secrets "Incorrect default secrets"
         }
+
         test "Creates key vault secrets correctly" {
             let parameterSecret = SecretConfig.create "test"
             Expect.equal parameterSecret.SecretName "test" "Invalid name of simple secret"

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -330,7 +330,7 @@ let tests =
             Expect.isTrue (adminToken["azureADOnlyAuthentication"].GetValue()) "Should only have AD auth."
         }
 
-        test "No Entra ARM when just using SQL" {
+        test "No Entra ARM when just using SQL auth" {
             let theServer = sqlServer {
                 name "my-sql-server"
                 admin_username "test"
@@ -354,7 +354,8 @@ let tests =
 
             let azureAdOnlyAuth =
                 json.["resources"].[0].["properties"].["administrators"].["azureADOnlyAuthentication"]
+                    .GetValue()
 
-            Expect.isFalse (azureAdOnlyAuth.GetValue()) "Should not only have AD auth."
+            Expect.isFalse azureAdOnlyAuth "Should be mixed authetication."
         }
     ]

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -319,7 +319,6 @@ let tests =
             }
 
             let template = arm { add_resource server }
-
             let json = template.Template |> Writer.toJson |> JsonObject.Parse
             let adminToken = json.["resources"].[0].["properties"].["administrators"]
 
@@ -357,5 +356,37 @@ let tests =
                     .GetValue()
 
             Expect.isFalse azureAdOnlyAuth "Should be mixed authetication."
+        }
+
+        test "Can set Entra Auth for users" {
+            let server = sqlServer {
+                name "my-sql-server"
+                entra_id_admin_user "entra-user" (ObjectId Guid.Empty)
+            }
+
+            let template = arm { add_resource server }
+            let json = template.Template |> Writer.toJson |> JsonObject.Parse
+
+            let principalType =
+                json.["resources"].[0].["properties"].["administrators"].["principalType"]
+                    .GetValue()
+
+            Expect.equal principalType "User" "Principal type should be User"
+        }
+
+        test "Can set Entra Auth for groups" {
+            let server = sqlServer {
+                name "my-sql-server"
+                entra_id_admin_group "entra-group" (ObjectId Guid.Empty)
+            }
+
+            let template = arm { add_resource server }
+            let json = template.Template |> Writer.toJson |> JsonObject.Parse
+
+            let principalType =
+                json.["resources"].[0].["properties"].["administrators"].["principalType"]
+                    .GetValue()
+
+            Expect.equal principalType "Group" "Principal type should be Group"
         }
     ]

--- a/src/Tests/Sql.fs
+++ b/src/Tests/Sql.fs
@@ -311,12 +311,7 @@ let tests =
         test "Can use Entra ID auth" {
             let server = sqlServer {
                 name "my-sql-server"
-
-                active_directory_admin {
-                    Login = "entra-user"
-                    Sid = ObjectId(Guid.Parse "f9d49c34-01ba-4897-b7e2-3694bf3de2cf")
-                    PrincipalType = PrincipalType.User
-                }
+                entra_id_admin "entra-user" "f9d49c34-01ba-4897-b7e2-3694bf3de2cf" PrincipalType.User
             }
 
             let template = arm { add_resource server }
@@ -353,12 +348,7 @@ let tests =
             let theServer = sqlServer {
                 name "my-sql-server"
                 admin_username "test"
-
-                active_directory_admin {
-                    Login = ""
-                    Sid = ObjectId Guid.Empty
-                    PrincipalType = PrincipalType.User
-                }
+                entra_id_admin "" (string Guid.Empty) PrincipalType.User
             }
 
             let template = arm { add_resource theServer }

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -16,9 +16,9 @@
       "location": "northeurope",
       "name": "farmersql1979",
       "properties": {
-        "version": "12.0",
         "administratorLogin": "farmersqladmin",
-        "administratorLoginPassword": "[parameters('password-for-farmersql1979')]"
+        "administratorLoginPassword": "[parameters('password-for-farmersql1979')]",
+        "version": "12.0"
       },
       "tags": {
         "displayName": "farmersql1979"


### PR DESCRIPTION
This PR closes #1146

The changes in this PR are as follows:

* Update the API surface to make it easier to interact with.
* Support for mixed-mode authentication.
* Improve type-system by making a dedicated authentication type that caters for sql / entra id / mixed mode.authentication.
* Simply the ARM generation code and remove the unusual "base" code implementation.
* Added some extra unit tests.
* Automatically retrieve the ObjectID of the user if it is not supplied (via an AZ CLI call)

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

```fsharp
let theServer = sqlServer {
    name "isaac-farmer-entra-test-server"

    // Can still use this if you want to still enable SQL auth, but no longer necessary
    admin_user "super-sql-admin"

    // Use one of the following
    entra_id_admin_user "me@mycompany.com" (ObjectId Guid.Empty) // get via Farmer.Builders.AccessPolicy.findUsers
    entra_id_admin_group "DBA Adminstrators Group"  (ObjectId Guid.Empty) // get via Farmer.Builders.AccessPolicy.findGroups
    entra_id_admin "me@mycompany.com" (ObjectId Guid.Empty) PrincipalType.User
}
```
