### PR TITLE
AKS Cluster: Add os_sku option for agent pool config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.9.21
+* AKS Cluster: Added os_sku option for agentPool config
+
 ## 1.9.20
 * Data Collection: Fixes bug in data collection association by removing location field.
 

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -60,6 +60,7 @@ The Agent Pool builder (`agentPool`) constructs agent pools in the AKS cluster.
 | enable_fips               | Uses a FIPS compliant OS image for VM's in the agent pool.                                             |
 | max_pods                  | Sets the maximum number of pods in the agent pool.                                                     |
 | os_type                   | Sets the OS type of the VM's in the agent pool.                                                        |
+| os_sku                    | Sets the OS sku of the VM's in the agent pool.                                                         |
 | pod_subnet                | Sets the name of a virtual network subnet where this AKS cluster should be attached.                   |
 | subnet                    | Sets the name of a virtual network subnet where this AKS cluster should be attached.                   |
 | vm_size                   | Sets the size of the VM's in the agent pool.                                                           |

--- a/src/Farmer/Arm/ContainerService.fs
+++ b/src/Farmer/Arm/ContainerService.fs
@@ -244,6 +244,7 @@ type ManagedCluster = {
             Mode: AgentPoolMode
             OsDiskSize: int<Gb>
             OsType: OS
+            OsSKU: string option
             VmSize: VMSize
             AvailabilityZones: ZoneSelection
             VirtualNetworkName: ResourceName option
@@ -360,6 +361,7 @@ type ManagedCluster = {
                                 mode = agent.Mode |> string
                                 osDiskSizeGB = agent.OsDiskSize
                                 osType = string agent.OsType
+                                osSKU = agent.OsSKU
                                 vmSize = agent.VmSize.ArmValue
                                 availabilityZones = agent.AvailabilityZones.ArmValue
                                 vnetSubnetID =

--- a/src/Farmer/Builders/Builders.ContainerService.fs
+++ b/src/Farmer/Builders/Builders.ContainerService.fs
@@ -18,6 +18,7 @@ type AgentPoolConfig = {
     Mode: AgentPoolMode
     OsDiskSize: int<Gb>
     OsType: OS
+    OsSKU: string option
     VmSize: VMSize
     AvailabilityZones: ZoneSelection
     VirtualNetworkName: ResourceName option
@@ -40,6 +41,7 @@ type AgentPoolConfig = {
         Mode = System
         OsDiskSize = 0<Gb>
         OsType = OS.Linux
+        OsSKU = None
         VirtualNetworkName = None
         SubnetName = None
         PodSubnetName = None
@@ -188,6 +190,7 @@ type AksConfig = {
                         Mode = agentPool.Mode
                         OsDiskSize = agentPool.OsDiskSize
                         OsType = agentPool.OsType
+                        OsSKU = agentPool.OsSKU
                         SubnetName = agentPool.SubnetName
                         PodSubnetName = agentPool.PodSubnetName
                         VmSize = agentPool.VmSize
@@ -274,6 +277,9 @@ type AgentPoolBuilder() =
         state with
             EnableFIPS = Some featureFlag
     }
+
+    [<CustomOperation "os_sku">]
+    member _.osSKU(state: AgentPoolConfig, sku) = { state with OsSKU = Some sku }
 
     /// Sets the agent pool to user mode.
     [<CustomOperation "user_mode">]


### PR DESCRIPTION
The changes in this PR are as follows:

* Add os_sku option to agent pool config

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders
open Farmer.ContainerService

type AksDeploymentRequestV1 =
    { ManagementResourceGroupName: string
      TenantMsi: UserAssignedIdentityConfig }

let aksResourceV1 (req: AksDeploymentRequestV1) =
    aks {
        name $"{req.ManagementResourceGroupName}-aks"
        tier Tier.Standard
        add_agent_pools
            [ agentPool {
                  name "systempool"
                  os_sku "AzureLinux"
                  disk_size 128<Gb>
                  vm_size (Vm.CustomImage "Standard_D2s_v3")
              }
              agentPool {
                  name "userpool"
                  os_sku "AzureLinux"
                  user_mode
                  disk_size 128<Gb>
                  vm_size (Vm.CustomImage "Standard_D4s_v3")
              } ]
    }
```
