### PR TITLE
Cosmos DB: Add autoscale, backup policies, and firewall support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+## 1.9.29
+* Cosmos DB: Add autoscale throughput support via `CosmosDb.Autoscale` throughput option (e.g. throughput (CosmosDb.Autoscale 4000<CosmosDb.RU>)`).
+* Cosmos DB: Add continuous backup retention policy via `backup_retention` keyword (`CosmosDb.Continuous7Days` or `CosmosDb.Continuous30Days`).
+* Cosmos DB: Add IP firewall rules via `add_firewall_rule` and `enable_azure_firewall` keywords.
+* Cosmos DB: Always emit primary location for database accounts, fixing deployment failures on accounts restored from backup (`createMode: "Restore"`).
+* Cosmos DB: Update all DocumentDb ARM resource API versions to `2024-11-15`.
+
 ## 1.9.28
 * Container Apps: Add `resources` operation to the `container` builder to set both CPU and memory together using a `ConsumptionPlanResources` discriminated union. This ensures only valid consumption plan resource combinations can be selected at compile time. The individual `cpu_cores` and `memory` operations remain available for use with dedicated plans.
 

--- a/docs/content/api-overview/resources/cosmos-db.md
+++ b/docs/content/api-overview/resources/cosmos-db.md
@@ -24,7 +24,7 @@ The CosmosDB builder abstracts the idea of an account and database into one. If 
 |-|-------------------------------|-|
 | Database | name                          | Sets the name of the database. |
 | Database | link_to_account               | Instructs Farmer to link this database to an existing Cosmos DB account rather than creating a new one. |
-| Database | throughput                    | Sets the throughput with either "provisioned throughput" or "serverless". |
+| Database | throughput                    | Sets the throughput: provisioned (`400<CosmosDb.RU>`), autoscale (`CosmosDb.Autoscale 4000<CosmosDb.RU>`), or serverless (`CosmosDb.Serverless`). |
 | Database | add_containers                | Adds a list of containers to the database. |
 | Account | account_name                  | Sets the name of the CosmosDB account. |
 | Account | kind                          | Sets the API and data model to use -- currently defaults to "Core (SQL)". |
@@ -33,6 +33,9 @@ The CosmosDB builder abstracts the idea of an account and database into one. If 
 | Account | consistency_policy            | Sets the consistency policy of the database. |
 | Account | failover_policy               | Sets the failover policy of the database. |
 | Account | free_tier                     | Registers this server with the free pricing tier, if supported and allowed by Azure. |
+| Account | backup_retention              | Sets the continuous backup retention policy (`CosmosDb.Continuous7Days` or `CosmosDb.Continuous30Days`). |
+| Account | add_firewall_rule             | Adds an IP address or CIDR range to the account firewall allowlist. |
+| Account | enable_azure_firewall         | Shorthand to allow access from other Azure services (adds `0.0.0.0` to firewall rules). |
 
 #### Cosmos Container Builder
 The container builder allows you to create and configure a specific container that is attached to a cosmos database.
@@ -54,17 +57,21 @@ open Farmer.Builders
 let myCosmosDb = cosmosDb {
     name "isaacsappdb"
     account_name "isaacscosmosdb"
-    throughput 400<CosmosDb.RU> // or throughput Serverless
+    throughput 400<CosmosDb.RU>         // or: throughput (CosmosDb.Autoscale 4000<CosmosDb.RU>)
+                                        //     throughput CosmosDb.Serverless
     failover_policy CosmosDb.NoFailover
     consistency_policy (CosmosDb.BoundedStaleness(500, 1000))
-    //kind DatabaseKind.Gremlin //Create a gremlin enabled account
+    backup_retention CosmosDb.Continuous7Days
+    enable_azure_firewall               // allow access from Azure services
+    add_firewall_rule "203.0.113.0"     // allow a specific IP
+    //kind DatabaseKind.Gremlin         // create a Gremlin-enabled account
     add_containers [
         cosmosContainer {
             name "myContainer"
             partition_key [ "/id" ] CosmosDb.Hash
             add_index "/path" [ CosmosDb.Number, CosmosDb.Hash ]
             exclude_path "/excluded/*"
-            //gremlin_graph //Mark this container to be a graph
+            //gremlin_graph             // mark this container as a graph
         }
     ]
 }

--- a/src/Farmer/Arm/DocumentDb.fs
+++ b/src/Farmer/Arm/DocumentDb.fs
@@ -5,22 +5,22 @@ open Farmer
 open Farmer.CosmosDb
 
 let containers =
-    ResourceType("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2021-04-15")
+    ResourceType("Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers", "2024-11-15")
 
 let sqlDatabases =
-    ResourceType("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2021-04-15")
+    ResourceType("Microsoft.DocumentDb/databaseAccounts/sqlDatabases", "2024-11-15")
 
 let mongoDatabases =
-    ResourceType("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2021-04-15")
+    ResourceType("Microsoft.DocumentDb/databaseAccounts/mongodbDatabases", "2024-11-15")
 
 let databaseAccounts =
-    ResourceType("Microsoft.DocumentDb/databaseAccounts", "2021-04-15")
+    ResourceType("Microsoft.DocumentDb/databaseAccounts", "2024-11-15")
 
 let gremlinDatabases =
-    ResourceType("Microsoft.DocumentDb/databaseAccounts/gremlinDatabases", "2022-05-15")
+    ResourceType("Microsoft.DocumentDb/databaseAccounts/gremlinDatabases", "2024-11-15")
 
 let graphs =
-    ResourceType("Microsoft.DocumentDb/databaseAccounts/gremlinDatabases/graphs", "2022-05-15")
+    ResourceType("Microsoft.DocumentDb/databaseAccounts/gremlinDatabases/graphs", "2024-11-15")
 
 type DatabaseKind =
     | Document
@@ -128,12 +128,14 @@ module DatabaseAccounts =
                     resource.Create(this.Account / this.Name, dependsOn = [ databaseAccounts.resourceId this.Account ]) with
                         properties = {|
                             resource = {| id = this.Name.Value |}
-                            options = {|
-                                throughput =
-                                    match this.Throughput with
-                                    | Provisioned t -> string t
-                                    | Serverless -> null
-                            |}
+                            options =
+                                match this.Throughput with
+                                | Provisioned t -> box {| throughput = string t |}
+                                | Autoscale t ->
+                                    box {|
+                                        autoscaleSettings = {| maxThroughput = int t |}
+                                    |}
+                                | Serverless -> null
                         |}
                 |}
 
@@ -143,6 +145,8 @@ type DatabaseAccount = {
     ConsistencyPolicy: ConsistencyPolicy
     FailoverPolicy: FailoverPolicy
     PublicNetworkAccess: FeatureFlag
+    BackupRetention: BackupRetention option
+    IpRules: string list
     FreeTier: bool
     Serverless: FeatureFlag
     Kind: DatabaseKind
@@ -215,22 +219,37 @@ type DatabaseAccount = {
                             maxIntervalInSeconds = this.MaxInterval |> Option.toNullable
                         |}
                         databaseAccountOfferType = "Standard"
+                        backupPolicy =
+                            match this.BackupRetention with
+                            | Some retention ->
+                                box {|
+                                    ``type`` = "Continuous"
+                                    continuousModeProperties = {| tier = retention.ArmValue |}
+                                |}
+                            | None -> null
                         enableAutomaticFailover = this.EnableAutomaticFailover |> Option.toNullable
                         enableMultipleWriteLocations = this.EnableMultipleWriteLocations |> Option.toNullable
+                        // Always include a primary location: required for Gremlin accounts and restored
+                        // accounts (createMode: "Restore") where Azure locks location to restore-point values.
                         locations =
-                            // Locations has to be specified for the account to be gremlin enabled.
-                            // Otherwise graph database provisioning fails.
-                            match this.FailoverLocations, (this.Serverless = Enabled || this.Kind = Gremlin) with
-                            | [], true ->
+                            match this.FailoverLocations with
+                            | [] ->
                                 box [
                                     {|
                                         locationName = this.Location.ArmValue
                                     |}
                                 ]
-                            | [], false -> null
-                            | locations, _ -> box locations
+                            | locations -> box locations
                         publicNetworkAccess = string this.PublicNetworkAccess
                         enableFreeTier = this.FreeTier
+                        ipRules =
+                            match this.IpRules with
+                            | [] -> null
+                            | rules ->
+                                box [
+                                    for ipRule in rules do
+                                        {| ipAddressOrRange = ipRule |}
+                                ]
                         capabilities =
                             if this.Serverless = Enabled || this.Kind = Gremlin then
                                 box [

--- a/src/Farmer/Builders/Builders.Cosmos.fs
+++ b/src/Farmer/Builders/Builders.Cosmos.fs
@@ -73,6 +73,8 @@ type CosmosDbConfig = {
     DbName: ResourceName
     DbThroughput: Throughput
     Containers: CosmosDbContainerConfig list
+    BackupRetention: BackupRetention option
+    IpRules: string list
     PublicNetworkAccess: FeatureFlag
     FreeTier: bool
     Tags: Map<string, string>
@@ -116,9 +118,12 @@ type CosmosDbConfig = {
                 Serverless =
                     match this.DbThroughput with
                     | Serverless -> Enabled
-                    | Provisioned _ -> Disabled
+                    | Provisioned _
+                    | Autoscale _ -> Disabled
                 PublicNetworkAccess = this.PublicNetworkAccess
                 FailoverPolicy = this.AccountFailoverPolicy
+                BackupRetention = this.BackupRetention
+                IpRules = this.IpRules
                 FreeTier = this.FreeTier
                 Tags = this.Tags
               }
@@ -242,6 +247,8 @@ type CosmosDbBuilder() =
         AccountFailoverPolicy = NoFailover
         DbThroughput = Provisioned 400<RU>
         Containers = []
+        BackupRetention = None
+        IpRules = []
         PublicNetworkAccess = Enabled
         FreeTier = false
         Tags = Map.empty
@@ -352,6 +359,24 @@ type CosmosDbBuilder() =
     /// Enables the use of CosmosDB free tier (one per subscription).
     [<CustomOperation "free_tier">]
     member _.FreeTier(state: CosmosDbConfig) = { state with FreeTier = true }
+
+    /// Sets the continuous backup retention policy for the account.
+    [<CustomOperation "backup_retention">]
+    member _.BackupRetention(state: CosmosDbConfig, retention: BackupRetention) = {
+        state with
+            BackupRetention = Some retention
+    }
+
+    /// Adds an IP address or CIDR range to the account firewall allowlist.
+    [<CustomOperation "add_firewall_rule">]
+    member _.AddFirewallRule(state: CosmosDbConfig, ipAddressOrRange: string) = {
+        state with
+            IpRules = state.IpRules @ [ ipAddressOrRange ]
+    }
+
+    /// Adds a firewall rule that enables access from other Azure services (0.0.0.0).
+    [<CustomOperation "enable_azure_firewall">]
+    member this.EnableAzureFirewall(state: CosmosDbConfig) = this.AddFirewallRule(state, "0.0.0.0")
 
     interface ITaggable<CosmosDbConfig> with
         member _.Add state tags = {

--- a/src/Farmer/Common.fs
+++ b/src/Farmer/Common.fs
@@ -3154,7 +3154,18 @@ module CosmosDb =
     /// The throughput for CosmosDB account
     type Throughput =
         | Provisioned of int<RU>
+        | Autoscale of int<RU>
         | Serverless
+
+    /// Continuous backup retention tier for a CosmosDB account.
+    type BackupRetention =
+        | Continuous7Days
+        | Continuous30Days
+
+        member this.ArmValue =
+            match this with
+            | Continuous7Days -> "Continuous7Days"
+            | Continuous30Days -> "Continuous30Days"
 
 module PostgreSQL =
     open Vm

--- a/src/Tests/Cosmos.fs
+++ b/src/Tests/Cosmos.fs
@@ -85,7 +85,7 @@ let tests =
 
             Expect.equal
                 (db.Endpoint.Eval())
-                "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2021-04-15').documentEndpoint]"
+                "[reference(resourceId('Microsoft.DocumentDb/databaseAccounts', 'test-account'), '2024-11-15').documentEndpoint]"
                 "Endpoint is incorrect"
 
             Expect.equal
@@ -274,4 +274,109 @@ let tests =
                         why
                 }
         ]
+
+        test "Autoscale template should include autoscaleSettings and not throughput" {
+            let t = arm {
+                add_resource (
+                    cosmosDb {
+                        name "foo"
+                        throughput (CosmosDb.Autoscale 4000<CosmosDb.RU>)
+                    }
+                )
+            }
+
+            let jobj = t.Template |> Writer.toJson |> Newtonsoft.Json.Linq.JObject.Parse
+
+            let dbOptions =
+                jobj.SelectToken(
+                    "$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts/sqlDatabases')].properties.options"
+                )
+
+            Expect.isNotNull dbOptions "Database resource should have options."
+
+            Expect.isNotNull
+                (dbOptions.SelectToken("autoscaleSettings.maxThroughput"))
+                "Autoscale options should contain autoscaleSettings.maxThroughput."
+
+            Expect.equal
+                (dbOptions.SelectToken("autoscaleSettings.maxThroughput") |> string)
+                "4000"
+                "maxThroughput should be 4000."
+
+            Expect.isNull (dbOptions.SelectToken("throughput")) "Autoscale options should not contain throughput."
+        }
+
+        test "Continuous backup retention should emit backupPolicy in template" {
+            let t = arm {
+                add_resource (
+                    cosmosDb {
+                        name "foo"
+                        backup_retention CosmosDb.Continuous7Days
+                    }
+                )
+            }
+
+            let json = t.Template |> Writer.toJson
+
+            Expect.isTrue (json.Contains("backupPolicy")) "Should contain backupPolicy."
+            Expect.isTrue (json.Contains("Continuous")) "Should contain Continuous backup type."
+            Expect.isTrue (json.Contains("Continuous7Days")) "Should contain Continuous7Days tier."
+        }
+
+        test "IP firewall rules should emit ipRules in template" {
+            let t = arm {
+                add_resource (
+                    cosmosDb {
+                        name "foo"
+                        add_firewall_rule "10.0.0.1"
+                        add_firewall_rule "10.0.0.2"
+                    }
+                )
+            }
+
+            let json = t.Template |> Writer.toJson
+
+            Expect.isTrue (json.Contains("ipRules")) "Should contain ipRules."
+            Expect.isTrue (json.Contains("10.0.0.1")) "Should contain first firewall IP."
+            Expect.isTrue (json.Contains("10.0.0.2")) "Should contain second firewall IP."
+        }
+
+        test "Enable Azure firewall should add 0.0.0.0 to IP rules" {
+            let t = arm {
+                add_resource (
+                    cosmosDb {
+                        name "foo"
+                        enable_azure_firewall
+                    }
+                )
+            }
+
+            let json = t.Template |> Writer.toJson
+
+            Expect.isTrue (json.Contains("0.0.0.0")) "Should contain 0.0.0.0 for Azure services access."
+        }
+
+        test "Provisioned account without failover should still emit a locations array" {
+            let t = arm {
+                add_resource (
+                    cosmosDb {
+                        name "foo"
+                        throughput 400<CosmosDb.RU>
+                    }
+                )
+            }
+
+            let jobj = t.Template |> Writer.toJson |> Newtonsoft.Json.Linq.JObject.Parse
+
+            let locationToken =
+                jobj.SelectToken(
+                    "$.resources[?(@.type=='Microsoft.DocumentDb/databaseAccounts')].properties.locations[0]"
+                )
+
+            Expect.isNotNull locationToken "Provisioned account should emit a locations array."
+
+            let locationName = locationToken.SelectToken("locationName") |> string
+
+            Expect.isNotEmpty locationName "Location name should not be empty."
+        }
     ]

--- a/src/Tests/test-data/lots-of-resources.json
+++ b/src/Tests/test-data/lots-of-resources.json
@@ -523,7 +523,7 @@
           },
           "resources": [
             {
-              "apiVersion": "2021-04-15",
+              "apiVersion": "2024-11-15",
               "kind": "GlobalDocumentDB",
               "location": "uksouth",
               "name": "testaccount",
@@ -535,13 +535,18 @@
                 },
                 "databaseAccountOfferType": "Standard",
                 "enableFreeTier": false,
+                "locations": [
+                  {
+                    "locationName": "uksouth"
+                  }
+                ],
                 "publicNetworkAccess": "Enabled"
               },
               "tags": {},
               "type": "Microsoft.DocumentDb/databaseAccounts"
             },
             {
-              "apiVersion": "2021-04-15",
+              "apiVersion": "2024-11-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccount')]"
               ],
@@ -557,7 +562,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases"
             },
             {
-              "apiVersion": "2021-04-15",
+              "apiVersion": "2024-11-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts/sqlDatabases', 'testaccount', 'testdb')]"
               ],
@@ -599,7 +604,7 @@
               "type": "Microsoft.DocumentDb/databaseAccounts/sqlDatabases/containers"
             },
             {
-              "apiVersion": "2021-04-15",
+              "apiVersion": "2024-11-15",
               "kind": "MongoDB",
               "location": "uksouth",
               "name": "testaccountmongo",
@@ -611,13 +616,18 @@
                 },
                 "databaseAccountOfferType": "Standard",
                 "enableFreeTier": false,
+                "locations": [
+                  {
+                    "locationName": "uksouth"
+                  }
+                ],
                 "publicNetworkAccess": "Enabled"
               },
               "tags": {},
               "type": "Microsoft.DocumentDb/databaseAccounts"
             },
             {
-              "apiVersion": "2021-04-15",
+              "apiVersion": "2024-11-15",
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts', 'testaccountmongo')]"
               ],


### PR DESCRIPTION
This PR closes #354, closes #438, and closes #1253

The changes in this PR are as follows:
* Add autoscale throughput support via CosmosDb.Autoscale.
* Add continuous backup retention policy support.
* Add IP firewall rules and Azure firewall toggle.
* Fix deployment failures for restored accounts by emitting primary location.
* Update ARM API versions to 2024-11-15.

I have read the [contributing guidelines](CONTRIBUTING.md) and have completed the following:
* [x] **Tested my code** end-to-end against a live Azure subscription.
* [x] **Updated the documentation** in the docs folder for the affected changes.
* [x] **Written unit tests** against the modified code that I have made.
* [x] **Updated the [release notes](RELEASE_NOTES.md)** with a new entry for this PR.
* [x] **Checked the coding standards** outlined in the [contributions guide](CONTRIBUTING.md) and ensured my code adheres to them.

Below is a minimal example configuration that includes the new features, which can be used to deploy to Azure:

```fsharp
open Farmer
open Farmer.Builders

let myCosmosDb =  cosmosDb {
        name "my-cosmos-account"
        account_name "my-cosmos-account"
        throughput (CosmosDb.Autoscale 4000<CosmosDb.RU>)
        backup_retention CosmosDb.Continuous7Days
        enable_azure_firewall
        add_firewall_rule "203.0.113.0"
        add_containers [
            cosmosContainer {
                name "my-container"
                partition_key [ "/id" ] CosmosDb.Hash
            }
        ]
    }

let deployment = arm {
        add_resource myCosmosDb
    }
```
