### PR TITLE
Adding nsg support to nics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.9.6
+- Network Interface: Support for adding Network Security Group (NSG) to Network Interface (NIC)
+
 ## 1.9.5
 * Fix an issue with Access Policies that allows non-string sequences to be supplied for user / group lookups.
 * Virtual Network: Specify the route table for a subnet.

--- a/docs/content/api-overview/resources/network-interface.md
+++ b/docs/content/api-overview/resources/network-interface.md
@@ -5,8 +5,8 @@ weight: 5
 ---
 
 #### Overview
-The `networkInterface` builder allows you to create network interfaces (NIC) so that Azure virtual machine (VM) can 
-communicate with internet, Azure, and on-premises resources. To learn more about routeServer, reference to 
+The `networkInterface` builder allows you to create network interfaces (NIC) so that Azure virtual machine (VM) can
+communicate with internet, Azure, and on-premises resources. To learn more about routeServer, reference to
 [Azure Docs](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-network-interface?tabs=azure-portal)
 
 * NetworkInterface (`Microsoft.Network/networkInterfaces`)
@@ -23,6 +23,8 @@ communicate with internet, Azure, and on-premises resources. To learn more about
 | networkInterface | add_static_ip       | Use static ip for the network interface. If not provided, ip will be dynamically allocated            |
 | networkInterface | accelerated_networking_flag    | The accelerated networking flag for the network interface. Default is false                           |
 | networkInterface | ip_forwarding_flag    | The ip forwarding flag for the network interface. Default is false                                    |
+| networkInterface | network_security_group               | Specify the network security group from the same deployment.                                          |
+| networkInterface | link_to_network_security_group       | Specify an existing network security group for this network interface.                                |
 
 #### Example
 

--- a/src/Farmer/Arm/Compute.fs
+++ b/src/Farmer/Arm/Compute.fs
@@ -176,7 +176,7 @@ type NetworkInterfaceConfiguration = {
     EnableIpForwarding: bool option
     IpConfigs: IpConfiguration list
     VirtualNetwork: LinkedResource
-    NetworkSecurityGroup: ResourceId option
+    NetworkSecurityGroup: LinkedResource option
     Primary: bool
 } with
 
@@ -187,6 +187,7 @@ type NetworkInterfaceConfiguration = {
             enableIPForwarding = this.EnableIpForwarding |> Option.map box |> Option.defaultValue null
             networkSecurityGroup =
                 this.NetworkSecurityGroup
+                |> Option.map _.ResourceId
                 |> Option.map ResourceId.AsIdObject
                 |> Option.map box
                 |> Option.defaultValue null

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -156,7 +156,7 @@ type VmConfig = {
                         Prefixes = [ this.SubnetPrefix ]
                         VirtualNetwork = Some(Managed vnet)
                         RouteTable = None
-                        NetworkSecurityGroup = nsgId |> Option.map Managed
+                        NetworkSecurityGroup = nsgId
                         Delegations = []
                         NatGateway = None
                         ServiceEndpoints = []
@@ -176,7 +176,9 @@ type VmConfig = {
         member this.ResourceId = this.ResourceId
 
         member this.BuildResources location =
-            let nsgId = this.NetworkSecurityGroup |> Option.map (fun nsg -> nsg.ResourceId)
+            let nsgId =
+                this.NetworkSecurityGroup |> Option.map (fun nsg -> (Managed nsg.ResourceId))
+
             let generatedNics = this.buildNics (location, nsgId)
 
             [

--- a/src/Farmer/Builders/Builders.VmScaleSet.fs
+++ b/src/Farmer/Builders/Builders.VmScaleSet.fs
@@ -165,7 +165,8 @@ type VmScaleSetConfig = {
             match this.Vm with
             | None -> raiseFarmer "The 'vm_profile' must be set for the VM scale set."
             | Some vm ->
-                let nsgId = vm.NetworkSecurityGroup |> Option.map (fun lr -> lr.ResourceId)
+                let nsgId =
+                    vm.NetworkSecurityGroup |> Option.map (fun lr -> (Managed lr.ResourceId))
 
                 [
                     // The VM Scale Set


### PR DESCRIPTION
This PR closes #1158 

The changes in this PR are as follows:

* Network Interface: Support for adding Network Security Group (NSG) to Network Interface (NIC)


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let deployment = arm {
    location Location.EastUS
    add_resources [
        nsg { name "my-nsg" }
        networkInterface {
            name "my-network-interface-with-nsg"
            link_to_subnet "test-subnet"
            link_to_vnet "test-vnet"
            network_security_group (networkSecurityGroups.resourceId "my-nsg")
        }
    ]
}
```
