### PR TITLE
Add link_to_subnet and link_to_pod_subnet for aks deployments

### DIFF
--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -56,6 +56,8 @@ The Agent Pool builder (`agentPool`) constructs agent pools in the AKS cluster.
 | os_type                           | Sets the OS type of the VM's in the agent pool.                                                  |
 | pod_subnet                        | Sets the name of a virtual network subnet where this AKS cluster should be attached.             |
 | subnet                            | Sets the name of a virtual network subnet where this AKS cluster should be attached.             |
+| link_to_subnet                    | Specify an existing subnet this AKS cluster should be attached.                                  |
+| link_to_pod_subnet                | Specify an existing subnet this AKS cluster should be attached.                                  |
 | vm_size                           | Sets the size of the VM's in the agent pool.                                                     |
 | add_availability_zones            | Sets the Azure availability zones for the VM's in the agent pool.                                |
 | vnet                              | Sets the name of a virtual network in the same region where this AKS cluster should be attached. |

--- a/src/Farmer/Arm/ContainerService.fs
+++ b/src/Farmer/Arm/ContainerService.fs
@@ -186,6 +186,8 @@ type ManagedCluster = {
             AvailabilityZones: string list
             VirtualNetworkName: ResourceName option
             SubnetName: ResourceName option
+            Subnet: LinkedResource option
+            PodSubnet: LinkedResource option
             PodSubnetName: ResourceName option
             AutoscaleSetting: FeatureFlag option
             ScaleDownMode: ScaleDownMode option
@@ -239,6 +241,16 @@ type ManagedCluster = {
         member this.JsonModel =
             let dependencies =
                 [
+                    this.AgentPoolProfiles
+                    |> List.choose(fun pool ->
+                        match pool.PodSubnet with
+                        | Some(Managed podSubnet) -> Some podSubnet
+                        | _ -> None)
+                    this.AgentPoolProfiles
+                    |> List.choose(fun pool ->
+                        match pool.Subnet with
+                        | Some(Managed subnet) -> Some subnet
+                        | _ -> None)
                     this.AgentPoolProfiles
                     |> List.choose (fun pool -> pool.VirtualNetworkName)
                     |> List.map virtualNetworks.resourceId
@@ -300,11 +312,17 @@ type ManagedCluster = {
                                 vnetSubnetID =
                                     match agent.VirtualNetworkName, agent.SubnetName with
                                     | Some vnet, Some subnet -> subnets.resourceId(vnet, subnet).Eval()
-                                    | _ -> null
+                                    | _ ->
+                                        match agent.Subnet with
+                                        | Some subnet -> subnet.ResourceId.Eval()
+                                        | _ -> null
                                 podSubnetID =
                                     match agent.VirtualNetworkName, agent.PodSubnetName with
                                     | Some vnet, Some pod_subnet -> subnets.resourceId(vnet, pod_subnet).Eval()
-                                    | _ -> null
+                                    | _ -> 
+                                        match agent.PodSubnet with
+                                        | Some podSubnet -> podSubnet.ResourceId.Eval()
+                                        | _ -> null
                                 enableAutoScaling = agent.AutoscaleSetting |> Option.mapBoxed _.AsBoolean
                                 scaleDownMode =
                                     match agent.ScaleDownMode with

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -23,6 +23,8 @@ type AgentPoolConfig = {
     VirtualNetworkName: ResourceName option
     SubnetName: ResourceName option
     PodSubnetName: ResourceName option
+    Subnet: LinkedResource option
+    PodSubnet: LinkedResource option
     AutoscaleSetting: FeatureFlag option
     ScaleDownMode: ScaleDownMode option
     MinCount: int option
@@ -42,6 +44,8 @@ type AgentPoolConfig = {
         VirtualNetworkName = None
         SubnetName = None
         PodSubnetName = None
+        PodSubnet = None
+        Subnet = None
         VmSize = Standard_DS2_v2
         AvailabilityZones = []
         AutoscaleSetting = None
@@ -186,6 +190,8 @@ type AksConfig = {
                         OsType = agentPool.OsType
                         SubnetName = agentPool.SubnetName
                         PodSubnetName = agentPool.PodSubnetName
+                        Subnet = agentPool.Subnet
+                        PodSubnet = agentPool.PodSubnet
                         VmSize = agentPool.VmSize
                         AvailabilityZones = agentPool.AvailabilityZones
                         VirtualNetworkName = agentPool.VirtualNetworkName
@@ -269,6 +275,21 @@ type AgentPoolBuilder() =
     /// Sets the agent pool to user mode.
     [<CustomOperation "user_mode">]
     member _.UserMode(state: AgentPoolConfig) = { state with Mode = AgentPoolMode.User }
+
+
+    /// Sets the name of a virtual network where this agent pool should be attached.
+    [<CustomOperation "link_to_subnet">]
+    member _.LinkToSubnetId(state: AgentPoolConfig, subnetId: ResourceId) = {
+        state with
+            Subnet = Some(Unmanaged subnetId)
+    }
+
+    /// Sets the name of a virtual network where this agent pool should be attached.
+    [<CustomOperation "link_to_pod_subnet">]
+    member _.LinkToPodSubnetId(state: AgentPoolConfig, subnetId: ResourceId) = {
+        state with
+            PodSubnet = Some(Unmanaged subnetId)
+    }
 
     /// Sets the disk size for the VM's in the agent pool.
     [<CustomOperation "disk_size">]


### PR DESCRIPTION
The changes in this PR are as follows:

* adds link_to_subnet to agent pool config
* adds link_to_pod_subnet to agent pool config

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
#r "nuget:Farmer"

open System
open System.IO
open Farmer
open Farmer.Arm.ContainerService
open Farmer.Builders
open Farmer.ContainerService

type AksDeploymentRequestV1 =
    { ManagementResourceGroupName: string
      TenantMsi: UserAssignedIdentityConfig
      PodSubnet: ResourceId
      NodeSubnet: ResourceId }

type KubenetBuilder() =
    inherit NetworkProfileBuilder()

    member _.Yield = {
        NetworkPlugin = Some ContainerService.NetworkPlugin.AzureCni
        LoadBalancerSku = None
        DnsServiceIP = None
        DockerBridgeCidr = None
        ServiceCidr = None
    }

let aksResourceV1 (req: AksDeploymentRequestV1) =
    let networkProfile = KubenetBuilder()
    aks {
        name $"{req.ManagementResourceGroupName}-aks"
        tier Tier.Standard
        service_principal_use_msi
        add_identity req.TenantMsi
        kubelet_identity req.TenantMsi
        network_profile networkProfile.Yield
        enable_workload_identity
        enable_image_cleaner
        enable_private_cluster
        dns_prefix "aks"
        add_agent_pools
            [ agentPool {
                  name "systempool"
                  count 2
                  disk_size 128<Gb>
                  add_availability_zones [ "1"; "2"; "3" ]
                  vm_size (Vm.CustomImage "Standard_D2s_v3")
                  link_to_subnet req.NodeSubnet
                  link_to_pod_subnet req.PodSubnet
              }
              agentPool {
                  name "userpool"
                  user_mode
                  disk_size 128<Gb>
                  add_availability_zones [ "1"; "2"; "3" ]
                  enable_autoscale
                  autoscale_min_count 2
                  autoscale_max_count 4
                  vm_size (Vm.CustomImage "Standard_D4s_v3")
                  link_to_subnet req.NodeSubnet
                  link_to_pod_subnet req.PodSubnet
              } ]
    }

let msi = userAssignedIdentity { name "aks-rg-msi" }
let aksDeploy = 
    { ManagementResourceGroupName = "aks-rg"
      TenantMsi = msi
      PodSubnet = Arm.Network.subnets.resourceId (ResourceName "aks-rg", ResourceName "aksPod" )
      NodeSubnet = Arm.Network.subnets.resourceId (ResourceName "aks-rg", ResourceName "aksNode" ) }

arm {
    location Location.EastUS2
    add_resources [
        msi
        aksResourceV1 aksDeploy
    ]
}
|> Writer.quickWrite "aks-on-vnet"
```
