### PR TITLE
add aks node pool availability zones

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.9.8
+* AKS Cluster: support for node pool availability zones
+
 ## 1.9.7
 * AKS Cluster: support for Sku and Tier. Support for pod subnet in agent pool config. Support for node pool autoscaling
 * CosmosDB: Add support for Gremlin Graphs

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -57,6 +57,7 @@ The Agent Pool builder (`agentPool`) constructs agent pools in the AKS cluster.
 | pod_subnet                        | Sets the name of a virtual network subnet where this AKS cluster should be attached.             |
 | subnet                            | Sets the name of a virtual network subnet where this AKS cluster should be attached.             |
 | vm_size                           | Sets the size of the VM's in the agent pool.                                                     |
+| add_availability_zones            | Sets the Azure availability zones for the VM's in the agent pool.                                |
 | vnet                              | Sets the name of a virtual network in the same region where this AKS cluster should be attached. |
 | enable_autoscale                  | Enables node pool autoscale                                                                      |
 | autoscale_scale_down_mode         | Optional. Use with enable_autoscaling. Options are Delete and Deallocate                         |

--- a/src/Farmer/Arm/ContainerService.fs
+++ b/src/Farmer/Arm/ContainerService.fs
@@ -183,6 +183,7 @@ type ManagedCluster = {
             OsDiskSize: int<Gb>
             OsType: OS
             VmSize: VMSize
+            AvailabilityZones: string list
             VirtualNetworkName: ResourceName option
             SubnetName: ResourceName option
             PodSubnetName: ResourceName option
@@ -295,6 +296,7 @@ type ManagedCluster = {
                                 osDiskSizeGB = agent.OsDiskSize
                                 osType = string agent.OsType
                                 vmSize = agent.VmSize.ArmValue
+                                availabilityZones = agent.AvailabilityZones
                                 vnetSubnetID =
                                     match agent.VirtualNetworkName, agent.SubnetName with
                                     | Some vnet, Some subnet -> subnets.resourceId(vnet, subnet).Eval()

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -19,6 +19,7 @@ type AgentPoolConfig = {
     OsDiskSize: int<Gb>
     OsType: OS
     VmSize: VMSize
+    AvailabilityZones: string list
     VirtualNetworkName: ResourceName option
     SubnetName: ResourceName option
     PodSubnetName: ResourceName option
@@ -42,6 +43,7 @@ type AgentPoolConfig = {
         SubnetName = None
         PodSubnetName = None
         VmSize = Standard_DS2_v2
+        AvailabilityZones = []
         AutoscaleSetting = None
         ScaleDownMode = None
         MinCount = None
@@ -185,6 +187,7 @@ type AksConfig = {
                         SubnetName = agentPool.SubnetName
                         PodSubnetName = agentPool.PodSubnetName
                         VmSize = agentPool.VmSize
+                        AvailabilityZones = agentPool.AvailabilityZones
                         VirtualNetworkName = agentPool.VirtualNetworkName
                         AutoscaleSetting = agentPool.AutoscaleSetting
                         ScaleDownMode = agentPool.ScaleDownMode
@@ -281,6 +284,12 @@ type AgentPoolBuilder() =
     /// Sets the OS type of the VM's in the agent pool.
     [<CustomOperation "os_type">]
     member _.OsType(state: AgentPoolConfig, os) = { state with OsType = os }
+
+    [<CustomOperation "add_availability_zones">]
+    member _.AddAvailabilityZone(state: AgentPoolConfig, availabilityZones: string list) = {
+        state with
+            AvailabilityZones = state.AvailabilityZones @ availabilityZones
+    }
 
     /// Sets the name of a virtual network subnet where this AKS cluster should be attached.
     [<CustomOperation "subnet">]

--- a/src/Tests/test-data/aks-with-acr.json
+++ b/src/Tests/test-data/aks-with-acr.json
@@ -53,6 +53,7 @@
       "properties": {
         "agentPoolProfiles": [
           {
+            "availabilityZones": [],
             "count": 3,
             "mode": "System",
             "name": "nodepool1",


### PR DESCRIPTION
The changes in this PR are as follows:

* add aks node pool availability zones option

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
#r "nuget:Farmer"

open System
open System.IO
open Farmer
open Farmer.Arm.ContainerService
open Farmer.Builders
open Farmer.ContainerService

let homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)

let pubKey =
    [ homeDir; ".ssh"; "id_rsa.pub" ]
    |> String.concat (string Path.DirectorySeparatorChar)
    |> File.ReadAllText

let myAksUser = "AKS SVC PRINCIPAL OBJECT ID"

let aksSubnet = "containernet"
let podSubnet = "podnet"

let vnetName = sprintf "env%0i-vnet"
let aksName = sprintf "env%0i-aks"
let aksDns = aksName

let makeVnet (n: int) =
    vnet {
        name (vnetName n)
        add_address_spaces [ "10.1.0.0/16" ]

        add_subnets [
            subnet {
                name "default"
                prefix "10.1.0.0/24"
            }
            subnet {
                name aksSubnet
                prefix "10.1.30.0/25"
            }
            subnet {
                name podSubnet
                prefix "10.1.31.0/25"
            }
        ]
    }
    :> IBuilder

let msi = userAssignedIdentity { name "aks-user" }

let makeAks (n: int) =
    aks {
        name (aksName n)
        tier Tier.Standard
        add_api_server_authorized_ip_ranges ["AzureCloud"]
        dns_prefix (aksDns n)
        enable_rbac
        add_identity msi

        add_agent_pools [
            agentPool {
                name "linuxPool"
                count 3
                add_availability_zones [ "1"; "2"; "3" ]
                vnet (vnetName n)
                subnet aksSubnet
                pod_subnet podSubnet
                enable_autoscaling
                scaleDownMode Delete
                min_count 2
                max_count 4
            }
        ]

        network_profile (azureCniNetworkProfile { service_cidr "10.250.0.0/16" })
        linux_profile "aksuser" pubKey
        service_principal_client_id myAksUser
    }
    :> IBuilder

let vnets = [ 1..1 ] |> Seq.map makeVnet |> List.ofSeq
let akses = [ 1..1 ] |> Seq.map makeAks |> List.ofSeq

arm {
    location Location.EastUS
    add_resource msi
    add_resources akses
    add_resources vnets
}
|> Writer.quickWrite "aks-on-vnet"
```
