### PR TITLE
#1097 - Gremlin graph support to CosmosDb

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,12 @@
 Release Notes
 =============
-## vNext
+
+## 1.9.5
 * Fix an issue with Access Policies that allows non-string sequences to be supplied for user / group lookups.
+* Virtual Network: Specify the route table for a subnet.
 
 ## 1.9.4
 * Network Security Groups: Use a common protocol in security rules with multiple sources. Defaults to Any if sources use different protocols.
-* Virtual Network: Specify the route table for a subnet.
 
 ## 1.9.3
 * Deployments: Default to resource group location rather than West Europe.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.9.6
+* CosmosDB: Add support for Gremlin Graphs
+
 ## 1.9.5
 * Fix an issue with Access Policies that allows non-string sequences to be supplied for user / group lookups.
 * Virtual Network: Specify the route table for a subnet.

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -12,35 +12,39 @@ The CosmosDb package containers two builders, used to create *databases* and *co
 * CosmosDB SQL (`Microsoft.DocumentDB/databaseAccounts/sqlDatabases`)
 * CosmosDB MongoDB (`Microsoft.DocumentDB/databaseAccounts/mongodbDatabases`)
 * CosmosDB SQL Container (`Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers`)
+* CosmosDB Graph databases (`Microsoft.DocumentDb/databaseAccounts/gremlinDatabases`)
+* CosmosDB Graph containers (`Microsoft.DocumentDb/databaseAccounts/gremlinDatabases/graphs`)
 
-> There is currently only support for document databases (the so-called "SQL API"), with support for Gremlin, Table and Cassandra data models planned.
+> There is currently support for document databases (the so-called "SQL API") and Gremlin graphs. Support for Table and Cassandra data models planned.
 
 #### Cosmos DB Builder
 The CosmosDB builder abstracts the idea of an account and database into one. If you wish to "re-use" an already-created Cosmos DB account, use the `link_to_account` keyword - no account will be created and the database will be attached to the existing one.
 
-| Applies To | Keyword | Purpose |
-|-|-|-|
-| Database | name | Sets the name of the database. |
-| Database | link_to_account | Instructs Farmer to link this database to an existing Cosmos DB account rather than creating a new one. |
-| Database | throughput | Sets the throughput with either "provisioned throughput" or "serverless". |
-| Database | add_containers | Adds a list of containers to the database. |
-| Account | account_name | Sets the name of the CosmosDB account. |
-| Account | api (not yet implemented) | Sets the API and data model to use -- currently defaults to "Core (SQL)". |
-| Account | enable_public_network_access | Enables public network access for the account. |
+| Applies To | Keyword                       | Purpose |
+|-|-------------------------------|-|
+| Database | name                          | Sets the name of the database. |
+| Database | link_to_account               | Instructs Farmer to link this database to an existing Cosmos DB account rather than creating a new one. |
+| Database | throughput                    | Sets the throughput with either "provisioned throughput" or "serverless". |
+| Database | add_containers                | Adds a list of containers to the database. |
+| Account | account_name                  | Sets the name of the CosmosDB account. |
+| Account | kind                          | Sets the API and data model to use -- currently defaults to "Core (SQL)". |
+| Account | enable_public_network_access  | Enables public network access for the account. |
 | Account | disable_public_network_access | Disables public network access for the account. |
-| Account | consistency_policy | Sets the consistency policy of the database. |
-| Account | failover_policy | Sets the failover policy of the database. |
-| Account | free_tier | Registers this server with the free pricing tier, if supported and allowed by Azure. |
+| Account | consistency_policy            | Sets the consistency policy of the database. |
+| Account | failover_policy               | Sets the failover policy of the database. |
+| Account | free_tier                     | Registers this server with the free pricing tier, if supported and allowed by Azure. |
 
 #### Cosmos Container Builder
 The container builder allows you to create and configure a specific container that is attached to a cosmos database.
 
