### PR TITLE
Log analytics tables

### DIFF
--- a/docs/content/api-overview/resources/loganalytics.md
+++ b/docs/content/api-overview/resources/loganalytics.md
@@ -10,8 +10,9 @@ weight: 12
 The Log Analytics builder is used to create Work space instances.
 
 - Log Analytics (`Microsoft.OperationalInsights/workspaces`)
+- Tables (`Microsoft.OperationalInsights/workspaces/tables`)
 
-#### Builder Keywords
+#### Log Analytics Builder Keywords
 
 | Keyword          | Purpose                                                         |
 | ---------------- | --------------------------------------------------------------- |
@@ -20,8 +21,18 @@ The Log Analytics builder is used to create Work space instances.
 | enable_ingestion | Enables ingestion network traffic.                              |
 | enable_query     | Enables query network traffic.                                  |
 | daily_cap        | Specifies an upper limit on the amount of data to ingest daily. |
+| tables           | Defines tables to be created in the workspace.                  |
 | add_tags         | Adds a set of tags to the resource                              |
 | add_tag          | Adds a tag to the resource                                      |
+
+#### Table Builder Keywords
+
+| Keyword               | Purpose                                                                                                                               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------|
+| Name                  | Sets the name of the table.                                                                                                           |
+| Plan                  | Sets the table plan. Analytics plans can set a retention period between 4 and 730. If ommited will default to the workspace retention.|
+| Columns               | Sets the columns of the table. Each column has a name and type.                                                                       |
+| TotalRetentionInDays  | Sets the total retention period for the table in days, between 4 and 4383. If ommited will default to the Plan retention.             |
 
 #### Configuration Members
 
@@ -42,6 +53,17 @@ let myAnalytics = logAnalytics {
     enable_ingestion
     enable_query
     daily_cap 5<Gb>
+    tables [
+        {
+            Name = ResourceName "Serilog"
+            Plan = Analytics (Some 30<Days>)
+            Columns = [
+                { Name = "TimeGenerated"; Type = "datetime" }
+                { Name = "Event"; Type = "dynamic" }
+            ]
+            TotalRetentionInDays = None
+        }
+    ]
     add_tag "tag1" "myTestResourceFarmer"
 }
 

--- a/src/Farmer/Arm/LogAnalytics.fs
+++ b/src/Farmer/Arm/LogAnalytics.fs
@@ -9,11 +9,6 @@ let workspaces =
 let tables =
     ResourceType("Microsoft.OperationalInsights/workspaces/tables", "2023-09-01")
 
-type Column = {
-    Name: string
-    Type: string
-}
-
 type Plan =
     | Analytics of RetentionInDays : int<Days> option
     | Auxiliary

--- a/src/Farmer/Arm/LogAnalytics.fs
+++ b/src/Farmer/Arm/LogAnalytics.fs
@@ -6,6 +6,61 @@ open Farmer
 let workspaces =
     ResourceType("Microsoft.OperationalInsights/workspaces", "2020-03-01-preview")
 
