### PR TITLE
AKS Cluster: Added auto_upgrade_profile option for managed clusters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+## 1.9.21
+* AKS Cluster: Added auto_upgrade_profile option for managed clusters
+
 ## 1.9.20
 * Data Collection: Fixes bug in data collection association by removing location field.
 

--- a/docs/content/api-overview/resources/aks-cluster.md
+++ b/docs/content/api-overview/resources/aks-cluster.md
@@ -19,13 +19,13 @@ The AKS builder (`aks`) constructs AKS clusters.
 | sku                                 | Specifies the SKU of the AKS cluster - default is 'Base'.                                                                                                   |
 | tier                                | Specifies the tier of the AKS cluster - default is 'Free'.                                                                                                  |
 | dns_prefix                          | Sets the DNS prefix of the AKS cluster.                                                                                                                     |
-| enable_defender                     | Enables Defender for the containers running in the cluster.                
-| enable_azure_monitor                     | Enables Azure Monitor for AKS, does not set the `KubeStateMetrics`       
-| add_kube_state_metrics                     | Enables Azure Monitor for AKS and sets custom metrics for AKS (`KubeStateMetrics`)                                                                         |
+| enable_defender                     | Enables Defender for the containers running in the cluster.                                                                                                 |
+| enable_azure_monitor                | Enables Azure Monitor for AKS, does not set the `KubeStateMetrics`                                                                                          |
+| add_kube_state_metrics              | Enables Azure Monitor for AKS and sets custom metrics for AKS (`KubeStateMetrics`)                                                                          |
 | enable_image_cleaner                | Enables a service to periodically purge images that are no longer used.                                                                                     |
 | enable_private_cluster              | Restricts the cluster's Kubernetes API to only be accessible from private networks.                                                                         |
 | enable_rbac                         | Enable Kubernetes Role-Based Access Control.                                                                                                                |
-| kubernetes_version                  | Sets the Kubernetes version of the AKS cluster.                                                                                                              |
+| kubernetes_version                  | Sets the Kubernetes version of the AKS cluster.                                                                                                             |
 | enable_workload_identity            | Enables workload identity to assign a pod to a managed identity. Requires OIDC, so enables that as well.                                                    |
 | oidc_issuer                         | Enables or disables the OIDC issuer service for issuing tokens for federated identity.                                                                      |
 | add_agent_pools                     | Adds agent pools to the AKS cluster.                                                                                                                        |
@@ -43,6 +43,7 @@ The AKS builder (`aks`) constructs AKS clusters.
 | add_api_server_authorized_ip_ranges | Adds IP address CIDR ranges to be allowed Kubernetes API access.                                                                                            |
 | addon                               | A list with the configuration of all addons on the cluster (AciConnectorLinux, HttpApplicationRouting, KubeDashboard, IngressApplicationGateway, OmsAgent). |
 | node_resource_group                 | Name for the resource group where your AKS resources are stored                                                                                             |
+| auto_upgrade_profile                | Configuration options for managing automatic node and aks cluster upgrades                                                                                  |
 
 ##### Configuration Members
 

--- a/src/Farmer/Arm/ContainerService.fs
+++ b/src/Farmer/Arm/ContainerService.fs
@@ -14,6 +14,7 @@ module AutoUpgradeProfiles =
         AutoUpgradeChannel: AutoUpgradeChannel
         NodeOSUpgradeChannel: NodeOSUpgradeChannel
     } with