-| Keyword | Purpose |
-|-|-|
-| name | Sets the name of the container. |
-| partition_key | Sets the partition key of the container. |
-| add_index | Adds an index to the container. |
-| exclude_path | Excludes a path from the container index. |
+| Keyword | Purpose                                                                                    |
+|-|--------------------------------------------------------------------------------------------|
+| name | Sets the name of the container.                                                            |
+| partition_key | Sets the partition key of the container.                                                   |
+| add_index | Adds an index to the container.                                                            |
+| exclude_path | Excludes a path from the container index.                                                  |
+| gremlin_graph | Marks the container as graph (must be used with an account of `kind DatabaseKind.Gremlin`) |
+
 
 #### Example
 ```fsharp
@@ -53,12 +57,14 @@ let myCosmosDb = cosmosDb {
     throughput 400<CosmosDb.RU> // or throughput Serverless
     failover_policy CosmosDb.NoFailover
     consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
+    //kind DatabaseKind.Gremlin //Create a gremlin enabled account
     add_containers [
         cosmosContainer {
             name "myContainer"
             partition_key [ "/id" ] CosmosDb.Hash
             add_index "/path" [ CosmosDb.Number, CosmosDb.Hash ]
             exclude_path "/excluded/*"
+            //gremlin_graph //Mark this container to be a graph
         }
     ]
 }

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -218,14 +218,16 @@ type DatabaseAccount = {
                         enableAutomaticFailover = this.EnableAutomaticFailover |> Option.toNullable
                         enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
                         locations =
-                            match this.FailoverLocations, this.Serverless with
-                            | [], Enabled ->
+                            // Locations has to be specified for the account to be gremlin enabled.
+                            // Otherwise graph database provisioning fails.
+                            match this.FailoverLocations, (this.Serverless = Enabled || this.Kind = Gremlin) with
+                            | [], true ->
                                 box [
                                     {|
                                         locationName = this.Location.ArmValue
                                     |}
                                 ]
-                            | [], Disabled -> null
+                            | [], false -> null
                             | locations, _ -> box locations
                         publicNetworkAccess = string this.PublicNetworkAccess
                         enableFreeTier = this.FreeTier

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -28,7 +28,7 @@ type DatabaseKind =
     | Gremlin
 
 module DatabaseAccounts =
-    module SqlDatabases =
+    module Containers =
         type Container = {
             Name: ResourceName
             Account: ResourceName

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -16,9 +16,16 @@ let mongoDatabases =
 let databaseAccounts =
     ResourceType("Microsoft.DocumentDb/databaseAccounts", "2021-04-15")
 
+let gremlinDatabases =
+    ResourceType("Microsoft.DocumentDb/databaseAccounts/gremlinDatabases", "2022-05-15")
+
+let graphs =
+    ResourceType("Microsoft.DocumentDb/databaseAccounts/gremlinDatabases/graphs", "2022-05-15")
+
 type DatabaseKind =
     | Document
     | Mongo
+    | Gremlin
 
 module DatabaseAccounts =
     module SqlDatabases =
@@ -26,6 +33,7 @@ module DatabaseAccounts =
             Name: ResourceName
             Account: ResourceName
             Database: ResourceName
+            Kind: DatabaseKind
             PartitionKey: {|
                 Paths: string list
                 Kind: IndexKind
@@ -45,44 +53,56 @@ module DatabaseAccounts =
 
             interface IArmResource with
                 member this.ResourceId =
-                    containers.resourceId (this.Account / this.Database / this.Name)
+                    match this.Kind with
+                    | Gremlin -> graphs.resourceId (this.Account / this.Database / this.Name)
+                    | _ -> containers.resourceId (this.Account / this.Database / this.Name)
 
-                member this.JsonModel = {|
-                    containers.Create(
-                        this.Account / this.Database / this.Name,
-                        dependsOn = [ sqlDatabases.resourceId (this.Account, this.Database) ]
-                    ) with
-                        properties = {|
-                            resource = {|
-                                id = this.Name.Value
-                                partitionKey = {|
-                                    paths = this.PartitionKey.Paths
-                                    kind = string this.PartitionKey.Kind
-                                |}
-                                uniqueKeyPolicy = {|
-                                    uniqueKeys =
-                                        this.UniqueKeyPolicy.UniqueKeys |> Set.map (fun k -> {| paths = k.Paths |})
-                                |}
-                                indexingPolicy = {|
-                                    indexingMode = "consistent"
-                                    includedPaths =
-                                        this.IndexingPolicy.IncludedPaths
-                                        |> List.map (fun p -> {|
-                                            path = p.Path
-                                            indexes =
-                                                p.Indexes
-                                                |> List.map (fun (dataType, kind) -> {|
-                                                    kind = string kind
-                                                    dataType = dataType.ToString().ToLower()
-                                                    precision = -1
-                                                |})
-                                        |})
-                                    excludedPaths =
-                                        this.IndexingPolicy.ExcludedPaths |> List.map (fun p -> {| path = p |})
+                member this.JsonModel =
+                    let resourceType =
+                        match this.Kind with
+                        | Gremlin -> graphs
+                        | _ -> containers
+
+                    {|
+                        resourceType.Create(
+                            this.Account / this.Database / this.Name,
+                            dependsOn = [
+                                match this.Kind with
+                                | Gremlin -> gremlinDatabases.resourceId (this.Account, this.Database)
+                                | _ -> sqlDatabases.resourceId (this.Account, this.Database)
+                            ]
+                        ) with
+                            properties = {|
+                                resource = {|
+                                    id = this.Name.Value
+                                    partitionKey = {|
+                                        paths = this.PartitionKey.Paths
+                                        kind = string this.PartitionKey.Kind
+                                    |}
+                                    uniqueKeyPolicy = {|
+                                        uniqueKeys =
+                                            this.UniqueKeyPolicy.UniqueKeys |> Set.map (fun k -> {| paths = k.Paths |})
+                                    |}
+                                    indexingPolicy = {|
+                                        indexingMode = "consistent"
+                                        includedPaths =
+                                            this.IndexingPolicy.IncludedPaths
+                                            |> List.map (fun p -> {|
+                                                path = p.Path
+                                                indexes =
+                                                    p.Indexes
+                                                    |> List.map (fun (dataType, kind) -> {|
+                                                        kind = string kind
+                                                        dataType = dataType.ToString().ToLower()
+                                                        precision = -1
+                                                    |})
+                                            |})
+                                        excludedPaths =
+                                            this.IndexingPolicy.ExcludedPaths |> List.map (fun p -> {| path = p |})
+                                    |}
                                 |}
                             |}
-                        |}
-                |}
+                    |}
 
     type SqlDatabase = {
         Name: ResourceName
@@ -92,13 +112,17 @@ module DatabaseAccounts =
     } with
 
         interface IArmResource with
-            member this.ResourceId = sqlDatabases.resourceId (this.Account / this.Name)
+            member this.ResourceId =
+                match this.Kind with
+                | Gremlin -> gremlinDatabases.resourceId (this.Account / this.Name)
+                | _ -> sqlDatabases.resourceId (this.Account / this.Name)
 
             member this.JsonModel =
                 let resource =
                     match this.Kind with
                     | Document -> sqlDatabases
                     | Mongo -> mongoDatabases
+                    | Gremlin -> gremlinDatabases
 
                 {|
                     resource.Create(this.Account / this.Name, dependsOn = [ databaseAccounts.resourceId this.Account ]) with
@@ -176,6 +200,7 @@ type DatabaseAccount = {
                     match this.Kind with
                     | Document -> "GlobalDocumentDB"
                     | Mongo -> "MongoDB"
+                    | Gremlin -> "GlobalDocumentDB"
                 properties =
                     {|
                         consistencyPolicy = {|
@@ -205,10 +230,16 @@ type DatabaseAccount = {
                         publicNetworkAccess = string this.PublicNetworkAccess
                         enableFreeTier = this.FreeTier
                         capabilities =
-                            if this.Serverless = Enabled then
-                                box [ {| name = "EnableServerless" |} ]
+                            if this.Serverless = Enabled || this.Kind = Gremlin then
+                                box [
+                                    if this.Serverless = Enabled then
+                                        {| name = "EnableServerless" |}
+                                    if this.Kind = Gremlin then
+                                        {| name = "EnableGremlin" |}
+                                ]
                             else
                                 null
+
                     |}
                     |> box
         |}

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -2,8 +2,8 @@
 module Farmer.Builders.CosmosDb
 
 open Farmer
+open Farmer.Arm
 open Farmer.CosmosDb
-open Farmer.Arm.DocumentDb
 open DatabaseAccounts
 open SqlDatabases
 
@@ -62,6 +62,7 @@ type CosmosDbContainerConfig = {
     Indexes: (string * (IndexDataType * IndexKind) list) list
     UniqueKeys: Set<string list>
     ExcludedPaths: string list
+    Kind: DatabaseKind
 }
 
 type CosmosDbConfig = {
@@ -138,6 +139,7 @@ type CosmosDbConfig = {
                     Name = container.Name
                     Account = this.AccountResourceId.Name
                     Database = this.DbName
+                    Kind = container.Kind
                     PartitionKey = {|
                         Paths = fst container.PartitionKey
                         Kind = snd container.PartitionKey
@@ -160,6 +162,7 @@ type CosmosDbConfig = {
 type CosmosDbContainerBuilder() =
     member _.Yield _ = {
         Name = ResourceName ""
+        Kind = DatabaseKind.Document
         PartitionKey = [], Hash
         Indexes = []
         UniqueKeys = Set.empty
@@ -185,6 +188,13 @@ type CosmosDbContainerBuilder() =
     /// Sets the name of the container.
     [<CustomOperation "name">]
     member _.Name(state: CosmosDbContainerConfig, name) = { state with Name = ResourceName name }
+
+    /// Sets the container kind of the container.
+    [<CustomOperation "gremlin_graph">]
+    member _.Graph(state: CosmosDbContainerConfig) = {
+        state with
+            Kind = DatabaseKind.Gremlin
+    }
 
     /// Sets the partition key of the container.
     [<CustomOperation "partition_key">]

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -5,7 +5,7 @@ open Farmer
 open Farmer.Arm
 open Farmer.CosmosDb
 open DatabaseAccounts
-open SqlDatabases
+open Containers
 
 type KeyType =
     | PrimaryKey

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -270,6 +270,7 @@ type CosmosDbBuilder() =
 
         if errors.Length > 0 then
             errors |> String.concat Environment.NewLine |> raiseFarmer
+
         state
 
     /// Sets the name of the CosmosDB server.
@@ -331,11 +332,10 @@ type CosmosDbBuilder() =
 
     /// Adds a list of containers to the database.
     [<CustomOperation "add_containers">]
-    member _.AddContainers(state: CosmosDbConfig, containers) =
-        {
-            state with
-                Containers = state.Containers @ containers
-        }
+    member _.AddContainers(state: CosmosDbConfig, containers) = {
+        state with
+            Containers = state.Containers @ containers
+    }
 
     /// Enables public network access
     [<CustomOperation "enable_public_network_access">]

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <!-- General -->
         <AssemblyName>Farmer</AssemblyName>
-        <Version>1.9.4</Version>
+        <Version>1.9.5</Version>
         <Description>Farmer makes authoring ARM templates easy!</Description>
         <Copyright>Copyright 2019-2024 Compositional IT Ltd.</Copyright>
         <Company>Compositional IT</Company>

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -146,10 +146,40 @@ let tests =
 
                 Expect.equal db.Kind Mongo ""
             }
+
+            test "gremlin" {
+                let db = cosmosDb {
+                    name "test"
+                    kind Gremlin
+                }
+
+                Expect.equal db.Kind Gremlin ""
+            }
         ]
 
         test "Correctly serializes to JSON" {
             let t = arm { add_resource (cosmosDb { name "test" }) }
+
+            t.Template |> Writer.toJson |> ignore
+        }
+
+        test "Correctly serializes gremlin db and container to JSON" {
+            let t = arm {
+                add_resource (
+                    cosmosDb {
+                        name "test"
+                        kind Gremlin
+
+                        add_containers [
+                            cosmosContainer {
+                                name "myContainer"
+                                partition_key [ "pk" ] CosmosDb.Hash
+                                gremlin_graph
+                            }
+                        ]
+                    }
+                )
+            }
 
             t.Template |> Writer.toJson |> ignore
         }

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -183,6 +183,30 @@ let tests =
 
             t.Template |> Writer.toJson |> ignore
         }
+
+        test "Gremlin graph container cannot be created in mongo account" {
+            let testCase () =
+                let t = arm {
+                    add_resource (
+                        cosmosDb {
+                            name "test"
+                            kind Mongo
+
+                            add_containers [
+                                cosmosContainer {
+                                    name "myContainer"
+                                    partition_key [ "pk" ] CosmosDb.Hash
+                                    gremlin_graph
+                                }
+                            ]
+                        }
+                    )
+                }
+
+                t.Template |> Writer.toJson |> ignore
+
+            Expect.throws (fun _ -> testCase ()) "Container \"myContainer\" must be of Mongo kind"
+        }
         test "Creates connection string and keys with resource groups" {
             let conn =
                 CosmosDb


### PR DESCRIPTION
This PR closes #1097

The changes in this PR are as follows:

* Add support for creating Gremlin CosmosDb Accounts
* Add support for creating Gremlin Graphs under CosmosDb Accounts

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Just wanting to get initial feedback before finishing tasks.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let csmdbTest = cosmosDb {
    name "mw-account-name"       // Database name
    account_name "cmsdb-mw-test" // Cosmos DB resource name
    kind DatabaseKind.Gremlin

    add_containers [
        cosmosContainer {
            name "myContainer"
            partition_key ["pk"] CosmosDb.Hash
            gremlin_graph
        }
    ]
}

let template = arm {
    location Location.WestEurope
    add_resources [
        csmdbTest
    ]
}

template
|> Writer.quickWrite "mw-farmer-test"
```
