### PR TITLE
VM health extension autoupgrade

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.9.11
+* VM extensions: support for auto-upgrades and initial version
+
 ## 1.9.10
 * Application Gateways: Adds SSL Certificates
 * Network Security Groups: use ARM expressions in security rules

--- a/docs/content/api-overview/resources/vm-scale-set.md
+++ b/docs/content/api-overview/resources/vm-scale-set.md
@@ -35,6 +35,9 @@ The Virtual Machine Scale Set builder (`vmss`) creates a virtual machine scale s
 | applicationHealthExtension | port                           | TCP port to probe.                                                                                                                                                                                        |
 | applicationHealthExtension | interval                       | Interval to probe for health.                                                                                                                                                                             |
 | applicationHealthExtension | number_of_probes               | Sets the number of times the probe must fail to consider this instance a failure.                                                                                                                            |
+| applicationHealthExtension | enable_automatic_upgrade       | Enable/Disable automatic extension upgrade (not enabled by default)         |
+| applicationHealthExtension | type_handler_version           | Extension version (default: "1.0")         |
+
 
 #### Example
 

--- a/src/Farmer/Arm/Compute.fs
+++ b/src/Farmer/Arm/Compute.fs
@@ -124,6 +124,8 @@ type ApplicationHealthExtension = {
     NumberOfProbes: int option
     GracePeriod: TimeSpan option
     Tags: Map<string, string>
+    EnableAutomaticUpgrade: bool option
+    TypeHandlerVersion: string option
 } with
 
     static member Name = "HealthExtension"
@@ -138,8 +140,9 @@ type ApplicationHealthExtension = {
                 match this.OS with
                 | Linux -> "ApplicationHealthLinux"
                 | Windows -> "ApplicationHealthWindows"
-            typeHandlerVersion = "1.0"
+            typeHandlerVersion = this.TypeHandlerVersion |> Option.defaultValue "1.0"
             autoUpgradeMinorVersion = true
+            enableAutomaticUpgrade = this.EnableAutomaticUpgrade |> Option.map box |> Option.defaultValue null
             settings = {|
                 protocol = this.Protocol.ArmValue
                 port = this.Port

--- a/src/Farmer/Builders/Builders.Vm.fs
+++ b/src/Farmer/Builders/Builders.Vm.fs
@@ -1051,7 +1051,7 @@ type VmGalleryApplicationBuilder() =
         galleryApp
 
     [<CustomOperation "enable_automatic_upgrade">]
-    member _.EnableAutomaticUpgrade(state, enable) = {
+    member _.EnableAutomaticUpgrade(state: VmGalleryApplication, enable) = {
         state with
             EnableAutomaticUpgrade = Some enable
     }

--- a/src/Farmer/Builders/Builders.VmScaleSet.fs
+++ b/src/Farmer/Builders/Builders.VmScaleSet.fs
@@ -24,6 +24,8 @@ type ApplicationHealthExtensionConfig = {
     NumberOfProbes: int option
     GracePeriod: TimeSpan option
     Tags: Map<string, string>
+    TypeHandlerVersion: string option
+    EnableAutomaticUpgrade: bool option
 } with
 
     interface IExtensionBuilder with
@@ -37,6 +39,8 @@ type ApplicationHealthExtensionConfig = {
             NumberOfProbes = this.NumberOfProbes
             GracePeriod = this.GracePeriod
             Tags = this.Tags
+            TypeHandlerVersion = this.TypeHandlerVersion
+            EnableAutomaticUpgrade = this.EnableAutomaticUpgrade
         }
 
     interface IBuilder with
@@ -279,6 +283,20 @@ type ApplicationHealthExtensionBuilder() =
         NumberOfProbes = None
         GracePeriod = None
         Tags = Map.empty
+        TypeHandlerVersion = None
+        EnableAutomaticUpgrade = None
+    }
+
+    [<CustomOperation "enable_automatic_upgrade">]
+    member _.EnableAutomaticUpgrade(state: ApplicationHealthExtensionConfig, enable) = {
+        state with
+            EnableAutomaticUpgrade = Some enable
+    }
+
+    [<CustomOperation "type_handler_version">]
+    member _.TypeHandlerVersion(state: ApplicationHealthExtensionConfig, version) = {
+        state with
+            TypeHandlerVersion = Some version
     }
 
     /// Sets the VMSS where this health extension should be installed.


### PR DESCRIPTION
This PR closes #1178 

The changes in this PR are as follows:

* Added support for the `enableAutomaticUpgrade` property for `applicationHealthExtension`.
* Exposed inital version of the extension, defaulting to the same "1.0" for backwards compat


I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:
There are no tests for this CE and I figured no complexity worth adding them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
                        add_extensions [
                            applicationHealthExtension {
                                protocol (ApplicationHealthExtensionProtocol.HTTP "/healthcheck")
                                port 80
                                os Linux
                                enable_automatic_upgrade true
                                type_handler_version "2.1"
                            }
                        ]
```
