### PR TITLE
Remove Location Field in Data Rule Collection Association Template

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-## 1.9.19
+## 1.9.20
 * Fixes bug in data collection association by removing location field
 
 ## 1.9.18

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ Release Notes
 ## 1.9.20
 * Fixes bug in data collection association by removing location field
 
-## 1.9.18
+## 1.9.19
 * Data Collection: Adds `dataCollectionRule`, `dataCollectionEndpoint`, `
 RuleAssociation` builders for Azure Monitor
 * Prometheus Group Rules: Adds `prometheusRuleGroup` builder for prometheus metrics in Azure Monitor

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,12 @@
 Release Notes
 =============
 
+## 1.9.19
+* Fixes bug in data collection association by removing location field
+
 ## 1.9.18
-* Data Collection: Adds `dataCollectionRule`, `dataCollectionEndpoint`, `dataCollectionRuleAssociation` builders for Azure Monitor
+* Data Collection: Adds `dataCollectionRule`, `dataCollectionEndpoint`, `
+RuleAssociation` builders for Azure Monitor
 * Prometheus Group Rules: Adds `prometheusRuleGroup` builder for prometheus metrics in Azure Monitor
 * Container Service: add ability to specify `enable_azure_monitor` parameter
 * Action Group: adds ability to create Incident Receivers in action group with `add_incident_receivers`

--- a/src/Farmer/Arm/Monitor.fs
+++ b/src/Farmer/Arm/Monitor.fs
@@ -145,7 +145,7 @@ type DataCollectionRule = {
 
 
 let dataCollectionRuleAssociations (resourceType: ResourceType) =
-    ResourceType($"{resourceType.Type}/providers/dataCollectionRuleAssociations", "2022-06-01")
+    ResourceType($"{resourceType.Type}/providers/dataCollectionRuleAssociations", "2023-03-11")
 
 type DataCollectionRuleAssociation = {
     Name: ResourceName

--- a/src/Farmer/Arm/Monitor.fs
+++ b/src/Farmer/Arm/Monitor.fs
@@ -157,14 +157,16 @@ type DataCollectionRuleAssociation = {
 
     interface IArmResource with
         member this.ResourceId =
-            dataCollectionRuleAssociations(this.AssociatedResource.Type).resourceId (this.Name)
+            dataCollectionRuleAssociations(this.AssociatedResource.Type)
+                .resourceId (this.Name)
 
         member this.JsonModel =
             let dependencies =
                 [ this.AssociatedResource; this.RuleId ] @ (List.ofSeq this.Dependencies)
 
             {|
-                dataCollectionRuleAssociations(this.AssociatedResource.Type).Create(this.Name, dependsOn = dependencies) with
+                dataCollectionRuleAssociations(this.AssociatedResource.Type)
+                    .Create(this.Name, dependsOn = dependencies) with
                     properties = {|
                         description = this.Description
                         dataCollectionRuleId = this.RuleId.Eval()

--- a/src/Farmer/Arm/Monitor.fs
+++ b/src/Farmer/Arm/Monitor.fs
@@ -150,7 +150,6 @@ let dataCollectionRuleAssociations (resourceType: ResourceType) =
 type DataCollectionRuleAssociation = {
     Name: ResourceName
     AssociatedResource: ResourceId
-    Location: Location
     RuleId: ResourceId
     Description: string
     Dependencies: Set<ResourceId>
@@ -158,16 +157,14 @@ type DataCollectionRuleAssociation = {
 
     interface IArmResource with
         member this.ResourceId =
-            dataCollectionRuleAssociations(this.AssociatedResource.Type)
-                .resourceId (this.Name)
+            dataCollectionRuleAssociations(this.AssociatedResource.Type).resourceId (this.Name)
 
         member this.JsonModel =
             let dependencies =
                 [ this.AssociatedResource; this.RuleId ] @ (List.ofSeq this.Dependencies)
 
             {|
-                dataCollectionRuleAssociations(this.AssociatedResource.Type)
-                    .Create(this.Name, this.Location, dependencies) with
+                dataCollectionRuleAssociations(this.AssociatedResource.Type).Create(this.Name, dependsOn = dependencies) with
                     properties = {|
                         description = this.Description
                         dataCollectionRuleId = this.RuleId.Eval()

--- a/src/Farmer/Builders/Builders.AzureMonitor.fs
+++ b/src/Farmer/Builders/Builders.AzureMonitor.fs
@@ -179,11 +179,10 @@ type DataCollectionRuleAssociationConfig = {
         member this.ResourceId =
             dataCollectionRuleAssociations(this.AssociatedResource.Type).resourceId this.Name
 
-        member this.BuildResources location = [
+        member this.BuildResources _ = [
             {
-                Name = this.Name
+                DataCollectionRuleAssociation.Name = this.Name
                 AssociatedResource = this.AssociatedResource
-                Location = location
                 RuleId = this.RuleId
                 Description = this.Description
                 Dependencies = this.Dependencies

--- a/src/Tests/DataCollection.fs
+++ b/src/Tests/DataCollection.fs
@@ -153,6 +153,14 @@ let tests =
                     .SelectToken("resources[?(@.name=='myRuleAssociation')].properties.dataCollectionRuleId")
                     .ToString()
 
+            Expect.throws
+                (fun _ ->
+                    jobj
+                        .SelectToken("resources[?(@.name=='myRuleAssociation')].location")
+                        .ToString()
+                    |> ignore)
+                "Location should not be present in data collection rule association."
+
             let actualDependsOn =
                 jobj
                     .SelectToken("resources[?(@.name=='myRuleAssociation')].dependsOn")


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Removes the location property in the data rule collection association builder since that's not a property that exists in the arm template. 

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Tested my code** end-to-end against a live Azure subscription.
* [ ] **Updated the documentation** in the docs folder for the affected changes.
* [ ] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [ ] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
```
