### PR TITLE
Referencing Key Vault Secrets when creating Container App Secrets

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.9.13
+* Container Apps: Able to create Container Apps secrets referencing KeyVault secrets.
+
 ## 1.9.12
 * AKS Cluster: Add link_to_kubelet_identity
 * VMSS overprovisioning controls

--- a/docs/content/api-overview/resources/container-apps.md
+++ b/docs/content/api-overview/resources/container-apps.md
@@ -57,6 +57,7 @@ The Container Apps builder (`containerApp`) is used to define one or more contai
 | add_secret_parameters | Adds application secrets to the entire container app. This is passed as secure parameters to the template, and environment variables are automatically created which reference the secret. |
 | add_secret_expression | As per `add_secret_parameter`, but the value is sourced from an ARM expression instead of as a parameter. Useful for e.g. storage keys etc. |
 | add_secret_expressions | As per `add_secret_parameters`, but the values are sourced from ARM expressions instead of as parameters. Useful for e.g. storage keys etc. |
+| add_key_vault_secret | container app secret that references a KeyVault secret using the KeyVault URL. Environment variables are automatically created which reference the secret. |
 | add_env_variable | Adds a static, plain text environment variable. |
 | add_env_variables | Adds static, plain text environment variables. |
 | add_volumes | Adds volumes to a container app so they are accessible to containers. |

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -5,7 +5,8 @@ open System
 open Farmer.ContainerApp
 open Farmer
 
-let containerApps = ResourceType("Microsoft.App/containerApps", "2025-01-01")
+let containerApps =
+    ResourceType("Microsoft.App/containerApps", "2022-11-01-preview")
 
 let managedEnvironments =
     ResourceType("Microsoft.App/managedEnvironments", "2022-03-01")
@@ -218,8 +219,8 @@ type ContainerApp = {
                                     | ImageRegistryAuthentication.Credential cred -> {|
                                         name = cred.Username
                                         value = Some (cred.Password.ArmExpression.Eval())
-                                        keyVaultUrl = Option<string>.None
-                                        identity = Option<string>.None
+                                        keyVaultUrl = None
+                                        identity = None
                                       |}
                                     | ImageRegistryAuthentication.ListCredentials resourceId -> {|
                                         name = buildPasswordRef resourceId
@@ -229,8 +230,8 @@ type ContainerApp = {
                                                 )
                                                 .Eval()
                                                 )
-                                        keyVaultUrl = Option<string>.None
-                                        identity = Option<string>.None
+                                        keyVaultUrl = None
+                                        identity = None
                                       |}
                                     | ImageRegistryAuthentication.ManagedIdentityCredential cred -> ()
                                 for setting in this.Secrets do

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -313,6 +313,11 @@ type ContainerApp = {
                                                 value = null
                                                 secretref = env.Key
                                               |}