+let tables =
+    ResourceType("Microsoft.OperationalInsights/workspaces/tables", "2023-09-01")
+
+type Column = {
+    Name: string
+    Type: string
+}
+
+type Plan =
+    | Analytics of RetentionInDays : int<Days> option
+    | Auxiliary
+    | Basic
+    with
+        member this.ArmValue =
+            match this with
+            | Analytics _ -> "Analytics"
+            | Auxiliary -> "Auxiliary"
+            | Basic -> "Basic"
+
+        member this.RetentionInDays =
+            match this with
+            | Analytics days ->
+                match days with
+                | Some d -> Some d
+                | None -> Some -1<Days>
+            | Auxiliary -> None
+            | Basic -> None
+
+type Table = {
+    Name: ResourceName
+    Plan: Plan
+    Columns: Column list
+    TotalRetentionInDays: int<Days> option
+    LogAnalyticsWorkspace: ResourceId
+} with 
+    interface IArmResource with
+        member this.ResourceId = tables.resourceId this.Name
+        member this.JsonModel = {|
+            tables.Create(this.LogAnalyticsWorkspace.Name/this.Name, dependsOn = [ this.LogAnalyticsWorkspace ]) with
+                properties = {|
+                    plan = this.Plan.ArmValue
+                    retentionInDays = this.Plan.RetentionInDays |> Option.toNullable
+                    totalRetentionInDays = this.TotalRetentionInDays |> Option.defaultValue -1<Days>
+                    schema = {|
+                        name = this.Name.Value
+                        columns = 
+                            this.Columns
+                            |> List.map (fun c -> {|
+                                name = c.Name
+                                ``type`` = c.Type
+                            |})
+                    |}
+                |}
+        |}
+
 type Workspace = {
     Name: ResourceName
     Location: Location

--- a/src/Farmer/Arm/LogAnalytics.fs
+++ b/src/Farmer/Arm/LogAnalytics.fs
@@ -42,7 +42,7 @@ type Table = {
     LogAnalyticsWorkspace: ResourceId
 } with 
     interface IArmResource with
-        member this.ResourceId = tables.resourceId this.Name
+        member this.ResourceId = tables.resourceId (this.LogAnalyticsWorkspace.Name/this.Name)
         member this.JsonModel = {|
             tables.Create(this.LogAnalyticsWorkspace.Name/this.Name, dependsOn = [ this.LogAnalyticsWorkspace ]) with
                 properties = {|

--- a/src/Farmer/Builders/Builders.ContainerApps.fs
+++ b/src/Farmer/Builders/Builders.ContainerApps.fs
@@ -108,6 +108,7 @@ type ContainerEnvironmentConfig = {
                         IngestionSupport = None
                         QuerySupport = None
                         DailyCap = None
+                        Tables = []
                         Tags = Map.empty
                     }
                     :> IBuilder

--- a/src/Farmer/Builders/Builders.LogAnalytics.fs
+++ b/src/Farmer/Builders/Builders.LogAnalytics.fs
@@ -9,6 +9,26 @@ let private (|InBounds|OutOfBounds|) days =
     elif days > 730<Days> then OutOfBounds days
     else InBounds days
 
+type TableConfig = {
+    Name: ResourceName
+    Plan: Plan
+    Columns: Column list
+    TotalRetentionInDays: int<Days> option
+    LogAnalyticsWorkspace: ResourceId
+} with
+    interface IBuilder with
+        member this.ResourceId = tables.resourceId (this.LogAnalyticsWorkspace.Name/this.Name)
+        member this.BuildResources _ = [
+            let t : Table = {
+                Name = this.Name
+                Plan = this.Plan
+                Columns = this.Columns
+                TotalRetentionInDays = this.TotalRetentionInDays
+                LogAnalyticsWorkspace = this.LogAnalyticsWorkspace
+            }
+            t
+        ]
+
 type WorkspaceConfig = {
     Name: ResourceName
     RetentionPeriod: int<Days> option
@@ -38,6 +58,34 @@ type WorkspaceConfig = {
                 Tags = this.Tags
             }
         ]
+
+type TableBuilder() =
+    member _.Yield _ = {
+        Name = ResourceName.Empty
+        Plan = Basic
+        Columns = []
+        TotalRetentionInDays = None
+        LogAnalyticsWorkspace = ResourceId.Empty
+    }
+    /// Sets the name of the Log Analytics table.
+    [<CustomOperation "name">]
+    member _.Name(state: TableConfig, name) = { state with Name = ResourceName name }
+    /// Sets the plan of the Log Analytics table.
+    [<CustomOperation "plan">]
+    member _.Plan(state: TableConfig, plan) = { state with Plan = plan }
+    /// Sets the columns of the Log Analytics table.
+    [<CustomOperation "columns">]
+    member _.Columns(state: TableConfig, columns) = { state with Columns = columns }
+    /// Sets the total retention period of the Log Analytics table.
+    [<CustomOperation "total_retention_in_days">]
+    member _.TotalRetentionInDays(state: TableConfig, days) = { state with TotalRetentionInDays = Some days }
+    /// Sets the Log Analytics workspace for the table.
+    [<CustomOperation "log_analytics_workspace">]
+    member _.LogAnalyticsWorkspace(state: TableConfig, workspaceId : ResourceId) =
+        if workspaceId.Type.Type <> Arm.LogAnalytics.workspaces.Type then
+            raiseFarmer $"given resource was not of type '{Arm.LogAnalytics.workspaces.Type}'."
+        { state with LogAnalyticsWorkspace = workspaceId }
+
 
 type WorkspaceBuilder() =
     member _.Yield _ = {

--- a/src/Farmer/Builders/Builders.LogAnalytics.fs
+++ b/src/Farmer/Builders/Builders.LogAnalytics.fs
@@ -17,7 +17,7 @@ type TableConfig = {
 } with
     member this.BuildResources logAnalyticsWorkspace = [
         {
-            Name = this.Name
+            Name = ResourceName $"{this.Name.Value}_CL"
             Plan = this.Plan
             Columns = this.Columns
             TotalRetentionInDays = this.TotalRetentionInDays

--- a/src/Farmer/Builders/Builders.LogAnalytics.fs
+++ b/src/Farmer/Builders/Builders.LogAnalytics.fs
@@ -14,20 +14,16 @@ type TableConfig = {
     Plan: Plan
     Columns: Column list
     TotalRetentionInDays: int<Days> option
-    LogAnalyticsWorkspace: ResourceId
 } with
-    interface IBuilder with
-        member this.ResourceId = tables.resourceId (this.LogAnalyticsWorkspace.Name/this.Name)
-        member this.BuildResources _ = [
-            let t : Table = {
-                Name = this.Name
-                Plan = this.Plan
-                Columns = this.Columns
-                TotalRetentionInDays = this.TotalRetentionInDays
-                LogAnalyticsWorkspace = this.LogAnalyticsWorkspace
-            }
-            t
-        ]
+    member this.BuildResources logAnalyticsWorkspace = [
+        {
+            Name = this.Name
+            Plan = this.Plan
+            Columns = this.Columns
+            TotalRetentionInDays = this.TotalRetentionInDays
+            LogAnalyticsWorkspace = logAnalyticsWorkspace
+        } :> IArmResource
+    ]
 
 type WorkspaceConfig = {
     Name: ResourceName
@@ -35,6 +31,7 @@ type WorkspaceConfig = {
     IngestionSupport: FeatureFlag option
     QuerySupport: FeatureFlag option
     DailyCap: int<Gb> option
+    Tables : TableConfig list
     Tags: Map<string, string>
 } with
 
@@ -57,35 +54,9 @@ type WorkspaceConfig = {
                 DailyCap = this.DailyCap
                 Tags = this.Tags
             }
+            for table in this.Tables do
+                yield! table.BuildResources (this :> IBuilder).ResourceId
         ]
-
-type TableBuilder() =
-    member _.Yield _ = {
-        Name = ResourceName.Empty
-        Plan = Basic
-        Columns = []
-        TotalRetentionInDays = None
-        LogAnalyticsWorkspace = ResourceId.Empty
-    }
-    /// Sets the name of the Log Analytics table.
-    [<CustomOperation "name">]
-    member _.Name(state: TableConfig, name) = { state with Name = ResourceName name }
-    /// Sets the plan of the Log Analytics table.
-    [<CustomOperation "plan">]
-    member _.Plan(state: TableConfig, plan) = { state with Plan = plan }
-    /// Sets the columns of the Log Analytics table.
-    [<CustomOperation "columns">]
-    member _.Columns(state: TableConfig, columns) = { state with Columns = columns }
-    /// Sets the total retention period of the Log Analytics table.
-    [<CustomOperation "total_retention_in_days">]
-    member _.TotalRetentionInDays(state: TableConfig, days) = { state with TotalRetentionInDays = Some days }
-    /// Sets the Log Analytics workspace for the table.
-    [<CustomOperation "log_analytics_workspace">]
-    member _.LogAnalyticsWorkspace(state: TableConfig, workspaceId : ResourceId) =
-        if workspaceId.Type.Type <> Arm.LogAnalytics.workspaces.Type then
-            raiseFarmer $"given resource was not of type '{Arm.LogAnalytics.workspaces.Type}'."
-        { state with LogAnalyticsWorkspace = workspaceId }
-
 
 type WorkspaceBuilder() =
     member _.Yield _ = {
@@ -94,6 +65,7 @@ type WorkspaceBuilder() =
         DailyCap = None
         IngestionSupport = None
         QuerySupport = None
+        Tables = []
         Tags = Map.empty
     }
 
@@ -134,6 +106,13 @@ type WorkspaceBuilder() =
     /// Specifies the daily cap of ingested data.
     [<CustomOperation "daily_cap">]
     member _.DailyCap(state: WorkspaceConfig, cap) = { state with DailyCap = Some cap }
+
+    /// Adds tables to the Log Analytics workspace.
+    [<CustomOperation "tables">]
+    member _.Tables(state: WorkspaceConfig, tables: TableConfig list) = {
+        state with
+            Tables = tables
+    }
 
     interface ITaggable<WorkspaceConfig> with
         member _.Add state tags = {

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -1,6 +1,11 @@
-﻿namespace Farmer
+namespace Farmer
 
 open System
+
+type Column = {
+    Name: string
+    Type: string
+}
 
 type NonEmptyList<'T> =
     private

--- a/src/Tests/LogAnalytics.fs
+++ b/src/Tests/LogAnalytics.fs
@@ -1,4 +1,4 @@
-﻿module LogAnalytics
+module LogAnalytics
 
 open Expecto
 open Farmer
@@ -9,6 +9,7 @@ open Microsoft.Azure.Management.OperationalInsights
 open Microsoft.Azure.Management.OperationalInsights.Models
 open Microsoft.Rest
 open System
+open Newtonsoft.Json.Linq
 
 let dummyClient =
     new OperationalInsightsManagementClient(Uri "http://management.azure.com", TokenCredentials "NotNullOrWhiteSpace")
@@ -39,6 +40,33 @@ let tests =
             Expect.equal workspace.PublicNetworkAccessForQuery "Enabled" "QuerySupport"
             Expect.equal workspace.Sku.Name "PerGB2018" "Incorrect Sku"
             Expect.equal workspace.RetentionInDays (Nullable 30) "Incorrect Retention In Days"
+        }
+
+        test "Table created under workspace resource" {
+            let logging = logAnalytics {
+                name "MyAnalytics"
+                tables [
+                    {
+                        Name = ResourceName "MyTable"
+                        Plan = Analytics (Some 1<Days>)
+                        Columns = [
+                            { Name = "TimeGenerated"; Type = "datetime" }
+                            { Name = "Event"; Type = "dynamic" }
+                        ]
+                        TotalRetentionInDays = Some 2<Days>
+                    }
+                ]
+            }
+            let deployment = arm { add_resource logging }
+            let table =
+                deployment.Template.Resources
+                |> List.tryFind (fun r ->
+                    r.ResourceId.Name.Value = "MyAnalytics"
+                    && not(r.ResourceId.Segments |> List.isEmpty)
+                    && (r.ResourceId.Segments |> List.exactlyOne).Value = "MyTable")
+                |> Option.map (fun t -> t :?> Farmer.Arm.LogAnalytics.Table)
+
+            Expect.isSome table "Table resource not found"
         }
 
         test "Ingestion and Query are disabled by default" {

--- a/src/Tests/LogAnalytics.fs
+++ b/src/Tests/LogAnalytics.fs
@@ -66,7 +66,48 @@ let tests =
                     && (r.ResourceId.Segments |> List.exactlyOne).Value = "MyTable")
                 |> Option.map (fun t -> t :?> Farmer.Arm.LogAnalytics.Table)
 
-            Expect.isSome table "Table resource not found"
+            Expect.equal (table.Value.Columns.Length) 2 "Incorrect number of columns in table"
+            Expect.equal (table.Value.Columns[0].Name) "TimeGenerated" "Incorrect first column name"
+            Expect.equal (table.Value.Columns[0].Type) "datetime" "Incorrect first column type"
+            Expect.equal (table.Value.Columns[1].Name) "Event" "Incorrect second column name"
+            Expect.equal (table.Value.Columns[1].Type) "dynamic" "Incorrect second column type"
+            Expect.equal (table.Value.TotalRetentionInDays) (Some 2<Days>) "Incorrect total retention in days"
+            Expect.equal (table.Value.Plan.ArmValue) "Analytics" "Incorrect plan type"
+            Expect.equal (table.Value.Plan.RetentionInDays) (Some 1<Days>) "Incorrect plan retention in days"
+            Expect.equal (table.Value.LogAnalyticsWorkspace.Name.Value) "MyAnalytics" "Incorrect workspace name in table resource"
+        }
+
+        test "Table JSON emitted correctly" {
+            let logging = logAnalytics {
+                name "MyAnalytics"
+                tables [
+                    {
+                        Name = ResourceName "MyTable"
+                        Plan = Analytics (Some 1<Days>)
+                        Columns = [
+                            { Name = "TimeGenerated"; Type = "datetime" }
+                            { Name = "Event"; Type = "dynamic" }
+                        ]
+                        TotalRetentionInDays = Some 2<Days>
+                    }
+                ]
+            }
+            let deployment = arm { add_resource logging }
+            let jsonTemplate = deployment.Template |> Writer.toJson
+            let jobj = JObject.Parse jsonTemplate
+            let tableJson = jobj["resources"][1]
+            Expect.equal (tableJson["type"] |> string) LogAnalytics.tables.Type "Incorrect resource type"
+            Expect.equal (tableJson["apiVersion"] |> string) LogAnalytics.tables.ApiVersion "Incorrect api version"
+            Expect.equal (tableJson["dependsOn"][0] |> string) "[resourceId('Microsoft.OperationalInsights/workspaces', 'MyAnalytics')]" "Incorrect dependsOn"
+            Expect.equal (tableJson["name"] |> string) "MyAnalytics/MyTable" "Incorrect resource name"
+            Expect.equal (tableJson["properties"]["plan"] |> string) "Analytics" "Incorrect plan type"
+            Expect.equal (tableJson["properties"]["retentionInDays"] |> int) 1 "Incorrect plan retention in days"
+            Expect.equal (tableJson["properties"]["totalRetentionInDays"] |> int) 2 "Incorrect total retention in days"
+            let columns = tableJson["properties"].["schema"].["columns"]
+            Expect.equal (columns.[0]["name"] |> string) "TimeGenerated" "Incorrect first column name"
+            Expect.equal (columns.[0]["type"] |> string) "datetime" "Incorrect first column type"
+            Expect.equal (columns.[1]["name"] |> string) "Event" "Incorrect second column name"
+            Expect.equal (columns.[1]["type"] |> string) "dynamic" "Incorrect second column type"
         }
 
         test "Ingestion and Query are disabled by default" {

--- a/src/Tests/LogAnalytics.fs
+++ b/src/Tests/LogAnalytics.fs
@@ -4,7 +4,6 @@ open Expecto
 open Farmer
 open Farmer.Arm
 open Farmer.Builders
-open Farmer.Helpers
 open Microsoft.Azure.Management.OperationalInsights
 open Microsoft.Azure.Management.OperationalInsights.Models
 open Microsoft.Rest

--- a/src/Tests/LogAnalytics.fs
+++ b/src/Tests/LogAnalytics.fs
@@ -43,7 +43,7 @@ let tests =
 
         test "Table created under workspace resource" {
             let logging = logAnalytics {
-                name "MyAnalytics"
+                name "log-analytics"
                 tables [
                     {
                         Name = ResourceName "MyTable"
@@ -60,9 +60,9 @@ let tests =
             let table =
                 deployment.Template.Resources
                 |> List.tryFind (fun r ->
-                    r.ResourceId.Name.Value = "MyAnalytics"
+                    r.ResourceId.Name.Value = "log-analytics"
                     && not(r.ResourceId.Segments |> List.isEmpty)
-                    && (r.ResourceId.Segments |> List.exactlyOne).Value = "MyTable")
+                    && (r.ResourceId.Segments |> List.exactlyOne).Value = "MyTable_CL")
                 |> Option.map (fun t -> t :?> Farmer.Arm.LogAnalytics.Table)
 
             Expect.equal (table.Value.Columns.Length) 2 "Incorrect number of columns in table"
@@ -78,7 +78,7 @@ let tests =
 
         test "Table JSON emitted correctly" {
             let logging = logAnalytics {
-                name "MyAnalytics"
+                name "log-analytics"
                 tables [
                     {
                         Name = ResourceName "MyTable"
@@ -98,10 +98,11 @@ let tests =
             Expect.equal (tableJson["type"] |> string) LogAnalytics.tables.Type "Incorrect resource type"
             Expect.equal (tableJson["apiVersion"] |> string) LogAnalytics.tables.ApiVersion "Incorrect api version"
             Expect.equal (tableJson["dependsOn"][0] |> string) "[resourceId('Microsoft.OperationalInsights/workspaces', 'MyAnalytics')]" "Incorrect dependsOn"
-            Expect.equal (tableJson["name"] |> string) "MyAnalytics/MyTable" "Incorrect resource name"
+            Expect.equal (tableJson["name"] |> string) "log-analytics/MyTable_CL" "Incorrect resource name"
             Expect.equal (tableJson["properties"]["plan"] |> string) "Analytics" "Incorrect plan type"
             Expect.equal (tableJson["properties"]["retentionInDays"] |> int) 1 "Incorrect plan retention in days"
             Expect.equal (tableJson["properties"]["totalRetentionInDays"] |> int) 2 "Incorrect total retention in days"
+            Expect.equal (tableJson["properties"].["schema"].["name"] |> string) "MyTable_CL" "Incorrect table name"
             let columns = tableJson["properties"].["schema"].["columns"]
             Expect.equal (columns.[0]["name"] |> string) "TimeGenerated" "Incorrect first column name"
             Expect.equal (columns.[0]["type"] |> string) "datetime" "Incorrect first column type"

--- a/src/Tests/LogAnalytics.fs
+++ b/src/Tests/LogAnalytics.fs
@@ -73,7 +73,7 @@ let tests =
             Expect.equal (table.Value.TotalRetentionInDays) (Some 2<Days>) "Incorrect total retention in days"
             Expect.equal (table.Value.Plan.ArmValue) "Analytics" "Incorrect plan type"
             Expect.equal (table.Value.Plan.RetentionInDays) (Some 1<Days>) "Incorrect plan retention in days"
-            Expect.equal (table.Value.LogAnalyticsWorkspace.Name.Value) "MyAnalytics" "Incorrect workspace name in table resource"
+            Expect.equal (table.Value.LogAnalyticsWorkspace.Name.Value) "log-analytics" "Incorrect workspace name in table resource"
         }
 
         test "Table JSON emitted correctly" {
@@ -97,7 +97,7 @@ let tests =
             let tableJson = jobj["resources"][1]
             Expect.equal (tableJson["type"] |> string) LogAnalytics.tables.Type "Incorrect resource type"
             Expect.equal (tableJson["apiVersion"] |> string) LogAnalytics.tables.ApiVersion "Incorrect api version"
-            Expect.equal (tableJson["dependsOn"][0] |> string) "[resourceId('Microsoft.OperationalInsights/workspaces', 'MyAnalytics')]" "Incorrect dependsOn"
+            Expect.equal (tableJson["dependsOn"][0] |> string) "[resourceId('Microsoft.OperationalInsights/workspaces', 'log-analytics')]" "Incorrect dependsOn"
             Expect.equal (tableJson["name"] |> string) "log-analytics/MyTable_CL" "Incorrect resource name"
             Expect.equal (tableJson["properties"]["plan"] |> string) "Analytics" "Incorrect plan type"
             Expect.equal (tableJson["properties"]["retentionInDays"] |> int) 1 "Incorrect plan retention in days"


### PR DESCRIPTION
This PR is part of #1171

The changes in this PR are as follows:

* Adds a table builder as a child of the log analytics builder

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [ ] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
let logging = logAnalytics {
    name "log-analytics"
    tables [
        {
            Name = ResourceName "MyTable"
            Plan = Analytics (Some 30<Days>)
            Columns = [
                { Name = "TimeGenerated"; Type = "datetime" }
                { Name = "Event"; Type = "dynamic" }
            ]
            TotalRetentionInDays = None
        }
    ]
}
let deployment = arm {
    location Location.UKSouth
    add_resource logging
}
```

<img width="977" height="907" alt="image" src="https://github.com/user-attachments/assets/0c51221d-4f1a-4627-896a-5fa1d91ae7f0" />

<img width="785" height="749" alt="image" src="https://github.com/user-attachments/assets/4ab2b464-f215-49db-98f0-2396dfae9975" />
