### PR TITLE
App Gateway SSL Support, ARM Expressions in NSG rules and Gallery Apps

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+## 1.9.10
+* Application Gateways: Adds SSL Certificates
+* Network Security Groups: use ARM expressions in security rules
+* Gallery Applications: `source_media_link` can be an ARM expression
+
 ## 1.9.9
 * Virtual Machines: support for Azure Linux 3.0
 * Virtual Machines: support for Standard SKU Public IP Address

--- a/src/Farmer/Arm/Gallery.fs
+++ b/src/Farmer/Arm/Gallery.fs
@@ -297,7 +297,7 @@ type UserArtifactSettings = {
 
 type UserArtifactSource = {
     DefaultConfigurationLink: Uri option
-    MediaLink: Uri
+    MediaLink: string
 } with
 
     static member Empty = {

--- a/src/Farmer/Builders/Builders.ApplicationGateway.fs
+++ b/src/Farmer/Builders/Builders.ApplicationGateway.fs
@@ -235,8 +235,10 @@ type HttpListenerBuilder() =
     member _.Protocol(state: HttpListenerConfig, protocol) = { state with Protocol = protocol }
 
     [<CustomOperation "ssl_certificate">]
-    member _.SslCertificate(state: HttpListenerConfig, sslCertificate: string) =
-        { state with SslCertificate = Some (ResourceName sslCertificate) }
+    member _.SslCertificate(state: HttpListenerConfig, sslCertificate: string) = {
+        state with
+            SslCertificate = Some(ResourceName sslCertificate)
+    }
 
 let httpListener = HttpListenerBuilder()
 
@@ -574,9 +576,7 @@ type BasicRequestRoutingRuleBuilder() =
     }
 
     [<CustomOperation "priority">]
-    member _.Priority(state: RequestRoutingRuleConfig, priority: int) = {
-        state with Priority = Some priority
-    }
+    member _.Priority(state: RequestRoutingRuleConfig, priority: int) = { state with Priority = Some priority }
 
 let basicRequestRoutingRule = BasicRequestRoutingRuleBuilder()
 
@@ -584,27 +584,27 @@ type SslCertificateConfig = {
     Name: ResourceName
     KeyVaultSecretId: string option
 } with
-    static member BuildResource (conf:SslCertificateConfig) = {|
-          Name = conf.Name
-          Data = None // TODO: needs implementation after further testing.
-          KeyVaultSecretId = conf.KeyVaultSecretId
-          Password = None // TODO: needs implementation, will generate password parameter.
+
+    static member BuildResource(conf: SslCertificateConfig) = {|
+        Name = conf.Name
+        Data = None // TODO: needs implementation after further testing.
+        KeyVaultSecretId = conf.KeyVaultSecretId
+        Password = None // TODO: needs implementation, will generate password parameter.
     |}
 
-type SslCertificateBuilder () =
+type SslCertificateBuilder() =
     member _.Yield _ = {
         Name = ResourceName.Empty
         KeyVaultSecretId = None
     }
 
     [<CustomOperation "name">]
-    member _.Name (config:SslCertificateConfig, name:string) = {
-        config with Name = ResourceName name
-    }
+    member _.Name(config: SslCertificateConfig, name: string) = { config with Name = ResourceName name }
 
     [<CustomOperation "key_vault_secret_id">]
-    member _.KeyVaultSecretId (config:SslCertificateConfig, secretId:string) = {
-        config with KeyVaultSecretId = Some secretId
+    member _.KeyVaultSecretId(config: SslCertificateConfig, secretId: string) = {
+        config with
+            KeyVaultSecretId = Some secretId
     }
 
 let sslCertificate = SslCertificateBuilder()
@@ -803,8 +803,9 @@ type AppGatewayBuilder() =
     }
 
     [<CustomOperation "add_ssl_certificates">]
-    member _.AddSslCertificates (state: AppGatewayConfig, sslCertificates: SslCertificateConfig list) = {
-        state with SslCertificates = state.SslCertificates @ sslCertificates
+    member _.AddSslCertificates(state: AppGatewayConfig, sslCertificates: SslCertificateConfig list) = {
+        state with
+            SslCertificates = state.SslCertificates @ sslCertificates
     }
 
 let appGateway = AppGatewayBuilder()

--- a/src/Farmer/Builders/Builders.Gallery.fs
+++ b/src/Farmer/Builders/Builders.Gallery.fs
@@ -614,7 +614,7 @@ type GalleryApplicationVersionBuilder() =
         if String.IsNullOrEmpty config.ManageActions.Remove then
             raiseFarmer "Gallery application version 'remove_action' is required."
 
-        if config.Source.MediaLink.IsUnc then
+        if String.IsNullOrEmpty config.Source.MediaLink then
             raiseFarmer "Gallery application version 'source_media_link' is required."
 
         config
@@ -691,12 +691,17 @@ type GalleryApplicationVersionBuilder() =
     [<CustomOperation "source_media_link">]
     member _.SourceMediaLink(config: GalleryApplicationVersionConfig, sourceMediaLink) = {
         config with
-            Source.MediaLink = Uri sourceMediaLink
+            Source.MediaLink = sourceMediaLink
     }
 
-    member _.SourceMediaLink(config: GalleryApplicationVersionConfig, sourceMediaLink) = {
+    member _.SourceMediaLink(config: GalleryApplicationVersionConfig, sourceMediaLink: Uri) = {
         config with
-            Source.MediaLink = sourceMediaLink
+            Source.MediaLink = sourceMediaLink.AbsoluteUri
+    }
+
+    member _.SourceMediaLink(config: GalleryApplicationVersionConfig, sourceMediaLink: ArmExpression) = {
+        config with
+            Source.MediaLink = sourceMediaLink.Eval()
     }
 
     [<CustomOperation "default_configuration_link">]

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -3488,6 +3488,7 @@ module NetworkSecurity =
         | Network of IPAddressCidr
         | Tag of string
         | AnyEndpoint
+        | Expression of ArmExpression
 
         member this.ArmValue: obj =
             match this with
@@ -3496,6 +3497,7 @@ module NetworkSecurity =
             | Network cidr -> cidr |> IPAddressCidr.format |> box
             | Tag tag -> tag
             | AnyEndpoint -> "*"
+            | Expression expr -> expr.Eval()
 
     module Endpoint =
         let ArmValue (endpoint: Endpoint) = endpoint.ArmValue

--- a/src/Farmer/Farmer.fsproj
+++ b/src/Farmer/Farmer.fsproj
@@ -2,9 +2,9 @@
     <PropertyGroup>
         <!-- General -->
         <AssemblyName>Farmer</AssemblyName>
-        <Version>1.9.9</Version>
+        <Version>1.9.10</Version>
         <Description>Farmer makes authoring ARM templates easy!</Description>
-        <Copyright>Copyright 2019-2024 Compositional IT Ltd.</Copyright>
+        <Copyright>Copyright 2019-2025 Compositional IT Ltd.</Copyright>
         <Company>Compositional IT</Company>
         <Authors>Isaac Abraham and contributors</Authors>
 
@@ -19,7 +19,7 @@
         <PackageId>Farmer</PackageId>
         <PackageIcon>Icon.jpg</PackageIcon>
         <PackageTags>azure;resource-manager;template;dsl;fsharp;infrastructure-as-code</PackageTags>
-        <PackageReleaseNotes>https://raw.githubusercontent.com/CompositionalIT/farmer/master/RELEASE_NOTES.md</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/CompositionalIT/farmer/blob/master/RELEASE_NOTES.md</PackageReleaseNotes>
         <PackageProjectUrl>https://compositionalit.github.io/farmer</PackageProjectUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageReadmeFile>readme.md</PackageReadmeFile>

--- a/src/Tests/AppGateway.fs
+++ b/src/Tests/AppGateway.fs
@@ -9,6 +9,7 @@ open Farmer.ApplicationGateway
 open Farmer.Builders
 open Farmer.Network
 open Farmer.NetworkSecurity
+open Newtonsoft.Json.Linq
 
 let client =
     new NetworkManagementClient(Uri "http://management.azure.com", TokenCredentials "NotNullOrWhiteSpace")
@@ -157,8 +158,6 @@ let tests =
                 add_resources [ msi; net; myNsg; myAppGateway ]
             }
 
-            deployment.Template |> Writer.toJson |> ignore
-
             let resource =
                 deployment
                 |> findAzureResources<Microsoft.Azure.Management.Network.Models.ApplicationGateway>
@@ -223,6 +222,7 @@ let tests =
             Expect.hasLength resource.RequestRoutingRules 1 "Expecting 1 request routing rule"
             let routingRule = resource.RequestRoutingRules.[0]
             Expect.equal routingRule.Name "web-front-to-services-back" "Routing rule name did not match"
+            Expect.equal routingRule.Priority (Nullable(1000)) "Routing rule must have a priority"
 
             Expect.equal
                 routingRule.HttpListener.Id
@@ -239,4 +239,159 @@ let tests =
                 "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', 'app-gw', 'bp-default-web-80-web-80')]"
                 "Routing rule http settings did not match"
         }
+
+        test "HTTPS App Gateway" {
+            let myNsg = nsg {
+                name "agw-nsg"
+
+                add_rules [
+                    securityRule {
+                        name "app-gw"
+                        description "GatewayManager"
+                        services [ NetworkService("GatewayManager", Range(65200us, 65535us)) ]
+                        add_source_tag TCP "GatewayManager"
+                        add_destination_any
+                    }
+                    securityRule {
+                        name "inet-gw"
+                        description "Internet to gateway"
+                        services [ "https", 443 ]
+                        add_source_tag TCP "Internet"
+                        add_destination_network "10.28.0.0/24"
+                    }
+                    securityRule {
+                        name "app-servers"
+                        description "Internal app server access"
+                        services [ "http", 80 ]
+                        add_source_network TCP "10.28.0.0/24"
+                        add_destination_network "10.28.1.0/24"
+                    }
+                ]
+            }
+
+            let net = vnet {
+                name "agw-vnet"
+
+                build_address_spaces [
+                    addressSpace {
+                        space "10.28.0.0/16"
+
+                        subnets [
+                            subnetSpec {
+                                name "gw"
+                                size 24
+                                network_security_group myNsg
+                            }
+                            subnetSpec {
+                                name "apps"
+                                size 24
+                                network_security_group myNsg
+                            }
+                        ]
+                    }
+                ]
+            }
+
+            let msi = createUserAssignedIdentity "agw-msi"
+
+            let backendPoolName = ResourceName "agw-be-pool"
+
+            let myAppGateway =
+                let gwIp = gatewayIp {
+                    name "app-gw-ip"
+                    link_to_subnet net.Name net.Subnets.[0].Name
+                }
+
+                let frontendIp = frontendIp {
+                    name "app-gw-fe-ip"
+                    public_ip "agp-gw-pip"
+                }
+
+                let frontendPort = frontendPort {
+                    name "port-443"
+                    port 443
+                }
+
+                let listener = httpListener {
+                    name "https-listener"
+                    protocol Protocol.Https
+                    frontend_ip frontendIp
+                    frontend_port frontendPort
+                    backend_pool backendPoolName.Value
+                    ssl_certificate "ag-test-cert"
+                }
+
+                let backendPool = appGatewayBackendAddressPool {
+                    name backendPoolName.Value
+                    add_backend_addresses [ backend_ip_address "10.28.1.4"; backend_ip_address "10.28.1.5" ]
+                }
+
+                let healthProbe = appGatewayProbe {
+                    name "agw-probe"
+                    host "localhost"
+                    path "/"
+                    port 80
+                    protocol Protocol.Http
+                }
+
+                let backendSettings = backendHttpSettings {
+                    name "bp-default-web-80-web-80"
+                    port 80
+                    probe healthProbe
+                    protocol Protocol.Http
+                    request_timeout 10<Seconds>
+                }
+
+                let routingRule = basicRequestRoutingRule {
+                    name "web-front-to-services-back"
+                    http_listener listener
+                    backend_address_pool backendPool
+                    backend_http_settings backendSettings
+                }
+
+                appGateway {
+                    name "app-gw"
+                    sku_capacity 2
+                    add_identity msi
+                    add_ip_configs [ gwIp ]
+                    add_frontends [ frontendIp ]
+                    add_frontend_ports [ frontendPort ]
+                    add_http_listeners [ listener ]
+                    add_backend_address_pools [ backendPool ]
+                    add_backend_http_settings_collection [ backendSettings ]
+                    add_request_routing_rules [ routingRule ]
+                    add_probes [ healthProbe ]
+                    add_ssl_certificates [
+                        sslCertificate {
+                            name "ag-test-cert"
+                            key_vault_secret_id "https://my-kv.vault.azure.net/secrets/app-gw-cert"
+                        }
+                    ]
+                    depends_on myNsg
+                    depends_on net
+                }
+
+            let deployment = arm {
+                location Location.EastUS
+                add_resources [ msi; net; myNsg; myAppGateway ]
+            }
+
+            let jobj = deployment.Template |> Writer.toJson |> JObject.Parse
+            let appGwProps = jobj.SelectToken("resources[?(@.name=='app-gw')].properties")
+            let appGwHttpsCertId = appGwProps.SelectToken("httpListeners[0].properties.sslCertificate.id")
+            Expect.equal
+                (appGwHttpsCertId |> string)
+                "[resourceId('Microsoft.Network/applicationGateways/sslCertificates', 'app-gw', 'ag-test-cert')]"
+                "Generated incorrect references to HTTPS cert"
+            let appGwSslCert = appGwProps.SelectToken("sslCertificates[0]")
+            Expect.equal
+                (appGwSslCert["name"] |> string)
+                "ag-test-cert"
+                "Wrong name on SSL Certificate"
+            Expect.equal
+                (appGwSslCert.SelectToken("properties.keyVaultSecretId") |> string)
+                "https://my-kv.vault.azure.net/secrets/app-gw-cert"
+                "Wrong Key Vault Secret ID for SSL Certificate"
+        }
+
     ]


### PR DESCRIPTION
This PR closes #1164 and #1157 and #1175 

The changes in this PR are as follows:

* Application Gateways: Adds SSL Certificates
* Network Security Groups: use ARM expressions in security rules
* Gallery Applications: `source_media_link` can be an ARM expression

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let myAppGateway =
    let gwIp =
        gatewayIp {
            name "app-gw-ip"
            link_to_subnet net.Name net.Subnets.[0].Name
        }
    let frontendIp =
        frontendIp {
            name "app-gw-fe-ip"
            public_ip "agp-gw-pip"
        }
    let frontendPort =
        frontendPort {
            name "port-443"
            port 443
        }
    let listener =
        httpListener {
            name "https-listener"
            frontend_ip frontendIp
            frontend_port frontendPort
            backend_pool backendPoolName.Value
            protocol Protocol.Https
            ssl_certificate "my-tls-cert"
        }
    let backendPool =
        appGatewayBackendAddressPool {
            name backendPoolName.Value
            add_backend_addresses [
                backend_ip_address "10.28.1.4"
                backend_ip_address "10.28.1.5"
            ]
        }
    let healthProbe =
        appGatewayProbe {
            name "agw-probe"
            host "localhost"
            path "/"
            port 80
            protocol Protocol.Http
        }
    let backendSettings =
        backendHttpSettings {
            name "bp-default-web-80-web-80"
            port 80
            probe healthProbe
            protocol Protocol.Http
            request_timeout 10<Seconds>
        }
    let routingRule =
        basicRequestRoutingRule {
            name "web-front-to-services-back"
            http_listener listener
            backend_address_pool backendPool
            backend_http_settings backendSettings
        }

    appGateway {
        name "app-gw"
        sku_capacity 2
        add_identity msi
        add_ip_configs [ gwIp ]
        add_frontends [ frontendIp ]
        add_frontend_ports [ frontendPort ]
        add_http_listeners [ listener ]
        add_backend_address_pools [ backendPool ]
        add_backend_http_settings_collection [ backendSettings ]
        add_request_routing_rules [ routingRule ]
        add_probes [ healthProbe ]
        add_ssl_certificates [
            sslCertificate {
                name "my-tls-cert"
                // Ensure App Gateway identity (MSI) has access to read this secret.
                key_vault_secret_id "https://my-kv.vault.azure.net/secrets/app-gw-cert"
            }
        ]
        depends_on myNsg
        depends_on net
   }
```