+                                            | EnvValueSecretReference ref -> {|
+                                                name = env.Key
+                                                value = null
+                                                secretref = ref
+                                              |}
                                     |]
                                     resources =
                                         {|

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -5,7 +5,7 @@ open System
 open Farmer.ContainerApp
 open Farmer
 
-let containerApps = ResourceType("Microsoft.App/containerApps", "2022-03-01")
+let containerApps = ResourceType("Microsoft.App/containerApps", "2025-01-01")
 
 let managedEnvironments =
     ResourceType("Microsoft.App/managedEnvironments", "2022-03-01")
@@ -123,7 +123,7 @@ type DaprComponent = {
                     scopes = this.Scopes
                     secrets = [|
                         for secret in this.Secrets do
-                            secret.Value.armObj secret.Key
+                            secret.Value.toArmJson secret.Key
                     |]
                     secretStoreComponent = this.SecretStoreComponent |> Option.map _.Value |> Option.toObj
                     version = this.Version

--- a/src/Farmer/Arm/App.fs
+++ b/src/Farmer/Arm/App.fs
@@ -6,7 +6,7 @@ open Farmer.ContainerApp
 open Farmer
 
 let containerApps =
-    ResourceType("Microsoft.App/containerApps", "2022-11-01-preview")
+    ResourceType("Microsoft.App/containerApps", "2023-05-01")
 
 let managedEnvironments =
     ResourceType("Microsoft.App/managedEnvironments", "2022-03-01")
@@ -123,23 +123,8 @@ type DaprComponent = {
                     |]
                     scopes = this.Scopes
                     secrets = [|
-                        for KeyValue(name, secretValue) in this.Secrets ->
-                            match secretValue with
-                            | ParameterSecret secureParameter ->
-                               {| name = name
-                                  value = Some (secureParameter.ArmExpression.Eval())
-                                  keyVaultUrl = None
-                                  identity = None |}
-                            | ExpressionSecret armExpression ->
-                               {| name = name
-                                  value = Some (armExpression.Eval())
-                                  keyVaultUrl = None
-                                  identity = None |}
-                            | KeyVaultSecretReference (url, identity) ->
-                               {| name = name
-                                  value = None
-                                  keyVaultUrl = Some (url.Eval())
-                                  identity = Some (identity.Eval()) |}
+                        for secret in this.Secrets ->
+                            secret.Value.toArmJson secret.Key
                     |]
                     secretStoreComponent = this.SecretStoreComponent |> Option.map _.Value |> Option.toObj
                     version = this.Version

--- a/src/Farmer/Arm/ContainerInstance.fs
+++ b/src/Farmer/Arm/ContainerInstance.fs
@@ -249,12 +249,14 @@ type ContainerGroup = {
                     | SecureEnvValue p -> p
                     | SecureEnvExpression _ -> ()
                     | EnvValue _ -> ()
+                    | EnvValueSecretReference _ -> ()
             for container in this.InitContainers do
                 for envVar in container.EnvironmentVariables do
                     match envVar.Value with
                     | SecureEnvValue p -> p
                     | SecureEnvExpression _ -> ()
                     | EnvValue _ -> ()
+                    | EnvValueSecretReference _ -> ()
             for volume in this.Volumes do
                 match volume.Value with
                 | Volume.Secret secrets ->
@@ -313,6 +315,11 @@ type ContainerGroup = {
                                             value = null
                                             secureValue = value.ArmExpression.Eval()
                                           |}
+                                        | EnvValueSecretReference ref -> {|
+                                            name = key
+                                            value = null
+                                            secureValue = ref
+                                          |}
                                 ]
                                 livenessProbe = ContainerProbe.JsonModel container.LivenessProbe
                                 readinessProbe = ContainerProbe.JsonModel container.ReadinessProbe
@@ -358,6 +365,11 @@ type ContainerGroup = {
                                             name = key
                                             value = null
                                             secureValue = value.ArmExpression.Eval()
+                                          |}
+                                        | EnvValueSecretReference ref -> {|
+                                            name = key
+                                            value = null
+                                            secureValue = ref
                                           |}
                                 ]
                                 volumeMounts =

--- a/src/Farmer/Arm/DeploymentScript.fs
+++ b/src/Farmer/Arm/DeploymentScript.fs
@@ -97,6 +97,11 @@ type DeploymentScript = {
                                     value = null
                                     secureValue = v.ArmExpression.Eval()
                                   |}
+                                | EnvValueSecretReference ref -> {|
+                                    name = key
+                                    value = null
+                                    secureValue = ref
+                                  |}
                         ]
                         forceUpdateTag = this.ForceUpdateTag |> Option.toNullable
                         scriptContent =

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -45,7 +45,7 @@ module Vaults =
             member this.JsonModel = {|
                 secrets.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
                     properties = {|
-                        value = this.Value.armObj this.Name
+                        value = this.Value.toArmJson this.Name
                         contentType = this.ContentType |> Option.toObj
                         attributes = {|
                             enabled = this.Enabled |> Option.toNullable

--- a/src/Farmer/Arm/KeyVault.fs
+++ b/src/Farmer/Arm/KeyVault.fs
@@ -45,7 +45,7 @@ module Vaults =
             member this.JsonModel = {|
                 secrets.Create(this.Name, this.Location, this.Dependencies, this.Tags) with
                     properties = {|
-                        value = this.Value.Value
+                        value = this.Value.armObj this.Name
                         contentType = this.ContentType |> Option.toObj
                         attributes = {|
                             enabled = this.Enabled |> Option.toNullable

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -555,7 +555,7 @@ type ContainerAppBuilder() =
         {
             state with
                 Secrets = state.Secrets.Add(key, (KeyVaultSecretReference (keyVaultUrl, identity)))
-                EnvironmentVariables = state.EnvironmentVariables.Add(EnvVar.createSecure envVarName key.Value)
+                EnvironmentVariables = state.EnvironmentVariables.Add(EnvVar.createSecretReference envVarName key.Value)
                 Dependencies = state.Dependencies + newDeps
         }
 

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -542,12 +542,12 @@ type ContainerAppBuilder() =
         xs |> Seq.fold (fun s (k, e) -> this.AddSecretExpression(s, k, e)) state
 
     /// Adds a container app secret that references a KeyVault secret to the Azure Container App.
-    [<CustomOperation "add_keyvault_secret">]
+    [<CustomOperation "add_key_vault_secret">]
     member _.AddKeyVaultSecret(state: ContainerAppConfig, key, keyVaultUrl: ArmExpression, identity: ArmExpression) =
         let key = (ContainerAppSettingKey.Create key).OkValue
 
         let newDeps =
-            [ identity.Owner; keyVaultUrl.Owner ]
+            [ keyVaultUrl.Owner ]
             |> Seq.choose id
             |> Set.ofSeq
 

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -541,7 +541,7 @@ type ContainerAppBuilder() =
     member this.AddSecretExpressions(state: ContainerAppConfig, xs: #seq<_>) =
         xs |> Seq.fold (fun s (k, e) -> this.AddSecretExpression(s, k, e)) state
 
-    /// Adds a container app secret referencing a KeyVault secret using the KeyVault URL.
+    /// Adds a container app secret that references a KeyVault secret using the KeyVault URL as an ArmExpression.
     /// Overloaded function allows for passing environment variable name different from secret.
     [<CustomOperation "add_key_vault_secret">]
     member this.AddKeyVaultSecret(state: ContainerAppConfig, key, envVarName, keyVaultUrl: ArmExpression, identity: ArmExpression) =
@@ -559,7 +559,7 @@ type ContainerAppBuilder() =
                 Dependencies = state.Dependencies + newDeps
         }
 
-    /// Adds a container app secret that references a KeyVault secret using the KeyVault URL.
+    /// Adds a container app secret that references a KeyVault secret using the KeyVault URL as an ArmExpression.
     [<CustomOperation "add_key_vault_secret">]
     member this.AddKeyVaultSecret(state: ContainerAppConfig, key, keyVaultUrl: ArmExpression, identity: ArmExpression) =
         this.AddKeyVaultSecret(state, key, key, keyVaultUrl, identity)

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -534,7 +534,6 @@ type ContainerAppBuilder() =
                     match expression.Owner with
                     | Some owner -> state.Dependencies.Add owner
                     | None -> state.Dependencies
-
         }
 
     /// Adds an application secrets to the Azure Container App.
@@ -542,18 +541,15 @@ type ContainerAppBuilder() =
     member this.AddSecretExpressions(state: ContainerAppConfig, xs: #seq<_>) =
         xs |> Seq.fold (fun s (k, e) -> this.AddSecretExpression(s, k, e)) state
 
-
-    /// Adds an application secret to the Azure Container App.
-    [<CustomOperation "add_secret_keyvault_ref">]
-    member _.AddSecretKeyVaultRef(state: ContainerAppConfig, key, keyVaultUrl: string, identity: string) =
+    /// Adds an application secret referencing a KeyVault  to the Azure Container App.
+    [<CustomOperation "add_secret_keyvault_reference">]
+    member _.AddSecretKeyVaultReference(state: ContainerAppConfig, key, keyVaultUrl: string, identity: string) =
         let key = (ContainerAppSettingKey.Create key).OkValue
 
         {
             state with
                 Secrets = state.Secrets.Add(key, (KeyVaultSecretReference (keyVaultUrl, identity)))
                 EnvironmentVariables = state.EnvironmentVariables.Add(EnvVar.createSecure key.Value key.Value)
-                // TODO: Need to track resourceId of dependencies for keyVaultUrl and Identity
-                // Dependencies = state.Dependencies
         }
 
     /// Adds a public environment variable to the Azure Container App environment variables.

--- a/src/Farmer/Builders/Builders.KeyVault.fs
+++ b/src/Farmer/Builders/Builders.KeyVault.fs
@@ -116,7 +116,13 @@ type SecretConfig = {
 
     member this.ResourceName = this.Vault |> Option.map (fun x -> x.Name / this.SecretName)
     member this.ResourceId = this.ResourceName |> Option.map secrets.resourceId
-
+    member this.CreateExpression field =
+        this.ResourceId
+        |> Option.map (
+            ArmExpression.reference >> _.Map(fun e ->
+                $"{e}.%s{field}"))
+    member this.SecretUri = this.CreateExpression "secretUri"
+    member this.SecretUriWithVersion = this.CreateExpression "secretUriWithVersion"
     static member private HandleNoVault() =
         failwith "Secret must be linked to a vault in order to add it to a deployment"
 

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -149,6 +149,8 @@ type EnvVar =
     | SecureEnvValue of SecureParameter
     /// Use for secret environment variables that get their value from an ARM Expression. These will be an ARM expression in the template, but value used in a secure context.
     | SecureEnvExpression of ArmExpression
+    /// Use for secret environment variables that reference a Container App Secret.
+    | EnvValueSecretReference of string
 
     static member create (name: string) (value: string) = name, EnvValue value
 
@@ -157,6 +159,9 @@ type EnvVar =
 
     static member createSecureExpression (name: string) (armExpression: ArmExpression) =
         name, SecureEnvExpression armExpression
+
+    static member createSecretReference (name: string) (paramName: string) =
+        name, EnvValueSecretReference paramName
 
 module Mb =
     let toBytes (mb: int<Mb>) = int64 mb * 1024L * 1024L

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -450,27 +450,9 @@ type ObjectId =
         | ObjectId id -> id
 
 type SecretValue =
-    | KeyVaultSecretReference of keyVaultUrl: string * identity: string
+    | KeyVaultSecretReference of keyVaultUrl: ArmExpression * identity: ArmExpression
     | ParameterSecret of SecureParameter
     | ExpressionSecret of ArmExpression
-
-    member this.toArmJson name =
-       match this with
-       | ParameterSecret secureParameter ->
-           {| name = name
-              value = Some (secureParameter.ArmExpression.Eval())
-              keyVaultUrl = None
-              identity = None |}
-       | ExpressionSecret armExpression ->
-           {| name = name
-              value = Some (armExpression.Eval())
-              keyVaultUrl = None
-              identity = None |}
-       | KeyVaultSecretReference (url, identity) ->
-           {| name = name
-              value = None
-              keyVaultUrl = Some url
-              identity = Some identity |}
 
 type Setting =
     | ParameterSetting of SecureParameter

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -454,6 +454,27 @@ type SecretValue =
     | ParameterSecret of SecureParameter
     | ExpressionSecret of ArmExpression
 
+    member this.toArmJson name =
+        match this with
+        | ParameterSecret secureParameter -> {|
+            name = name
+            value = Some(secureParameter.ArmExpression.Eval())
+            keyVaultUrl = None
+            identity = None
+          |}
+        | ExpressionSecret armExpression -> {|
+            name = name
+            value = Some(armExpression.Eval())
+            keyVaultUrl = None
+            identity = None
+          |}
+        | KeyVaultSecretReference(url, identity) -> {|
+            name = name
+            value = None
+            keyVaultUrl = Some (url.Eval())
+            identity = Some (identity.Eval())
+          |}
+
 type Setting =
     | ParameterSetting of SecureParameter
     | LiteralSetting of string

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -454,7 +454,7 @@ type SecretValue =
     | ParameterSecret of SecureParameter
     | ExpressionSecret of ArmExpression
 
-    member this.armObj name=
+    member this.toArmJson name =
        match this with
        | ParameterSecret secureParameter ->
            {| name = name

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -449,15 +449,28 @@ type ObjectId =
         match this with
         | ObjectId id -> id
 
-/// Represents a secret to be captured either via an ARM expression or a secure parameter.
 type SecretValue =
+    | KeyVaultSecretReference of keyVaultUrl: string * identity: string
     | ParameterSecret of SecureParameter
     | ExpressionSecret of ArmExpression
 
-    member this.Value =
-        match this with
-        | ParameterSecret secureParameter -> secureParameter.ArmExpression.Eval()
-        | ExpressionSecret armExpression -> armExpression.Eval()
+    member this.armObj name=
+       match this with
+       | ParameterSecret secureParameter ->
+           {| name = name
+              value = Some (secureParameter.ArmExpression.Eval())
+              keyVaultUrl = None
+              identity = None |}
+       | ExpressionSecret armExpression ->
+           {| name = name
+              value = Some (armExpression.Eval())
+              keyVaultUrl = None
+              identity = None |}
+       | KeyVaultSecretReference (url, identity) ->
+           {| name = name
+              value = None
+              keyVaultUrl = Some url
+              identity = Some identity |}
 
 type Setting =
     | ParameterSetting of SecureParameter

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -455,25 +455,22 @@ type SecretValue =
     | ExpressionSecret of ArmExpression
 
     member this.toArmJson name =
+        let defaultArm =
+            {|
+              name = name
+              value = None
+              keyVaultUrl = None
+              identity = None
+            |}
         match this with
-        | ParameterSecret secureParameter -> {|
-            name = name
-            value = Some(secureParameter.ArmExpression.Eval())
-            keyVaultUrl = None
-            identity = None
-          |}
-        | ExpressionSecret armExpression -> {|
-            name = name
-            value = Some(armExpression.Eval())
-            keyVaultUrl = None
-            identity = None
-          |}
-        | KeyVaultSecretReference(url, identity) -> {|
-            name = name
-            value = None
-            keyVaultUrl = Some (url.Eval())
-            identity = Some (identity.Eval())
-          |}
+        | ParameterSecret secureParameter -> {| defaultArm with value = Some(secureParameter.ArmExpression.Eval()) |}
+        | ExpressionSecret armExpression -> {| defaultArm with value = Some(armExpression.Eval()) |}
+        | KeyVaultSecretReference(url, identity) ->
+            {|
+              defaultArm with
+                keyVaultUrl = Some (url.Eval())
+                identity = Some (identity.Eval())
+            |}
 
 type Setting =
     | ParameterSetting of SecureParameter

--- a/src/Farmer/Types.fs
+++ b/src/Farmer/Types.fs
@@ -465,7 +465,7 @@ type SecretValue =
         match this with
         | ParameterSecret secureParameter -> {| defaultArm with value = Some(secureParameter.ArmExpression.Eval()) |}
         | ExpressionSecret armExpression -> {| defaultArm with value = Some(armExpression.Eval()) |}
-        | KeyVaultSecretReference(url, identity) ->
+        | KeyVaultSecretReference (url, identity) ->
             {|
               defaultArm with
                 keyVaultUrl = Some (url.Eval())

--- a/src/Tests/ContainerApps.fs
+++ b/src/Tests/ContainerApps.fs
@@ -89,6 +89,7 @@ let fullContainerAppDeployment =
                 add_env_variables [ "ServiceBusQueueName", "wishrequests" ]
 
                 add_secret_expressions [ "containerlogs", containerLogs.PrimarySharedKey ]
+                add_secret_keyvault_ref "keyvaultname" "url" "master"
             }
             containerApp {
                 name "servicebus"
@@ -464,5 +465,14 @@ let tests =
                     | _ -> None)
 
             Expect.isSome managedEnvironment.AppInsightsInstrumentationKey "Dapr AI key not set"
+        }
+
+        test "Referencing KeyVault Secrets in Container App Secrets" {
+            let containerApp = jobj.SelectToken("resources[?(@.name=='multienv')]")
+            let secrets = containerApp.SelectToken("properties.configuration.secrets")
+
+            Expect.equal (secrets.[1].["name"] |> string) "keyvaultname" "Incorrect Name for KeyVault Secret Reference"
+            Expect.equal (secrets.[1].["keyVaultUrl"] |> string) "url" "Incorrect Url for KeyVault Secret Reference"
+            Expect.equal (secrets.[1].["identity"] |> string) "master" "Incorrect Url for KeyVault Secret Reference"
         }
     ]

--- a/src/Tests/ContainerApps.fs
+++ b/src/Tests/ContainerApps.fs
@@ -153,8 +153,6 @@ let tests =
     testList "Container Apps" [
         let jsonTemplate = fullContainerAppDeployment.Template |> Writer.toJson
 
-        printfn $"{jsonTemplate}"
-
         let jobj = JObject.Parse jsonTemplate
 
         test "Container automatically creates a log analytics workspace" {


### PR DESCRIPTION
Still working on the below PR. This is my first time contributing to Farmer, so please let me know if the pattern I've established is consistent with the project. I wanted to get this PR started so that no one else also starts working on this issue. I'm still working on getting the minimal example configuration working. Thanks!

This PR closes #1195 

The changes in this PR are as follows:

* Added a custom operation to the Container App Builder that allows for adding container app secrets referencing KeyVault secrets. The KeyVault URL and identity are represented as ArmExpressions to allow for ARM template functions that dynamically resolve the resource identifier (e.g "resourceId(...)" and/or "reference(...)"). This feature was added to ARM with ApiVersion [2022-11-01-preview](https://learn.microsoft.com/en-us/azure/templates/microsoft.app/2022-11-01-preview/containerapps?pivots=deployment-language-arm-template#secret-1).
* Added the KeyVaultSecretReference type to the discriminated union to include KeyVaultSecretUrl property when serializing secrets.
* Added ability to create environment variables that reference container app secrets.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let identityName = "appUser"
let containerRegistryName = "myregistry"
let keyVaultName = "mykeyvault"
let secretName = "mysecretname"
let msi = createUserAssignedIdentity identityName

let fullContainerAppDeployment =
    let containerRegistryDomain = $"{containerRegistryName}.azurecr.io"

    let version = "1.0.0"
    let identity = ManagedIdentity.create msi.ResourceId

    let secret = secret {
        name keyVaultName
        link_to_unmanaged_keyvault (vaults.resourceId (ResourceName "mykeyvault"))
    }

    let httpContainerApp = containerApp {
        name "http"
        add_identity msi
        system_identity
        active_revision_mode Single

        add_registry_credentials [ registry containerRegistryDomain containerRegistryName identity ]

        add_containers [
            container {
                name "http"
                private_docker_image containerRegistryDomain "http" version
                cpu_cores 0.25<VCores>
                memory 0.5<Gb>
                ephemeral_storage 1.<Gb>
            }
        ]

        add_key_vault_secret secretName secret.SecretUri.Value msi.ResourceId.ArmExpression
    }

    let containerEnv = containerEnvironment {
        name "testing"
        add_containers [ httpContainerApp ]
    }

    arm { add_resources [ containerEnv; secret; msi ] }


```