+
         static member Default = {
             AutoUpgradeChannel = AutoUpgradeChannel.Stable
             NodeOSUpgradeChannel = NodeOSUpgradeChannel.NodeImage
@@ -207,6 +208,7 @@ type KubernetesVersion = {
     //Latest patch version selected if not specified
     Patch: int option
 } with
+
     static member Create(version: string) =
         let parts = version.Split('.')
 
@@ -400,9 +402,7 @@ type ManagedCluster = {
                             match this.KubernetesVersion with
                             | Some version -> version.Value
                             | None -> null
-                        autoUpgradeProfile = 
-                            this.AutoUpgradeProfile 
-                            |> Option.map AutoUpgradeProfiles.toArmJson
+                        autoUpgradeProfile = this.AutoUpgradeProfile |> Option.map AutoUpgradeProfiles.toArmJson
                         identityProfile =
                             match this.IdentityProfile with
                             | Some identityProfile -> identityProfile.ToArmJson

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -2436,6 +2436,30 @@ module ContainerService =
 
     type ContainerServiceSku = { Name: Sku; Tier: Tier }
 
+    [<RequireQualifiedAccess>]
+    type AutoUpgradeChannel =
+        | Patch
+        | Stable
+        | Rapid
+
+        member this.ArmValue =
+            match this with
+            | Patch -> "patch"
+            | Stable -> "stable"
+            | Rapid -> "rapid"
+
+    [<RequireQualifiedAccess>]
+    type NodeOSUpgradeChannel =
+        | NodeImage
+        | SecurityPatch
+        | Unmanaged
+
+        member this.ArmValue =
+            match this with
+            | NodeImage -> "NodeImage"
+            | SecurityPatch -> "SecurityPatch"
+            | Unmanaged -> "Unmanaged"
+
 module B2cTenant =
     type Sku =
         | PremiumP1

--- a/src/Tests/ContainerService.fs
+++ b/src/Tests/ContainerService.fs
@@ -681,8 +681,6 @@ let tests =
             let json = template.Template |> Writer.toJson
             let jobj = Newtonsoft.Json.Linq.JObject.Parse(json)
 
-            failwithf "%A" json
-
             let autoUpgradeChannel =
                 jobj.SelectToken("resources[?(@.name=='aks-cluster')].properties.autoUpgradeProfile.upgradeChannel")
                 |> string

--- a/src/Tests/ContainerService.fs
+++ b/src/Tests/ContainerService.fs
@@ -658,4 +658,35 @@ let tests =
                 "app"
                 "azureMonitorProfile.metrics.kubeStateMetrics.metricLabelsAllowList should be 'app' when specified"
         }
+        test "Basic AKS cluster with auto upgrade channel" {
+            let autoUpgradeConfig = {
+                AutoUpgradeChannel = ContainerService.AutoUpgradeChannel.Stable
+                NodeOSUpgradeChannel = ContainerService.NodeOSUpgradeChannel.NodeImage
+            }
+
+            let myAks = aks {
+                name "aks-cluster"
+                dns_prefix "testaks"
+                auto_upgrade_profile autoUpgradeConfig
+
+                add_agent_pools [
+                    agentPool {
+                        name "linuxPool"
+                        count 3
+                    }
+                ]
+            }
+
+            let template = arm { add_resource myAks }
+            let json = template.Template |> Writer.toJson
+            let jobj = Newtonsoft.Json.Linq.JObject.Parse(json)
+
+            failwithf "%A" json
+
+            let autoUpgradeChannel =
+                jobj.SelectToken("resources[?(@.name=='aks-cluster')].properties.autoUpgradeProfile.upgradeChannel")
+                |> string
+
+            Expect.equal autoUpgradeChannel "stable" "Incorrect autoUpgradeChannel value"
+        }
     ]


### PR DESCRIPTION
The changes in this PR are as follows:

* AKS Cluster: Added auto_upgrade_profile option for managed clusters

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

If I haven't completed any of the tasks above, I include the reasons why here:

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders
open Farmer.ContainerService

let autoUpgradeConfig =
    { AutoUpgradeChannel = ContainerService.AutoUpgradeChannel.Stable
      NodeOSUpgradeChannel = ContainerService.NodeOSUpgradeChannel.NodeImage }
aks {
    name $"{req.ManagementResourceGroupName}-aks"
    tier Tier.Standard
    auto_upgrade_profile autoUpgradeConfig
    add_agent_pools
        [ agentPool {
              name "systempool"
              disk_size 128<Gb>
              vm_size (Vm.CustomImage "Standard_D2s_v3")
          }
          agentPool {
              name "userpool"
              user_mode
              disk_size 128<Gb>
              vm_size (Vm.CustomImage "Standard_D4s_v3")
          } ]
}
```
