### PR TITLE
NAT Gateways: set the SKU of NAT Gateway to deploy.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,10 @@
 Release Notes
 =============
 
-## 1.9.17
+## 1.9.19
+* NAT Gateways: set the SKU of NAT Gateway to deploy.
+
+## 1.9.18
 * AKS: add ability to specify `kubernetes_version` parameter
 
 ## 1.9.16

--- a/docs/content/api-overview/resources/nat-gateway.md
+++ b/docs/content/api-overview/resources/nat-gateway.md
@@ -14,10 +14,11 @@ addresses or prefixes of groups of addresses can be specified.
 
 #### Builder Keywords
 
-| Applies To | Keyword | Purpose |
-|-|-|-|
-| natGateway | name | Name of the NAT Gateway resource |
+| Applies To | Keyword      | Purpose                                                                                            |
+|-|--------------|----------------------------------------------------------------------------------------------------|
+| natGateway | name         | Name of the NAT Gateway resource                                                                   |
 | natGateway | idle_timeout | Timeout after which connections that have seen no traffic will be disconnected to free SNAT ports. |
+| natGateway | sku          | Set the SKU of NAT Gateway to deploy                                                               |
 
 #### Example
 
@@ -32,6 +33,7 @@ arm {
     add_resources [
         natGateway {
             name "my-nat-gateway"
+            sku NatGateway.Sku.Standard
         }
         vnet {
             name "my-net"

--- a/src/Farmer/Arm/Network.fs
+++ b/src/Farmer/Arm/Network.fs
@@ -1,13 +1,12 @@
 [<AutoOpen>]
 module Farmer.Arm.Network
 
-open System.Net.Mail
 open Farmer
-open Farmer.Arm
 open Farmer.ExpressRoute
 open Farmer.Network
 open Farmer.Route
 open Farmer.RouteServer
+open Farmer.Storage
 open Farmer.VirtualNetworkGateway
 
 let connections = ResourceType("Microsoft.Network/connections", "2020-04-01")
@@ -28,10 +27,10 @@ let networkProfiles =
     ResourceType("Microsoft.Network/networkProfiles", "2020-04-01")
 
 let publicIPAddresses =
-    ResourceType("Microsoft.Network/publicIPAddresses", "2024-05-01")
+    ResourceType("Microsoft.Network/publicIPAddresses", "2024-07-01")
 
 let publicIPPrefixes =
-    ResourceType("Microsoft.Network/publicIPPrefixes", "2024-05-01")
+    ResourceType("Microsoft.Network/publicIPPrefixes", "2024-07-01")
 
 let serviceEndpointPolicies =
     ResourceType("Microsoft.Network/serviceEndpointPolicies", "2020-07-01")
@@ -48,7 +47,7 @@ let virtualNetworkGateways =
 let localNetworkGateways =
     ResourceType("Microsoft.Network/localNetworkGateways", "")
 
-let natGateways = ResourceType("Microsoft.Network/natGateways", "2021-08-01")
+let natGateways = ResourceType("Microsoft.Network/natGateways", "2024-07-01")
 
 let privateEndpoints =
     ResourceType("Microsoft.Network/privateEndpoints", "2021-05-01")
@@ -164,7 +163,7 @@ type RouteTable = {
 type RouteServer = {
     Name: ResourceName
     Location: Location
-    Sku: Sku
+    Sku: RouteServer.Sku
     AllowBranchToBranchTraffic: FeatureFlag
     HubRoutingPreference: HubRoutingPreference
     Tags: Map<string, string>
@@ -1028,6 +1027,7 @@ type NatGateway = {
     IdleTimeout: int<Minutes>
     PublicIpAddresses: LinkedResource list
     PublicIpPrefixes: LinkedResource list
+    Sku: NatGateway.Sku
     Tags: Map<string, string>
 } with
 
@@ -1046,7 +1046,7 @@ type NatGateway = {
 
             {|
                 natGateways.Create(this.Name, this.Location, dependsOn = dependencies, tags = this.Tags) with
-                    sku = {| name = "Standard" |}
+                    sku = {| name = this.Sku.ArmValue |}
                     properties = {|
                         idleTimeoutInMinutes = this.IdleTimeout
                         publicIpAddresses = this.PublicIpAddresses |> List.map LinkedResource.AsIdObject

--- a/src/Farmer/Builders/Builders.NatGateway.fs
+++ b/src/Farmer/Builders/Builders.NatGateway.fs
@@ -8,6 +8,7 @@ open Farmer.PublicIpAddress
 type NatGatewayConfig = {
     Name: ResourceName
     IdleTimeout: int<Minutes>
+    Sku: NatGateway.Sku
     Tags: Map<string, string>
 } with
 
@@ -15,12 +16,15 @@ type NatGatewayConfig = {
         member this.ResourceId = natGateways.resourceId this.Name
 
         member this.BuildResources location = [
-            // Currently just generate with a single public IP.
+            // Currently generate with a single public IP.
             {
                 PublicIpAddress.Name = ResourceName $"{this.Name.Value}-publicip-1"
                 AvailabilityZones = NoZone
                 Location = location
-                Sku = Sku.Standard
+                Sku =
+                    match this.Sku with
+                    | Farmer.NatGateway.Sku.Standard -> PublicIpAddress.Sku.Standard
+                    | Farmer.NatGateway.Sku.StandardV2 -> PublicIpAddress.Sku.StandardV2
                 AllocationMethod = AllocationMethod.Static
                 AddressVersion = Network.AddressVersion.IPv4
                 DomainNameLabel = None
@@ -28,6 +32,7 @@ type NatGatewayConfig = {
             }
             {
                 NatGateway.Name = this.Name
+                Sku = this.Sku
                 Location = location
                 PublicIpAddresses = [
                     LinkedResource.Managed(publicIPAddresses.resourceId $"{this.Name.Value}-publicip-1")
@@ -42,6 +47,7 @@ type NatGatewayBuilder() =
     member _.Yield _ = {
         Name = ResourceName.Empty
         IdleTimeout = 4<Minutes>
+        Sku = NatGateway.Sku.Standard
         Tags = Map.empty
     }
 
@@ -54,5 +60,8 @@ type NatGatewayBuilder() =
             raiseFarmer "Maximum idle timeout is 120 minutes."
 
         { state with IdleTimeout = idleTimeout }
+
+    [<CustomOperation "sku">]
+    member _.Sku(state: NatGatewayConfig, sku: NatGateway.Sku) = { state with Sku = sku }
 
 let natGateway = NatGatewayBuilder()

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -2948,6 +2948,16 @@ module ApplicationGateway =
             | TemporaryRedirect -> "TemporaryRedirect"
             | PermanentRedirect -> "PermanentRedirect"
 
+module NatGateway =
+    [<RequireQualifiedAccess>]
+    type Sku =
+        | Standard
+        | StandardV2
+
+        member this.ArmValue =
+            match this with
+            | Standard -> "Standard"
+            | StandardV2 -> "StandardV2"
 
 module VirtualNetworkGateway =
     [<RequireQualifiedAccess>]
@@ -3531,10 +3541,12 @@ module PublicIpAddress =
 
     type Sku =
         | Standard
+        | StandardV2
 
         member this.ArmValue =
             match this with
             | Standard -> "Standard"
+            | StandardV2 -> "StandardV2"
 
 module Cdn =
     type Sku =

--- a/src/Tests/test-data/load-balancer.json
+++ b/src/Tests/test-data/load-balancer.json
@@ -137,7 +137,7 @@
       "type": "Microsoft.Network/loadBalancers/backendAddressPools"
     },
     {
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2024-07-01",
       "location": "northeurope",
       "name": "lb-pip",
       "properties": {

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -743,7 +743,7 @@
               "type": "Microsoft.Network/virtualNetworks"
             },
             {
-              "apiVersion": "2024-05-01",
+              "apiVersion": "2024-07-01",
               "location": "uksouth",
               "name": "farmervm-ip",
               "properties": {

--- a/src/Tests/test-data/vm.json
+++ b/src/Tests/test-data/vm.json
@@ -130,7 +130,7 @@
       "type": "Microsoft.Network/virtualNetworks"
     },
     {
-      "apiVersion": "2024-05-01",
+      "apiVersion": "2024-07-01",
       "location": "northeurope",
       "name": "isaacsVM-ip",
       "properties": {


### PR DESCRIPTION
The changes in this PR are as follows:

* NAT Gateways: set the SKU of NAT Gateway to deploy.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
natGateway {
    name "my-nat-gateway"
    sku NatGateway.Sku.Standard
}
```
