### PR TITLE
Example proposal for Issue #731

### DIFF
--- a/src/Farmer/Builders/Builders.WebApp.fs
+++ b/src/Farmer/Builders/Builders.WebApp.fs
@@ -947,24 +947,6 @@ type WebAppBuilder() =
         VirtualApplications = Map []
         FunctionAppScaleLimit = None
     }
-    member __.Combine (currentValueFromYield: WebAppConfig, accumulatorFromDelay: WebAppConfig) =
-        System.Console.WriteLine($"currentValueFromYield: {currentValueFromYield.CommonWebConfig.AlwaysOn}")
-        System.Console.WriteLine($"accumulatorFromDelay: {accumulatorFromDelay.CommonWebConfig.AlwaysOn}")
-        { currentValueFromYield with
-           WebAppConfig.CommonWebConfig.AlwaysOn = false//accumulatorFromDelay.CommonWebConfig.AlwaysOn
-        }
-
-    member this.For(state: WebAppConfig , f: unit -> WebAppConfig) =
-        let delayed = f()
-        this.Combine(state, delayed)
-
-    member x.Zero() =
-        let v = x.Yield()
-        System.Console.WriteLine($"Zero {v.CommonWebConfig.AlwaysOn}")
-        v
-    // [<CustomOperation "eef">]
-    // member _.eef(cond, thenExpr, elseExpr) =
-    //     if cond then thenExpr() else elseExpr()
 
     member _.Run(state: WebAppConfig) =
         if state.Name.ResourceName = ResourceName.Empty then
@@ -1575,13 +1557,9 @@ module Extensions =
 
         /// Sets "Always On" flag
         [<CustomOperation "always_on">]
-        member this.AlwaysOn(state: 'T) =
-            { this.Get state with AlwaysOn = true } |> this.Wrap state
-
-        /// Sets "Always On" flag
-        [<CustomOperation "always_on">]
-        member this.AlwaysOn(state: 'T, value: bool) =
-            { this.Get state with AlwaysOn = value } |> this.Wrap state
+        member this.AlwaysOn(state: 'T, ?value: bool) =
+            let v = defaultArg value true
+            { this.Get state with AlwaysOn = v } |> this.Wrap state
 
         ///Chooses the bitness (32 or 64) of the worker process
         [<CustomOperation "worker_process">]

--- a/src/Tests/WebApp.fs
+++ b/src/Tests/WebApp.fs
@@ -675,6 +675,7 @@ let tests =
             Expect.isEmpty wa.SiteConfig.AppSettings "Should be no settings"
         }
 
+
         test "Supports always on" {
             let template = webApp {
                 name "web"
@@ -685,6 +686,16 @@ let tests =
 
             let w: Site = webApp { name "testDefault" } |> getResourceAtIndex 3
             Expect.equal w.SiteConfig.AlwaysOn (Nullable false) "always on should be false by default"
+        }
+
+        test "Supports conditional always on" {
+            let expected = false
+            let template = webApp {
+                name "web"
+                always_on expected
+            }
+
+            Expect.equal template.CommonWebConfig.AlwaysOn expected $"AlwaysOn should be {expected}"
         }
 
         test "Supports 32 and 64 bit worker processes" {


### PR DESCRIPTION
This is linked to the issue described in https://github.com/CompositionalIT/farmer/issues/731 and is just for demo purposes.

I have encountered this issue a few times with Farmer and do not know of an elegant solution.
Something like this can get you out in a pinch but it requires knowing what the builder is setting, which leaks the details. It's also just not very elegant.

```fsharp
let mutable myWebApp = webApp {
            name "myWebApp"
            service_plan_name "myServicePlan"
            setting "myKey" "aValue"
            sku WebApp.Sku.B1
            always_on
            app_insights_off
            worker_size Medium
            number_of_workers 3
            run_from_package
            system_identity
        }
        let disableAlwaysOn = false
        if disableAlwaysOn then 
            myWebApp <- { myWebApp with WebAppConfig.CommonWebConfig.AlwaysOn = true }
```
An elegant solution would be if we could implement `For` and `Zero` in a way that allowed for `if` in the CE but playing around with it for a few minutes did not work as expected. I have not worked with CEs for a while but not sure if this is even possible for a non-collection based CE.

A simple solution (albeit quite some work) is to take in a value but add an optional parameter.

```fsharp
let expected = false
let template = webApp {
  name "web"
  always_on expected
}
```

This matches what I usually do in builders in C# where boolean switching takes in a boolean with a default value.