### PR TITLE
Add link_to_kubelet_identity to AKS config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,8 @@
 Release Notes
 =============
 
-## 1.9.13
-
-* AKS Cluster: Add link_to_kubelet_identity
-
 ## 1.9.12
+* AKS Cluster: Add link_to_kubelet_identity
 * VMSS overprovisioning controls
 
 ## 1.9.11

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 1.9.13
+
+* AKS Cluster: Add link_to_kubelet_identity
+
 ## 1.9.12
 * VMSS overprovisioning controls
 

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -28,8 +28,10 @@ The AKS builder (`aks`) constructs AKS clusters.
 | add_agent_pools                     | Adds agent pools to the AKS cluster.                                                                                                                        |
 | add_agent_pool                      | Adds an agent pool to the AKS cluster.                                                                                                                      |
 | add_identity                        | Adds a managed identity to the the AKS cluster.                                                                                                             |
+| link_to_identity                    | Links an existing managed identity to the container group.                                                                                                  |
 | system_identity                     | Activates the system identity of the AKS cluster.                                                                                                           |
 | kubelet_identity                    | Assigns a user assigned identity to the kubelet user that pulls container images.                                                                           |
+| link_to_kubelet_identity            | Links an existing managed identity to the kublet user that pulls container images.                                                                          |
 | network_profile                     | Sets the network profile for the AKS cluster.                                                                                                               |
 | linux_profile                       | Sets the linux profile for the AKS cluster.                                                                                                                 |
 | service_principal_client_id         | Sets the client id of the service principal for the AKS cluster.                                                                                            |

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -591,7 +591,7 @@ type AksBuilder() =
                     }
           }
 
-    [<CustomOperation "link_to_kublet_identity">]
+    [<CustomOperation "link_to_kubelet_identity">]
     member this.LinkToKubletIdentity(state: AksConfig, resourceId: ResourceId) =
         match state.IdentityProfile with
         | None -> {

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -577,14 +577,36 @@ type AksBuilder() =
         match state.IdentityProfile with
         | None -> {
             state with
-                IdentityProfile = Some { KubeletIdentity = Some identity }
+                IdentityProfile =
+                    Some {
+                        KubeletIdentity = Some(Managed(identity))
+                    }
           }
         | Some identityProfile -> {
             state with
                 IdentityProfile =
                     Some {
                         identityProfile with
-                            KubeletIdentity = Some identity
+                            KubeletIdentity = Some(Managed(identity))
+                    }
+          }
+
+    [<CustomOperation "link_to_kublet_identity">]
+    member this.LinkToKubletIdentity(state: AksConfig, resourceId: ResourceId) =
+        match state.IdentityProfile with
+        | None -> {
+            state with
+                IdentityProfile =
+                    Some {
+                        KubeletIdentity = Some(Unmanaged(resourceId))
+                    }
+          }
+        | Some identityProfile -> {
+            state with
+                IdentityProfile =
+                    Some {
+                        identityProfile with
+                            KubeletIdentity = Some(Unmanaged(resourceId))
                     }
           }
 


### PR DESCRIPTION
The changes in this PR are as follows:

* Add link_to_kubelet_identity to AKS config
* Update docs to reference existing link_to_identity option in AKS config

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
#r "nuget:Farmer"

open System
open System.IO
open Farmer
open Farmer.Arm.ContainerService
open Farmer.Builders
open Farmer.ContainerService

type AksDeploymentRequestV1 =
    { ManagementResourceGroupName: string
      TenantMsi: ResourceId
      PodSubnet: ResourceId
      NodeSubnet: ResourceId }

type KubenetBuilder() =
    inherit NetworkProfileBuilder()

    member _.Yield = {
        NetworkPlugin = Some ContainerService.NetworkPlugin.AzureCni
        LoadBalancerSku = None
        DnsServiceIP = None
        DockerBridgeCidr = None
        ServiceCidr = None
    }

let aksResourceV1 (req: AksDeploymentRequestV1) =
    let networkProfile = KubenetBuilder()
    aks {
        name $"{req.ManagementResourceGroupName}-aks"
        tier Tier.Standard
        service_principal_use_msi
        link_identity req.TenantMsi
        link_to_kubelet_identity req.TenantMsi
        network_profile networkProfile.Yield
        enable_workload_identity
        enable_image_cleaner
        enable_private_cluster
        dns_prefix "aks"
        add_agent_pools
            [ agentPool {
                  name "systempool"
                  count 2
                  disk_size 128<Gb>
                  add_availability_zones [ "1"; "2"; "3" ]
                  vm_size (Vm.CustomImage "Standard_D2s_v3")
                  link_to_subnet req.NodeSubnet
                  link_to_pod_subnet req.PodSubnet
              }
              agentPool {
                  name "userpool"
                  user_mode
                  disk_size 128<Gb>
                  add_availability_zones [ "1"; "2"; "3" ]
                  enable_autoscale
                  autoscale_min_count 2
                  autoscale_max_count 4
                  vm_size (Vm.CustomImage "Standard_D4s_v3")
                  link_to_subnet req.NodeSubnet
                  link_to_pod_subnet req.PodSubnet
              } ]
    }

let msi = userAssignedIdentity { name "aks-rg-msi" }
let aksDeploy = 
    { ManagementResourceGroupName = "aks-rg"
      TenantMsi =
          ResourceId.create(
            ResourceType.ResourceType("Microsoft.ManagedIdentity/userAssignedIdentities", "2023-01-31"),
            Farmer.ResourceName("aks-msi"),
            "aks-rg",
            "344D4BBB-718E-4AD0-9180-79FAD22517D4"
          )
      PodSubnet = Arm.Network.subnets.resourceId (ResourceName "aks-rg", ResourceName "aksPod" )
      NodeSubnet = Arm.Network.subnets.resourceId (ResourceName "aks-rg", ResourceName "aksNode" ) }

arm {
    location Location.EastUS2
    add_resources [
        aksResourceV1 aksDeploy
    ]
}
|> Writer.quickWrite "aks-on-vnet"
```
